### PR TITLE
feat(sclc): add dictionary literals and types

### DIFF
--- a/crates/sclc/src/ast.rs
+++ b/crates/sclc/src/ast.rs
@@ -74,6 +74,14 @@ impl Expr {
                 }
                 vars
             }
+            Expr::Dict(dict_expr) => {
+                let mut vars = HashSet::new();
+                for entry in &dict_expr.entries {
+                    vars.extend(entry.key.as_ref().free_vars());
+                    vars.extend(entry.value.as_ref().free_vars());
+                }
+                vars
+            }
             Expr::List(list_expr) => {
                 let mut vars = HashSet::new();
                 for item in &list_expr.items {
@@ -114,6 +122,7 @@ pub enum Expr {
     Call(CallExpr),
     Var(Loc<Var>),
     Record(RecordExpr),
+    Dict(DictExpr),
     List(ListExpr),
     Interp(InterpExpr),
     PropertyAccess(PropertyAccessExpr),
@@ -181,6 +190,11 @@ pub struct RecordExpr {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DictExpr {
+    pub entries: Vec<DictEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ListExpr {
     pub items: Vec<ListItem>,
 }
@@ -232,6 +246,12 @@ pub struct RecordField {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DictEntry {
+    pub key: Loc<Expr>,
+    pub value: Loc<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PropertyAccessExpr {
     pub expr: Box<Loc<Expr>>,
     pub property: Loc<Var>,
@@ -256,6 +276,7 @@ pub enum TypeExpr {
     List(Box<Loc<TypeExpr>>),
     Fn(FnTypeExpr),
     Record(RecordTypeExpr),
+    Dict(DictTypeExpr),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -267,6 +288,12 @@ pub struct FnTypeExpr {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecordTypeExpr {
     pub fields: Vec<RecordTypeFieldExpr>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DictTypeExpr {
+    pub key: Box<Loc<TypeExpr>>,
+    pub value: Box<Loc<TypeExpr>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -3,7 +3,9 @@ use std::path::Component;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::{AnySource, DiagList, Diagnosed, FnType, Package, Program, RecordType, Type, ast};
+use crate::{
+    AnySource, DiagList, Diagnosed, DictType, FnType, Package, Program, RecordType, Type, ast,
+};
 use thiserror::Error;
 
 pub struct TypeEnv<'a> {
@@ -293,6 +295,23 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                             err.causing(TypeIssue::Mismatch(lhs.clone(), rhs.clone()))
                         })?;
                     }
+                    Ok(())
+                }
+                _ => Err(TypeError::new(TypeIssue::Mismatch(
+                    lhs.clone(),
+                    rhs.clone(),
+                ))),
+            },
+            Type::Dict(lhs_dict) => match rhs {
+                Type::Dict(rhs_dict) => {
+                    self.assign_type(lhs_dict.key.as_ref(), rhs_dict.key.as_ref())
+                        .map_err(|err| {
+                            err.causing(TypeIssue::Mismatch(lhs.clone(), rhs.clone()))
+                        })?;
+                    self.assign_type(lhs_dict.value.as_ref(), rhs_dict.value.as_ref())
+                        .map_err(|err| {
+                            err.causing(TypeIssue::Mismatch(lhs.clone(), rhs.clone()))
+                        })?;
                     Ok(())
                 }
                 _ => Err(TypeError::new(TypeIssue::Mismatch(
@@ -645,6 +664,57 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                     .unpack(&mut diags);
                 Ok(Diagnosed::new(ty, diags))
             }
+            ast::Expr::Dict(dict_expr) => {
+                let mut diags = DiagList::new();
+                let expected_dict = match expected_type {
+                    Some(Type::Dict(dict_ty)) => Some(dict_ty),
+                    _ => None,
+                };
+
+                let dict_ty = if let Some(expected_dict) = expected_dict {
+                    let expected_key = expected_dict.key.as_ref().clone().unfold();
+                    let expected_value = expected_dict.value.as_ref().clone().unfold();
+                    for entry in &dict_expr.entries {
+                        self.check_expr(env, &entry.key, Some(&expected_key))?
+                            .unpack(&mut diags);
+                        self.check_expr(env, &entry.value, Some(&expected_value))?
+                            .unpack(&mut diags);
+                    }
+                    Type::Dict(DictType {
+                        key: Box::new(expected_key),
+                        value: Box::new(expected_value),
+                    })
+                } else if let Some((first, rest)) = dict_expr.entries.split_first() {
+                    let key_ty = self
+                        .check_expr(env, &first.key, None)?
+                        .unpack(&mut diags)
+                        .unfold();
+                    let value_ty = self
+                        .check_expr(env, &first.value, None)?
+                        .unpack(&mut diags)
+                        .unfold();
+                    for entry in rest {
+                        self.check_expr(env, &entry.key, Some(&key_ty))?
+                            .unpack(&mut diags);
+                        self.check_expr(env, &entry.value, Some(&value_ty))?
+                            .unpack(&mut diags);
+                    }
+                    Type::Dict(DictType {
+                        key: Box::new(key_ty),
+                        value: Box::new(value_ty),
+                    })
+                } else {
+                    Type::Dict(DictType {
+                        key: Box::new(Type::Never),
+                        value: Box::new(Type::Never),
+                    })
+                };
+
+                let ty = self
+                    .apply_expected_type(env, expr.span(), dict_ty, expected_type)?
+                    .unpack(&mut diags);
+                Ok(Diagnosed::new(ty, diags))
+            }
             ast::Expr::List(list_expr) => {
                 let mut diags = DiagList::new();
                 let list_ty = if let Some(Type::List(expected_item_ty)) = expected_type {
@@ -806,6 +876,10 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                 }
                 Type::Record(resolved)
             }
+            ast::TypeExpr::Dict(dict_ty) => Type::Dict(DictType {
+                key: Box::new(self.resolve_type_expr(&dict_ty.key)),
+                value: Box::new(self.resolve_type_expr(&dict_ty.value)),
+            }),
             ast::TypeExpr::Var(_) => Type::Never,
         }
     }
@@ -898,8 +972,8 @@ fn module_id_for_path(package_id: &crate::ModuleId, path: &Path) -> crate::Modul
 mod tests {
     use super::TypeChecker;
     use crate::{
-        Loc, ModuleId, Position, Program, RecordType, Span, StdSourceRepo, Type,
-        ast::{Expr, Int, RecordExpr, RecordField, Var},
+        DictType, Loc, ModuleId, Position, Program, RecordType, Span, StdSourceRepo, Type,
+        ast::{DictEntry, DictExpr, Expr, Int, RecordExpr, RecordField, StrExpr, Var},
     };
 
     fn checker() -> TypeChecker<'static, StdSourceRepo> {
@@ -1040,5 +1114,55 @@ mod tests {
         let (_, span) = diag.locate();
         assert_eq!(span, field_span);
         assert!(diags.next().is_none(), "expected only one diagnostic");
+    }
+
+    #[test]
+    fn assign_type_dict_covariant() {
+        let checker = checker();
+        let lhs = Type::Dict(DictType {
+            key: Box::new(Type::Optional(Box::new(Type::Str))),
+            value: Box::new(Type::Optional(Box::new(Type::Int))),
+        });
+        let rhs = Type::Dict(DictType {
+            key: Box::new(Type::Str),
+            value: Box::new(Type::Int),
+        });
+
+        assert!(checker.assign_type(&lhs, &rhs).is_ok());
+    }
+
+    #[test]
+    fn dict_infers_key_value_types_from_first_entry() {
+        let checker = checker();
+        let module_id = ModuleId::default();
+        let env = super::TypeEnv::new().with_module_id(&module_id);
+        let span = Span::new(Position::new(1, 1), Position::new(1, 10));
+
+        let dict_expr = loc(
+            Expr::Dict(DictExpr {
+                entries: vec![
+                    DictEntry {
+                        key: loc(Expr::Int(Int { value: 1 }), span),
+                        value: loc(Expr::Str(StrExpr { value: "a".into() }), span),
+                    },
+                    DictEntry {
+                        key: loc(Expr::Int(Int { value: 2 }), span),
+                        value: loc(Expr::Str(StrExpr { value: "b".into() }), span),
+                    },
+                ],
+            }),
+            span,
+        );
+
+        let diagnosed = checker
+            .check_expr(&env, &dict_expr, None)
+            .expect("type check should succeed");
+        assert_eq!(
+            diagnosed.into_inner(),
+            Type::Dict(DictType {
+                key: Box::new(Type::Int),
+                value: Box::new(Type::Str),
+            })
+        );
     }
 }

--- a/crates/sclc/src/eval.rs
+++ b/crates/sclc/src/eval.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 use tokio::sync::mpsc;
 
-use crate::{ExternFnValue, FnValue, PendingValue, Record, Value, ast};
+use crate::{Dict, ExternFnValue, FnValue, PendingValue, Record, Value, ast};
 
 pub struct EvalEnv<'a> {
     module_id: Option<&'a crate::ModuleId>,
@@ -384,6 +384,18 @@ impl Eval {
                 }
                 Ok(Value::Record(record))
             }
+            ast::Expr::Dict(dict_expr) => {
+                let mut dict = Dict::default();
+                for entry in &dict_expr.entries {
+                    let key = self.eval_expr(env, &entry.key)?;
+                    let value = self.eval_expr(env, &entry.value)?;
+                    if matches!(key, Value::Pending(_)) || matches!(value, Value::Pending(_)) {
+                        return Ok(Value::Pending(PendingValue));
+                    }
+                    dict.insert(key, value);
+                }
+                Ok(Value::Dict(dict))
+            }
             ast::Expr::List(list_expr) => {
                 let mut values = Vec::new();
                 for item in &list_expr.items {
@@ -448,11 +460,7 @@ impl Eval {
                         for value in values {
                             let inner_env = env.with_local(for_item.var.name.as_str(), value);
                             if matches!(
-                                self.eval_list_item(
-                                    &inner_env,
-                                    for_item.emit_item.as_ref(),
-                                    out
-                                )?,
+                                self.eval_list_item(&inner_env, for_item.emit_item.as_ref(), out)?,
                                 ListItemOutcome::Pending
                             ) {
                                 return Ok(ListItemOutcome::Pending);

--- a/crates/sclc/src/lexer.rs
+++ b/crates/sclc/src/lexer.rs
@@ -7,6 +7,7 @@ use crate::{Loc, Position, Span};
 pub enum Token<'a> {
     OpenCurly,
     CloseCurly,
+    Hash,
     Colon,
     Comma,
     Dot,
@@ -303,6 +304,7 @@ impl<'a> Iterator for Lexer<'a> {
                 "\"" => return Some(self.consume_string_from_quote(grapheme_index, start)),
                 "{" => Token::OpenCurly,
                 "}" => Token::CloseCurly,
+                "#" => Token::Hash,
                 ":" => Token::Colon,
                 "," => Token::Comma,
                 "." => Token::Dot,

--- a/crates/sclc/src/parser.rs
+++ b/crates/sclc/src/parser.rs
@@ -4,10 +4,11 @@ use peg::{Parse, ParseElem, RuleResult};
 use thiserror::Error;
 
 use crate::{
-    Bool, CallExpr, Diag, DiagList, Diagnosed, Expr, FileMod, FnExpr, FnParam, IfExpr, ImportStmt,
-    Int, InterpExpr, LetBind, LetExpr, Lexer, ListExpr, ListForItem, ListIfItem, ListItem, Loc,
-    ModStmt, ModuleId, Position, PropertyAccessExpr, RecordExpr, RecordField, RecordTypeExpr,
-    RecordTypeFieldExpr, ReplLine, Span, StrExpr, Token, TypeExpr, Var,
+    Bool, CallExpr, Diag, DiagList, Diagnosed, DictEntry, DictExpr, DictTypeExpr, Expr, FileMod,
+    FnExpr, FnParam, IfExpr, ImportStmt, Int, InterpExpr, LetBind, LetExpr, Lexer, ListExpr,
+    ListForItem, ListIfItem, ListItem, Loc, ModStmt, ModuleId, Position, PropertyAccessExpr,
+    RecordExpr, RecordField, RecordTypeExpr, RecordTypeFieldExpr, ReplLine, Span, StrExpr, Token,
+    TypeExpr, Var,
 };
 
 #[derive(Error, Debug)]
@@ -175,6 +176,7 @@ peg::parser! {
 
         rule type_expr_base() -> Loc<TypeExpr>
             = fn_type_expr:type_expr_fn() { fn_type_expr }
+            / dict_type_expr:type_expr_dict() { dict_type_expr }
             / record_type_expr:type_expr_record() { record_type_expr }
             / list_type_expr:type_expr_list() { list_type_expr }
             / var:var() {
@@ -202,6 +204,17 @@ peg::parser! {
         rule type_expr_params() -> Vec<Loc<TypeExpr>>
             = params:(type_expr() ++ comma()) comma()? { params }
             / { vec![] }
+
+        rule type_expr_dict() -> Loc<TypeExpr>
+            = hash_span:hash() _open_curly_span:open_curly() key:type_expr() colon() value:type_expr() close_curly_span:close_curly() {
+                Loc::new(
+                    TypeExpr::Dict(DictTypeExpr {
+                        key: Box::new(key),
+                        value: Box::new(value),
+                    }),
+                    Span::new(hash_span.start(), close_curly_span.end()),
+                )
+            }
 
         rule type_expr_record() -> Loc<TypeExpr>
             = open_curly_span:open_curly() close_curly_span:close_curly() {
@@ -271,6 +284,7 @@ peg::parser! {
                 Loc::new(expr.into_inner(), Span::new(open_paren_span.start(), close_paren_span.end()))
             }
             / string_expr:string_expr() { string_expr }
+            / dict_expr:dict_expr() { dict_expr }
             / record_expr:record_expr() { record_expr }
             / list_expr:list_expr() { list_expr }
             / int:int() {
@@ -324,6 +338,23 @@ peg::parser! {
 
         rule record_field() -> RecordField
             = var:var() colon() expr:expr() { RecordField { var, expr } }
+
+        rule dict_expr() -> Loc<Expr>
+            = hash_span:hash() _open_curly_span:open_curly() close_curly_span:close_curly() {
+                Loc::new(
+                    Expr::Dict(DictExpr { entries: vec![] }),
+                    Span::new(hash_span.start(), close_curly_span.end()),
+                )
+            }
+            / hash_span:hash() _open_curly_span:open_curly() entries:(dict_entry() ++ comma()) comma()? close_curly_span:close_curly() {
+                Loc::new(
+                    Expr::Dict(DictExpr { entries }),
+                    Span::new(hash_span.start(), close_curly_span.end()),
+                )
+            }
+
+        rule dict_entry() -> DictEntry
+            = key:expr() colon() value:expr() { DictEntry { key, value } }
 
         rule list_expr() -> Loc<Expr>
             = open_square_span:open_square() close_square_span:close_square() {
@@ -435,6 +466,9 @@ peg::parser! {
 
         rule close_curly() -> Span
             = [token if matches!(token.as_ref(), Token::CloseCurly)] { token.span() }
+
+        rule hash() -> Span
+            = [token if matches!(token.as_ref(), Token::Hash)] { token.span() }
 
         rule colon() -> Span
             = [token if matches!(token.as_ref(), Token::Colon)] { token.span() }
@@ -557,6 +591,34 @@ mod tests {
         assert_eq!(record.fields.len(), 2);
         assert_eq!(record.fields[0].var.name, "a");
         assert_eq!(record.fields[1].var.name, "b");
+    }
+
+    #[test]
+    fn parses_dict_with_trailing_comma() {
+        let line = parse_repl_line("#{ \"a\": 1, \"b\": 2, }", &ModuleId::default())
+            .expect("dict should parse")
+            .into_inner();
+        let crate::ModStmt::Expr(expr) = line.statement else {
+            panic!("expected expression statement");
+        };
+        let crate::Expr::Dict(dict) = expr.into_inner() else {
+            panic!("expected dict expression");
+        };
+        assert_eq!(dict.entries.len(), 2);
+    }
+
+    #[test]
+    fn parses_empty_dict() {
+        let line = parse_repl_line("#{}", &ModuleId::default())
+            .expect("dict should parse")
+            .into_inner();
+        let crate::ModStmt::Expr(expr) = line.statement else {
+            panic!("expected expression statement");
+        };
+        let crate::Expr::Dict(dict) = expr.into_inner() else {
+            panic!("expected dict expression");
+        };
+        assert!(dict.entries.is_empty());
     }
 
     #[test]
@@ -877,5 +939,29 @@ mod tests {
             panic!("expected var inner type");
         };
         assert_eq!(var.name, "Int");
+    }
+
+    #[test]
+    fn parses_dict_type_expr() {
+        let line = parse_repl_line("extern \"dict\": #{ Str: Int }", &ModuleId::default())
+            .expect("dict type should parse")
+            .into_inner();
+        let crate::ModStmt::Expr(expr) = line.statement else {
+            panic!("expected expression statement");
+        };
+        let crate::Expr::Extern(extern_expr) = expr.into_inner() else {
+            panic!("expected extern expression");
+        };
+        let crate::TypeExpr::Dict(dict_ty) = extern_expr.ty.into_inner() else {
+            panic!("expected dict type expression");
+        };
+        let crate::TypeExpr::Var(key) = dict_ty.key.into_inner() else {
+            panic!("expected key type var");
+        };
+        let crate::TypeExpr::Var(value) = dict_ty.value.into_inner() else {
+            panic!("expected value type var");
+        };
+        assert_eq!(key.name, "Str");
+        assert_eq!(value.name, "Int");
     }
 }

--- a/crates/sclc/src/ty.rs
+++ b/crates/sclc/src/ty.rs
@@ -10,6 +10,7 @@ pub enum Type {
     List(Box<Type>),
     Fn(FnType),
     Record(RecordType),
+    Dict(DictType),
     IsoRec(usize, Box<Type>),
     Var(usize),
     Never,
@@ -24,6 +25,12 @@ pub struct FnType {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RecordType {
     fields: BTreeMap<String, Type>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DictType {
+    pub key: Box<Type>,
+    pub value: Box<Type>,
 }
 
 impl RecordType {
@@ -46,6 +53,15 @@ impl RecordType {
             .map(|(name, ty)| (name.clone(), f(ty)))
             .collect();
         Self { fields }
+    }
+}
+
+impl DictType {
+    fn map_types(&self, mut f: impl FnMut(&Type) -> Type) -> Self {
+        Self {
+            key: Box::new(f(self.key.as_ref())),
+            value: Box::new(f(self.value.as_ref())),
+        }
     }
 }
 
@@ -82,6 +98,7 @@ impl Type {
             Type::Record(record) => {
                 Type::Record(record.map_types(|ty| ty.unfold_inner(replacement)))
             }
+            Type::Dict(dict) => Type::Dict(dict.map_types(|ty| ty.unfold_inner(replacement))),
             Type::IsoRec(id, body) => {
                 let rec = Type::IsoRec(*id, body.clone());
                 body.unfold_inner(Some((*id, &rec)))
@@ -101,6 +118,7 @@ impl std::fmt::Display for Type {
             Type::List(ty) => write!(f, "[{ty}]"),
             Type::Fn(fn_ty) => write!(f, "{fn_ty}"),
             Type::Record(record) => write!(f, "{record}"),
+            Type::Dict(dict) => write!(f, "{dict}"),
             Type::IsoRec(id, ty) => write!(f, "IsoRec({id}, {ty})"),
             Type::Var(id) => write!(f, "Var({id})"),
             Type::Never => write!(f, "Never"),
@@ -137,5 +155,11 @@ impl std::fmt::Display for RecordType {
         }
 
         write!(f, "}}")
+    }
+}
+
+impl std::fmt::Display for DictType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{{{}: {}}}", self.key, self.value)
     }
 }

--- a/crates/sclc/src/value.rs
+++ b/crates/sclc/src/value.rs
@@ -12,6 +12,7 @@ pub enum Value {
     ExternFn(ExternFnValue),
     Fn(FnValue),
     Record(Record),
+    Dict(Dict),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -140,6 +141,11 @@ pub struct Record {
     fields: BTreeMap<String, Value>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dict {
+    entries: Vec<(Value, Value)>,
+}
+
 impl Record {
     pub fn insert(&mut self, name: String, value: Value) {
         self.fields.insert(name, value);
@@ -153,6 +159,16 @@ impl Record {
         self.fields
             .iter()
             .map(|(name, value)| (name.as_str(), value))
+    }
+}
+
+impl Dict {
+    pub fn insert(&mut self, key: Value, value: Value) {
+        self.entries.push((key, value));
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Value, &Value)> {
+        self.entries.iter().map(|(key, value)| (key, value))
     }
 }
 
@@ -178,6 +194,7 @@ impl std::fmt::Display for Value {
             Value::ExternFn(_) => write!(f, "<extern fn>"),
             Value::Fn(function) => write!(f, "{function}"),
             Value::Record(record) => write!(f, "{record}"),
+            Value::Dict(dict) => write!(f, "{dict}"),
         }
     }
 }
@@ -206,6 +223,22 @@ impl std::fmt::Display for Record {
         while let Some((name, value)) = fields.next() {
             write!(f, "{name}: {value}")?;
             if fields.peek().is_some() {
+                write!(f, ", ")?;
+            }
+        }
+
+        write!(f, "}}")
+    }
+}
+
+impl std::fmt::Display for Dict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "#{{")?;
+
+        let mut entries = self.entries.iter().peekable();
+        while let Some((key, value)) = entries.next() {
+            write!(f, "{key}: {value}")?;
+            if entries.peek().is_some() {
                 write!(f, ", ")?;
             }
         }


### PR DESCRIPTION
Closes #8

## Summary
- add dictionary literals and type syntax to SCLC (`#{ ... }`, `#{ K: V }`)
- implement dict typing rules (inference from first entry, `Never` for empty) and covariant subtyping
- extend value/eval support for dictionary runtime values
- add parser and type checker tests for dicts

## Testing
- not run (cargo not available by default)
