### PR TITLE
Migrate from slog to tracing for structured logging

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1042,7 +1042,10 @@ struct Cli {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
         .init();
 
     let cli = Cli::parse();

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { version = "1.49.0", features = ["full"] }
 tokio-tungstenite = { version = "0.24.0", features = ["rustls-tls-webpki-roots"] }
 rustyline = "14.0.0"
 sclc = { path = "../sclc" }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -38,6 +38,13 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let program = Program::parse();
 
     match program.command {

--- a/crates/de/Cargo.toml
+++ b/crates/de/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.101"
 clap = { version = "4.5.57", features = ["derive"] }
-slog = { version = "2.8.2", features = ["anyhow"] }
-slog-async = "2.8.0"
-slog-term = "2.9.2"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio = { version = "1.49.0", features = ["full"] }
 cdb = { path = "../cdb" }
 rdb = { path = "../rdb" }

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -7,13 +7,13 @@ use cdb::{DeploymentClient, DeploymentState};
 use clap::Parser;
 use futures_util::{StreamExt, TryStreamExt};
 use sclc::SourceRepo;
-use slog::{Drain, Logger, debug, error, info, o, warn};
 use tokio::{
     sync::mpsc,
     sync::oneshot::{self, error::TryRecvError},
     task,
     time::{Instant, sleep_until},
 };
+use tracing::Instrument;
 
 #[derive(Parser)]
 enum Program {
@@ -34,11 +34,12 @@ enum Program {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-
-    let log = slog::Logger::root(drain, o!());
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     match Program::parse() {
         Program::Daemon {
@@ -47,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
             rtq_hostname,
             ldb_hostname,
         } => {
-            info!(log, "starting deployment engine daemon");
+            tracing::info!("starting deployment engine daemon");
 
             let cdb_client = cdb::ClientBuilder::new()
                 .known_node(&cdb_hostname)
@@ -74,7 +75,6 @@ async fn main() -> anyhow::Result<()> {
                 let next_loop = Instant::now() + Duration::from_secs(20);
 
                 if let Err(e) = process(
-                    log.clone(),
                     cdb_client.clone(),
                     rdb_client.clone(),
                     rtq_publisher.clone(),
@@ -83,11 +83,10 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await
                 {
-                    error!(log, "{e}")
+                    tracing::error!("{e}")
                 }
 
-                debug!(
-                    log,
+                tracing::debug!(
                     "will poll for new deployments again in {:.2}s",
                     (next_loop - Instant::now()).as_secs_f64()
                 );
@@ -98,7 +97,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn process(
-    log: Logger,
     client: cdb::Client,
     rdb_client: rdb::Client,
     rtq_publisher: rtq::Publisher,
@@ -107,14 +105,14 @@ async fn process(
 ) -> anyhow::Result<()> {
     let deployments = client.active_deployments().await?.collect::<Vec<_>>().await;
 
-    debug!(log, "found {} deployments", deployments.len());
+    tracing::debug!("found {} deployments", deployments.len());
 
     let mut untouched = workers.keys().cloned().collect::<BTreeSet<_>>();
     for deployment in deployments {
         let deployment = deployment?;
         let id = deployment.fqid();
         if !untouched.remove(&id) {
-            debug!(log, "new deployment to process: {}", deployment.fqid());
+            tracing::debug!(dep = %id, "new deployment to process");
 
             let (tx, rx) = oneshot::channel();
             let namespace = format!("{}/{}", deployment.repository, deployment.id.ref_name);
@@ -122,32 +120,32 @@ async fn process(
             let log_publisher = match ldb_publisher.namespace(id.clone()).await {
                 Ok(log_publisher) => log_publisher,
                 Err(error) => {
-                    error!(
-                        log,
-                        "failed to create deployment log publisher topic";
-                        "dep" => id.clone(),
-                        "error" => error.to_string()
+                    tracing::error!(
+                        dep = %id,
+                        error = %error,
+                        "failed to create deployment log publisher topic",
                     );
                     continue;
                 }
             };
 
+            let dep_id = deployment.fqid();
             let worker = Worker {
-                log: log.new(o!("dep" => deployment.fqid())),
                 client: client.repo(deployment.repository).deployment(deployment.id),
                 namespace: rdb_client.namespace(namespace),
                 rtq_publisher: rtq_publisher.clone(),
                 log_publisher,
             };
 
-            task::spawn(worker.run_loop(rx));
+            let span = tracing::info_span!("worker", dep = %dep_id);
+            task::spawn(worker.run_loop(rx).instrument(span));
 
             workers.insert(id, tx);
         }
     }
 
     for id in untouched {
-        debug!(log, "no longer watching {}", id);
+        tracing::debug!(dep = %id, "no longer watching");
         workers.remove(&id);
     }
 
@@ -155,7 +153,6 @@ async fn process(
 }
 
 struct Worker {
-    log: Logger,
     client: DeploymentClient,
     namespace: rdb::NamespaceClient,
     rtq_publisher: rtq::Publisher,
@@ -177,13 +174,12 @@ impl Worker {
                 Ok(()) | Err(TryRecvError::Closed) => return,
                 Err(TryRecvError::Empty) => {
                     if let Err(e) = self.work().await {
-                        error!(self.log, "{e}");
+                        tracing::error!("{e}");
                     }
                 }
             }
 
-            debug!(
-                self.log,
+            tracing::debug!(
                 "will reconcile in {:.2}s",
                 (next_loop - Instant::now()).as_secs_f64()
             );
@@ -196,15 +192,12 @@ impl Worker {
 
         match deployment.state {
             DeploymentState::Down => {
-                info!(
-                    &self.log,
-                    "deployment down, waiting to be decommissioned..."
-                );
+                tracing::info!("deployment down, waiting to be decommissioned...");
                 Ok(())
             }
 
             DeploymentState::Desired => {
-                info!(&self.log, "reconciling");
+                tracing::info!("reconciling");
                 let completeness = self.compile_and_evaluate().await?;
 
                 match completeness {
@@ -217,8 +210,7 @@ impl Worker {
                         }
                     }
                     EvalCompleteness::Partial => {
-                        info!(
-                            &self.log,
+                        tracing::info!(
                             "evaluation incomplete; deferring superceded deployment teardown"
                         );
                     }
@@ -228,7 +220,7 @@ impl Worker {
             }
 
             DeploymentState::Undesired => {
-                info!(&self.log, "tearing down");
+                tracing::info!("tearing down");
 
                 let owner = deployment.fqid();
                 let mut all_resources = Vec::new();
@@ -255,10 +247,11 @@ impl Worker {
                     };
                     if living_dependency_targets.contains(&resource_id) {
                         blocked += 1;
-                        info!(&self.log, "resource still has living dependents; deferring destroy";
-                            "type" => resource.resource_type.clone(),
-                            "id" => resource.id.clone(),
-                            "owner" => resource.owner.clone()
+                        tracing::info!(
+                            resource_type = %resource.resource_type,
+                            resource_id = %resource.id,
+                            owner = ?resource.owner,
+                            "resource still has living dependents; deferring destroy",
                         );
                         continue;
                     }
@@ -274,20 +267,21 @@ impl Worker {
                     self.rtq_publisher.enqueue(&message).await?;
                     emitted += 1;
 
-                    info!(&self.log, "queued destroy";
-                        "type" => resource.resource_type.clone(),
-                        "id" => resource.id.clone(),
-                        "owner" => resource.owner.clone()
+                    tracing::info!(
+                        resource_type = %resource.resource_type,
+                        resource_id = %resource.id,
+                        owner = ?resource.owner,
+                        "queued destroy",
                     );
                 }
 
                 if emitted > 0 {
-                    info!(&self.log, "queued {} destroy messages", emitted);
+                    tracing::info!("queued {} destroy messages", emitted);
                     return Ok(());
                 }
 
                 if owned_resources.is_empty() {
-                    info!(&self.log, "no more resources, setting state to DOWN");
+                    tracing::info!("no more resources, setting state to DOWN");
                     self.client.set(DeploymentState::Down).await?;
                     self.log_publisher
                         .info(format!("No more resources, deployment is DOWN"))
@@ -296,8 +290,9 @@ impl Worker {
                 }
 
                 if blocked > 0 {
-                    info!(&self.log, "teardown waiting on living dependents";
-                        "blocked_resources" => blocked
+                    tracing::info!(
+                        blocked_resources = blocked,
+                        "teardown waiting on living dependents",
                     );
                     self.log_publisher
                         .info(format!("{blocked} resources still have living dependents"))
@@ -307,7 +302,7 @@ impl Worker {
             }
 
             DeploymentState::Lingering => {
-                info!(&self.log, "lingering...");
+                tracing::info!("lingering...");
                 let mut cursor = self.client.clone();
                 let mut seen = HashSet::new();
 
@@ -316,7 +311,7 @@ impl Worker {
                     let commit_hash = superceding_deployment.id.commit_hash.clone();
 
                     if !seen.insert(commit_hash) {
-                        warn!(&self.log, "detected supercession cycle while lingering");
+                        tracing::warn!("detected supercession cycle while lingering");
                         break;
                     }
 
@@ -339,10 +334,11 @@ impl Worker {
         let diagnosed = sclc::compile(self.client.clone()).await?;
         for diag in diagnosed.diags().iter() {
             let (module_id, span) = diag.locate();
-            info!(&self.log, "compile diagnostic";
-                "module" => module_id.to_string(),
-                "span" => span.to_string(),
-                "diag" => diag.to_string()
+            tracing::info!(
+                module = %module_id,
+                span = %span,
+                diag = %diag,
+                "compile diagnostic",
             );
         }
 
@@ -362,7 +358,7 @@ impl Worker {
         }
 
         if diagnosed.diags().has_errors() {
-            info!(&self.log, "compile produced errors; skipping evaluation");
+            tracing::info!("compile produced errors; skipping evaluation");
             return Ok(EvalCompleteness::Partial);
         }
 
@@ -401,7 +397,6 @@ impl Worker {
         }
         drop(resources);
 
-        let log = self.log.clone();
         let log_publisher = self.log_publisher.clone();
         let namespace_id = self.namespace.namespace().to_owned();
         let rtq_publisher = self.rtq_publisher.clone();
@@ -425,10 +420,11 @@ impl Worker {
                             inputs: match serde_json::to_value(&inputs) {
                                 Ok(value) => value,
                                 Err(error) => {
-                                    error!(log, "failed to encode create inputs";
-                                        "type" => id.ty,
-                                        "id" => id.id,
-                                        "error" => error.to_string()
+                                    tracing::error!(
+                                        resource_type = %id.ty,
+                                        resource_id = %id.id,
+                                        error = %error,
+                                        "failed to encode create inputs",
                                     );
                                     continue;
                                 }
@@ -443,8 +439,9 @@ impl Worker {
                                 .collect(),
                         });
                         if let Err(error) = rtq_publisher.enqueue(&message).await {
-                            error!(log, "failed to publish create message";
-                                "error" => error.to_string()
+                            tracing::error!(
+                                error = %error,
+                                "failed to publish create message",
                             );
 
                             log_publisher
@@ -457,10 +454,11 @@ impl Worker {
                             continue;
                         }
 
-                        info!(log, "effect create resource";
-                            "type" => id.ty.clone(),
-                            "id" => id.id.clone(),
-                            "inputs" => format!("{:?}", inputs)
+                        tracing::info!(
+                            resource_type = %id.ty,
+                            resource_id = %id.id,
+                            inputs = ?inputs,
+                            "effect create resource",
                         );
                     }
                     sclc::Effect::UpdateResource {
@@ -472,10 +470,11 @@ impl Worker {
                         let desired_inputs = match serde_json::to_value(&inputs) {
                             Ok(value) => value,
                             Err(error) => {
-                                error!(log, "failed to encode update inputs";
-                                    "type" => id.ty,
-                                    "id" => id.id,
-                                    "error" => error.to_string()
+                                tracing::error!(
+                                    resource_type = %id.ty,
+                                    resource_id = %id.id,
+                                    error = %error,
+                                    "failed to encode update inputs",
                                 );
                                 continue;
                             }
@@ -515,8 +514,9 @@ impl Worker {
                             })
                         };
                         if let Err(error) = rtq_publisher.enqueue(&message).await {
-                            error!(log, "failed to publish update message";
-                                "error" => error.to_string()
+                            tracing::error!(
+                                error = %error,
+                                "failed to publish update message",
                             );
 
                             log_publisher
@@ -528,10 +528,11 @@ impl Worker {
                             continue;
                         }
 
-                        info!(log, "effect update resource";
-                            "type" => id.ty.clone(),
-                            "id" => id.id.clone(),
-                            "inputs" => format!("{:?}", inputs)
+                        tracing::info!(
+                            resource_type = %id.ty,
+                            resource_id = %id.id,
+                            inputs = ?inputs,
+                            "effect update resource",
                         );
                     }
                     sclc::Effect::TouchResource {
@@ -548,10 +549,11 @@ impl Worker {
                         let desired_inputs = match serde_json::to_value(&inputs) {
                             Ok(value) => value,
                             Err(error) => {
-                                error!(log, "failed to encode touch inputs";
-                                    "type" => id.ty,
-                                    "id" => id.id,
-                                    "error" => error.to_string()
+                                tracing::error!(
+                                    resource_type = %id.ty,
+                                    resource_id = %id.id,
+                                    error = %error,
+                                    "failed to encode touch inputs",
                                 );
                                 continue;
                             }
@@ -576,8 +578,9 @@ impl Worker {
                             dependencies,
                         });
                         if let Err(error) = rtq_publisher.enqueue(&message).await {
-                            error!(log, "failed to publish touch adopt message";
-                                "error" => error.to_string()
+                            tracing::error!(
+                                error = %error,
+                                "failed to publish touch adopt message",
                             );
 
                             log_publisher
@@ -589,10 +592,11 @@ impl Worker {
                             continue;
                         }
 
-                        info!(log, "effect touch resource adopt";
-                            "type" => id.ty.clone(),
-                            "id" => id.id.clone(),
-                            "inputs" => format!("{:?}", inputs)
+                        tracing::info!(
+                            resource_type = %id.ty,
+                            resource_id = %id.id,
+                            inputs = ?inputs,
+                            "effect touch resource adopt",
                         );
                     }
                 }
@@ -603,7 +607,7 @@ impl Worker {
             } else {
                 EvalCompleteness::Complete
             }
-        });
+        }.instrument(tracing::Span::current()));
 
         program.evaluate(&module_id, &eval).await?;
         drop(eval);

--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -1262,7 +1262,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .init();
     let args = Args::parse();

--- a/crates/plugin_std_random/Cargo.toml
+++ b/crates/plugin_std_random/Cargo.toml
@@ -15,3 +15,4 @@ rand = "0.9.2"
 rtp = { path = "../rtp" }
 sclc = { path = "../sclc" }
 tokio = { version = "1.49.0", features = ["full"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/crates/plugin_std_random/src/main.rs
+++ b/crates/plugin_std_random/src/main.rs
@@ -63,6 +63,13 @@ impl rtp::Plugin for RandomPlugin {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
     let args = Args::parse();
     rtp::serve(&args.bind, RandomPlugin::new).await?;
     Ok(())

--- a/crates/rte/Cargo.toml
+++ b/crates/rte/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.101"
 clap = { version = "4.5.57", features = ["derive"] }
-slog = { version = "2.8.2", features = ["anyhow"] }
-slog-async = "2.8.0"
-slog-term = "2.9.2"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio = { version = "1.49.0", features = ["full"] }
 rtq = { path = "../rtq" }
 rtp = { path = "../rtp" }

--- a/crates/rte/src/main.rs
+++ b/crates/rte/src/main.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 use ldb::Severity;
-use slog::{Drain, Logger, error, info, o, warn};
 use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::task;
+use tracing::Instrument;
 
 #[derive(Parser)]
 enum Program {
@@ -61,11 +61,12 @@ impl FromStr for PluginSpec {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-
-    let log = slog::Logger::root(drain, o!());
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     match Program::parse() {
         Program::Daemon {
@@ -77,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
             local_workers,
             plugin,
         } => {
-            info!(log, "starting resource transition engine daemon");
+            tracing::info!("starting resource transition engine daemon");
 
             if local_workers == 0 {
                 anyhow::bail!("--local-workers must be at least 1");
@@ -101,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
                 .brokers(format!("{}:9092", ldb_hostname))
                 .build_publisher()
                 .await?;
-            let plugins = dial_plugins(&log, &plugin).await?;
+            let plugins = dial_plugins(&plugin).await?;
             let mut handles = Vec::new();
 
             for offset in 0..local_workers {
@@ -116,20 +117,22 @@ async fn main() -> anyhow::Result<()> {
                     .build_consumer(worker_cfg)
                     .await?;
 
-                let worker_log = log.new(o!("worker" => format!("{}/{}", index, worker_count)));
-                info!(
-                    worker_log,
-                    "started rtq consumer";
-                    "shards" => format!("{:?}", consumer.owned_shards())
+                let span = tracing::info_span!("worker", worker = %format!("{}/{}", index, worker_count));
+                tracing::info!(
+                    parent: &span,
+                    shards = ?consumer.owned_shards(),
+                    "started rtq consumer",
                 );
 
-                handles.push(task::spawn(worker_loop(
-                    worker_log,
-                    consumer,
-                    rdb_client.clone(),
-                    ldb_publisher.clone(),
-                    plugins.clone(),
-                )));
+                handles.push(task::spawn(
+                    worker_loop(
+                        consumer,
+                        rdb_client.clone(),
+                        ldb_publisher.clone(),
+                        plugins.clone(),
+                    )
+                    .instrument(span),
+                ));
             }
 
             for handle in handles {
@@ -142,7 +145,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn worker_loop(
-    log: Logger,
     mut consumer: rtq::Consumer,
     rdb_client: rdb::Client,
     ldb_publisher: ldb::Publisher,
@@ -150,12 +152,12 @@ async fn worker_loop(
 ) {
     loop {
         let keep_running =
-            match worker_loop_iteration(&log, &mut consumer, &rdb_client, &ldb_publisher, &plugins)
+            match worker_loop_iteration(&mut consumer, &rdb_client, &ldb_publisher, &plugins)
                 .await
             {
                 Ok(keep_running) => keep_running,
                 Err(error) => {
-                    error!(log, "worker loop iteration failed"; "error" => error.to_string());
+                    tracing::error!(error = %error, "worker loop iteration failed");
                     true
                 }
             };
@@ -167,24 +169,24 @@ async fn worker_loop(
 }
 
 async fn worker_loop_iteration(
-    log: &Logger,
     consumer: &mut rtq::Consumer,
     rdb_client: &rdb::Client,
     ldb_publisher: &ldb::Publisher,
     plugins: &HashMap<String, rtp::PluginClient>,
 ) -> anyhow::Result<bool> {
-    info!(log, "polling rtq consumer for next message");
+    tracing::info!("polling rtq consumer for next message");
     let Some(delivery) = consumer.next().await? else {
-        warn!(log, "rtq consumer stream closed");
+        tracing::warn!("rtq consumer stream closed");
         return Ok(false);
     };
     let (message_type, resource) = message_meta(&delivery.message);
-    info!(log, "received rtq message";
-        "message_type" => message_type,
-        "namespace" => resource.namespace.clone(),
-        "resource_type" => resource.resource_type.clone(),
-        "resource_id" => resource.resource_id.clone(),
-        "redelivered" => delivery.redelivered()
+    tracing::info!(
+        message_type,
+        namespace = %resource.namespace,
+        resource_type = %resource.resource_type,
+        resource_id = %resource.resource_id,
+        redelivered = delivery.redelivered(),
+        "received rtq message",
     );
 
     match &delivery.message {
@@ -197,21 +199,23 @@ async fn worker_loop_iteration(
                 );
             match resource_client.get().await {
                 Ok(Some(_)) => {
-                    info!(log, "dropping idempotent create for existing resource";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::info!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "dropping idempotent create for existing resource",
                     );
                     delivery.ack().await?;
                     return Ok(true);
                 }
                 Ok(None) => {}
                 Err(error) => {
-                    warn!(log, "failed to read resource state before create";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to read resource state before create",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -220,18 +224,20 @@ async fn worker_loop_iteration(
 
             let Some(plugin_name) = plugin_name_for_resource_type(&message.resource.resource_type)
             else {
-                warn!(log, "invalid resource type for create";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    "invalid resource type for create",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             };
             let Some(mut plugin) = plugins.get(plugin_name).cloned() else {
-                warn!(log, "no plugin configured for resource type";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "plugin" => plugin_name.to_owned()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    plugin = plugin_name,
+                    "no plugin configured for resource type",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
@@ -240,11 +246,12 @@ async fn worker_loop_iteration(
             let inputs: sclc::Record = match serde_json::from_value(message.inputs.clone()) {
                 Ok(inputs) => inputs,
                 Err(error) => {
-                    warn!(log, "invalid create inputs json";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "invalid create inputs json",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -255,20 +262,22 @@ async fn worker_loop_iteration(
                 ty: message.resource.resource_type.clone(),
                 id: message.resource.resource_id.clone(),
             };
-            info!(log, "calling plugin create_resource";
-                "plugin" => plugin_name.to_owned(),
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone()
+            tracing::info!(
+                plugin = plugin_name,
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "calling plugin create_resource",
             );
             let resource = match plugin.create_resource(id, inputs).await {
                 Ok(resource) => resource,
                 Err(error) => {
-                    warn!(log, "create_resource plugin call failed";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "create_resource plugin call failed",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -279,11 +288,12 @@ async fn worker_loop_iteration(
                 .set_input(resource.inputs.clone(), message.owner_deployment_id.clone())
                 .await
             {
-                warn!(log, "failed to persist created resource inputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist created resource inputs",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
@@ -291,34 +301,36 @@ async fn worker_loop_iteration(
 
             let dependencies = dependencies_from_refs(&message.dependencies);
             if let Err(error) = resource_client.set_dependencies(&dependencies).await {
-                warn!(log, "failed to persist created resource dependencies";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist created resource dependencies",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
 
             if let Err(error) = resource_client.set_output(resource.outputs).await {
-                warn!(log, "failed to persist created resource outputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist created resource outputs",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
 
-            info!(log, "created resource";
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone()
+            tracing::info!(
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "created resource",
             );
             log_deployment_event(
-                &log,
                 &ldb_publisher,
                 &message.owner_deployment_id,
                 Severity::Info,
@@ -339,12 +351,13 @@ async fn worker_loop_iteration(
             let current = match resource_client.get().await {
                 Ok(Some(resource)) => {
                     if resource.owner.as_deref() != Some(message.owner_deployment_id.as_str()) {
-                        info!(log, "dropping delete for non-matching owner";
-                            "namespace" => message.resource.namespace.clone(),
-                            "resource_type" => message.resource.resource_type.clone(),
-                            "resource_id" => message.resource.resource_id.clone(),
-                            "message_owner" => message.owner_deployment_id.clone(),
-                            "current_owner" => resource.owner
+                        tracing::info!(
+                            namespace = %message.resource.namespace,
+                            resource_type = %message.resource.resource_type,
+                            resource_id = %message.resource.resource_id,
+                            message_owner = %message.owner_deployment_id,
+                            current_owner = ?resource.owner,
+                            "dropping delete for non-matching owner",
                         );
                         delivery.ack().await?;
                         return Ok(true);
@@ -352,20 +365,22 @@ async fn worker_loop_iteration(
                     resource
                 }
                 Ok(None) => {
-                    info!(log, "dropping idempotent delete for missing resource";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::info!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "dropping idempotent delete for missing resource",
                     );
                     delivery.ack().await?;
                     return Ok(true);
                 }
                 Err(error) => {
-                    warn!(log, "failed to read resource state before delete";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to read resource state before delete",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -375,10 +390,11 @@ async fn worker_loop_iteration(
             let inputs = match current.inputs {
                 Some(inputs) => inputs,
                 None => {
-                    warn!(log, "missing current inputs for delete";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current inputs for delete",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -387,10 +403,11 @@ async fn worker_loop_iteration(
             let outputs = match current.outputs {
                 Some(outputs) => outputs,
                 None => {
-                    warn!(log, "missing current outputs for delete";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current outputs for delete",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -399,18 +416,20 @@ async fn worker_loop_iteration(
 
             let Some(plugin_name) = plugin_name_for_resource_type(&message.resource.resource_type)
             else {
-                warn!(log, "invalid resource type for delete";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    "invalid resource type for delete",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             };
             let Some(mut plugin) = plugins.get(plugin_name).cloned() else {
-                warn!(log, "no plugin configured for resource type";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "plugin" => plugin_name.to_owned()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    plugin = plugin_name,
+                    "no plugin configured for resource type",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
@@ -420,41 +439,44 @@ async fn worker_loop_iteration(
                 ty: message.resource.resource_type.clone(),
                 id: message.resource.resource_id.clone(),
             };
-            info!(log, "calling plugin delete_resource";
-                "plugin" => plugin_name.to_owned(),
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone()
+            tracing::info!(
+                plugin = plugin_name,
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "calling plugin delete_resource",
             );
             if let Err(error) = plugin.delete_resource(id, inputs, outputs).await {
-                warn!(log, "delete_resource plugin call failed";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "delete_resource plugin call failed",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
 
             if let Err(error) = resource_client.delete().await {
-                warn!(log, "failed to delete resource from rdb";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to delete resource from rdb",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
 
-            info!(log, "deleted resource";
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone()
+            tracing::info!(
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "deleted resource",
             );
             log_deployment_event(
-                &log,
                 &ldb_publisher,
                 &message.owner_deployment_id,
                 Severity::Info,
@@ -475,32 +497,35 @@ async fn worker_loop_iteration(
             let current = match resource_client.get().await {
                 Ok(Some(resource)) => resource,
                 Ok(None) => {
-                    info!(log, "dropping adopt for missing resource";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::info!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "dropping adopt for missing resource",
                     );
                     delivery.ack().await?;
                     return Ok(true);
                 }
                 Err(error) => {
-                    warn!(log, "failed to read resource state before adopt";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to read resource state before adopt",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 }
             };
             if current.owner.as_deref() != Some(message.from_owner_deployment_id.as_str()) {
-                info!(log, "dropping adopt for non-matching owner";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "from_owner" => message.from_owner_deployment_id.clone(),
-                    "current_owner" => current.owner
+                tracing::info!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    from_owner = %message.from_owner_deployment_id,
+                    current_owner = ?current.owner,
+                    "dropping adopt for non-matching owner",
                 );
                 delivery.ack().await?;
                 return Ok(true);
@@ -509,10 +534,11 @@ async fn worker_loop_iteration(
             let prev_inputs = match current.inputs {
                 Some(inputs) => inputs,
                 None => {
-                    warn!(log, "missing current inputs for adopt";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current inputs for adopt",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -521,10 +547,11 @@ async fn worker_loop_iteration(
             let prev_outputs = match current.outputs.clone() {
                 Some(outputs) => outputs,
                 None => {
-                    warn!(log, "missing current outputs for adopt";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current outputs for adopt",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -534,11 +561,12 @@ async fn worker_loop_iteration(
                 match serde_json::from_value(message.desired_inputs.clone()) {
                     Ok(inputs) => inputs,
                     Err(error) => {
-                        warn!(log, "invalid adopt desired_inputs json";
-                            "namespace" => message.resource.namespace.clone(),
-                            "resource_type" => message.resource.resource_type.clone(),
-                            "resource_id" => message.resource.resource_id.clone(),
-                            "error" => error.to_string()
+                        tracing::warn!(
+                            namespace = %message.resource.namespace,
+                            resource_type = %message.resource.resource_type,
+                            resource_id = %message.resource.resource_id,
+                            error = %error,
+                            "invalid adopt desired_inputs json",
                         );
                         delivery.nack(false).await?;
                         return Ok(true);
@@ -552,18 +580,20 @@ async fn worker_loop_iteration(
                 let Some(plugin_name) =
                     plugin_name_for_resource_type(&message.resource.resource_type)
                 else {
-                    warn!(log, "invalid resource type for adopt";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        "invalid resource type for adopt",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 };
                 let Some(mut plugin) = plugins.get(plugin_name).cloned() else {
-                    warn!(log, "no plugin configured for resource type";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "plugin" => plugin_name.to_owned()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        plugin = plugin_name,
+                        "no plugin configured for resource type",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -573,11 +603,12 @@ async fn worker_loop_iteration(
                     ty: message.resource.resource_type.clone(),
                     id: message.resource.resource_id.clone(),
                 };
-                info!(log, "calling plugin update_resource for adopt";
-                    "plugin" => plugin_name.to_owned(),
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::info!(
+                    plugin = plugin_name,
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "calling plugin update_resource for adopt",
                 );
                 let resource = match plugin
                     .update_resource(id, prev_inputs, prev_outputs, desired_inputs)
@@ -585,11 +616,12 @@ async fn worker_loop_iteration(
                 {
                     Ok(resource) => resource,
                     Err(error) => {
-                        warn!(log, "update_resource plugin call failed for adopt";
-                            "namespace" => message.resource.namespace.clone(),
-                            "resource_type" => message.resource.resource_type.clone(),
-                            "resource_id" => message.resource.resource_id.clone(),
-                            "error" => error.to_string()
+                        tracing::warn!(
+                            namespace = %message.resource.namespace,
+                            resource_type = %message.resource.resource_type,
+                            resource_id = %message.resource.resource_id,
+                            error = %error,
+                            "update_resource plugin call failed for adopt",
                         );
                         delivery.nack(false).await?;
                         return Ok(true);
@@ -598,10 +630,11 @@ async fn worker_loop_iteration(
                 inputs_to_persist = resource.inputs;
                 outputs_to_persist = Some(resource.outputs);
             } else {
-                info!(log, "skipping plugin update_resource for adopt with unchanged inputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::info!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "skipping plugin update_resource for adopt with unchanged inputs",
                 );
             }
 
@@ -609,51 +642,56 @@ async fn worker_loop_iteration(
                 .set_input(inputs_to_persist, message.to_owner_deployment_id.clone())
                 .await
             {
-                warn!(log, "failed to persist adopted resource inputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist adopted resource inputs",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
             let dependencies = dependencies_from_refs(&message.dependencies);
             if let Err(error) = resource_client.set_dependencies(&dependencies).await {
-                warn!(log, "failed to persist adopted resource dependencies";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist adopted resource dependencies",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
             if let Some(outputs) = outputs_to_persist {
                 if let Err(error) = resource_client.set_output(outputs).await {
-                    warn!(log, "failed to persist adopted resource outputs";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to persist adopted resource outputs",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 }
             } else {
-                warn!(log, "adopted resource has no outputs to persist";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "adopted resource has no outputs to persist",
                 );
             }
 
-            info!(log, "adopted resource";
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone(),
-                "from_owner" => message.from_owner_deployment_id.clone(),
-                "to_owner" => message.to_owner_deployment_id.clone()
+            tracing::info!(
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                from_owner = %message.from_owner_deployment_id,
+                to_owner = %message.to_owner_deployment_id,
+                "adopted resource",
             );
             let summary = format!(
                 "ADOPT applied for {}.{} from {} to {}",
@@ -663,7 +701,6 @@ async fn worker_loop_iteration(
                 message.to_owner_deployment_id
             );
             log_deployment_event(
-                &log,
                 &ldb_publisher,
                 &message.from_owner_deployment_id,
                 Severity::Info,
@@ -671,7 +708,6 @@ async fn worker_loop_iteration(
             )
             .await;
             log_deployment_event(
-                &log,
                 &ldb_publisher,
                 &message.to_owner_deployment_id,
                 Severity::Info,
@@ -689,32 +725,35 @@ async fn worker_loop_iteration(
             let current = match resource_client.get().await {
                 Ok(Some(resource)) => resource,
                 Ok(None) => {
-                    info!(log, "dropping restore for missing resource";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::info!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "dropping restore for missing resource",
                     );
                     delivery.ack().await?;
                     return Ok(true);
                 }
                 Err(error) => {
-                    warn!(log, "failed to read resource state before restore";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to read resource state before restore",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 }
             };
             if current.owner.as_deref() != Some(message.owner_deployment_id.as_str()) {
-                info!(log, "dropping restore for non-matching owner";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "message_owner" => message.owner_deployment_id.clone(),
-                    "current_owner" => current.owner
+                tracing::info!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    message_owner = %message.owner_deployment_id,
+                    current_owner = ?current.owner,
+                    "dropping restore for non-matching owner",
                 );
                 delivery.ack().await?;
                 return Ok(true);
@@ -723,10 +762,11 @@ async fn worker_loop_iteration(
             let prev_inputs = match current.inputs {
                 Some(inputs) => inputs,
                 None => {
-                    warn!(log, "missing current inputs for restore";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current inputs for restore",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -735,10 +775,11 @@ async fn worker_loop_iteration(
             let prev_outputs = match current.outputs.clone() {
                 Some(outputs) => outputs,
                 None => {
-                    warn!(log, "missing current outputs for restore";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        "missing current outputs for restore",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -748,11 +789,12 @@ async fn worker_loop_iteration(
                 match serde_json::from_value(message.desired_inputs.clone()) {
                     Ok(inputs) => inputs,
                     Err(error) => {
-                        warn!(log, "invalid restore desired_inputs json";
-                            "namespace" => message.resource.namespace.clone(),
-                            "resource_type" => message.resource.resource_type.clone(),
-                            "resource_id" => message.resource.resource_id.clone(),
-                            "error" => error.to_string()
+                        tracing::warn!(
+                            namespace = %message.resource.namespace,
+                            resource_type = %message.resource.resource_type,
+                            resource_id = %message.resource.resource_id,
+                            error = %error,
+                            "invalid restore desired_inputs json",
                         );
                         delivery.nack(false).await?;
                         return Ok(true);
@@ -766,18 +808,20 @@ async fn worker_loop_iteration(
                 let Some(plugin_name) =
                     plugin_name_for_resource_type(&message.resource.resource_type)
                 else {
-                    warn!(log, "invalid resource type for restore";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        "invalid resource type for restore",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 };
                 let Some(mut plugin) = plugins.get(plugin_name).cloned() else {
-                    warn!(log, "no plugin configured for resource type";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "plugin" => plugin_name.to_owned()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        plugin = plugin_name,
+                        "no plugin configured for resource type",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
@@ -787,11 +831,12 @@ async fn worker_loop_iteration(
                     ty: message.resource.resource_type.clone(),
                     id: message.resource.resource_id.clone(),
                 };
-                info!(log, "calling plugin update_resource for restore";
-                    "plugin" => plugin_name.to_owned(),
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::info!(
+                    plugin = plugin_name,
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "calling plugin update_resource for restore",
                 );
                 let resource = match plugin
                     .update_resource(id, prev_inputs, prev_outputs, desired_inputs)
@@ -799,11 +844,12 @@ async fn worker_loop_iteration(
                 {
                     Ok(resource) => resource,
                     Err(error) => {
-                        warn!(log, "update_resource plugin call failed for restore";
-                            "namespace" => message.resource.namespace.clone(),
-                            "resource_type" => message.resource.resource_type.clone(),
-                            "resource_id" => message.resource.resource_id.clone(),
-                            "error" => error.to_string()
+                        tracing::warn!(
+                            namespace = %message.resource.namespace,
+                            resource_type = %message.resource.resource_type,
+                            resource_id = %message.resource.resource_id,
+                            error = %error,
+                            "update_resource plugin call failed for restore",
                         );
                         delivery.nack(false).await?;
                         return Ok(true);
@@ -812,10 +858,11 @@ async fn worker_loop_iteration(
                 inputs_to_persist = resource.inputs;
                 outputs_to_persist = Some(resource.outputs);
             } else {
-                info!(log, "skipping plugin update_resource for restore with unchanged inputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::info!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "skipping plugin update_resource for restore with unchanged inputs",
                 );
             }
 
@@ -823,53 +870,57 @@ async fn worker_loop_iteration(
                 .set_input(inputs_to_persist, message.owner_deployment_id.clone())
                 .await
             {
-                warn!(log, "failed to persist restored resource inputs";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist restored resource inputs",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
             let dependencies = dependencies_from_refs(&message.dependencies);
             if let Err(error) = resource_client.set_dependencies(&dependencies).await {
-                warn!(log, "failed to persist restored resource dependencies";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone(),
-                    "error" => error.to_string()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    error = %error,
+                    "failed to persist restored resource dependencies",
                 );
                 delivery.nack(false).await?;
                 return Ok(true);
             }
             if let Some(outputs) = outputs_to_persist {
                 if let Err(error) = resource_client.set_output(outputs).await {
-                    warn!(log, "failed to persist restored resource outputs";
-                        "namespace" => message.resource.namespace.clone(),
-                        "resource_type" => message.resource.resource_type.clone(),
-                        "resource_id" => message.resource.resource_id.clone(),
-                        "error" => error.to_string()
+                    tracing::warn!(
+                        namespace = %message.resource.namespace,
+                        resource_type = %message.resource.resource_type,
+                        resource_id = %message.resource.resource_id,
+                        error = %error,
+                        "failed to persist restored resource outputs",
                     );
                     delivery.nack(false).await?;
                     return Ok(true);
                 }
             } else {
-                warn!(log, "restored resource has no outputs to persist";
-                    "namespace" => message.resource.namespace.clone(),
-                    "resource_type" => message.resource.resource_type.clone(),
-                    "resource_id" => message.resource.resource_id.clone()
+                tracing::warn!(
+                    namespace = %message.resource.namespace,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    "restored resource has no outputs to persist",
                 );
             }
 
-            info!(log, "restored resource";
-                "namespace" => message.resource.namespace.clone(),
-                "resource_type" => message.resource.resource_type.clone(),
-                "resource_id" => message.resource.resource_id.clone(),
-                "owner" => message.owner_deployment_id.clone()
+            tracing::info!(
+                namespace = %message.resource.namespace,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                owner = %message.owner_deployment_id,
+                "restored resource",
             );
             log_deployment_event(
-                &log,
                 &ldb_publisher,
                 &message.owner_deployment_id,
                 Severity::Info,
@@ -884,11 +935,12 @@ async fn worker_loop_iteration(
 
     // Placeholder behavior until transition execution is implemented.
     delivery.ack().await?;
-    info!(log, "acknowledged rtq message";
-        "message_type" => message_type,
-        "namespace" => resource.namespace.clone(),
-        "resource_type" => resource.resource_type.clone(),
-        "resource_id" => resource.resource_id.clone()
+    tracing::info!(
+        message_type,
+        namespace = %resource.namespace,
+        resource_type = %resource.resource_type,
+        resource_id = %resource.resource_id,
+        "acknowledged rtq message",
     );
     Ok(true)
 }
@@ -903,15 +955,15 @@ fn message_meta(message: &rtq::Message) -> (&'static str, &rtq::ResourceRef) {
 }
 
 async fn dial_plugins(
-    log: &Logger,
     plugin_specs: &[PluginSpec],
 ) -> anyhow::Result<HashMap<String, rtp::PluginClient>> {
     let mut plugins = HashMap::new();
     for spec in plugin_specs {
         let client = rtp::dial(spec.target.clone()).await?;
-        info!(log, "dialed plugin";
-            "name" => spec.name.to_string(),
-            "target" => format!("{:?}", spec.target)
+        tracing::info!(
+            name = %spec.name,
+            target = ?spec.target,
+            "dialed plugin",
         );
         plugins.insert(spec.name.to_string(), client);
     }
@@ -933,7 +985,6 @@ fn dependencies_from_refs(dependencies: &[rtq::ResourceRef]) -> Vec<sclc::Resour
 }
 
 async fn log_deployment_event(
-    log: &Logger,
     publisher: &ldb::Publisher,
     deployment_id: &str,
     severity: Severity,
@@ -942,17 +993,19 @@ async fn log_deployment_event(
     let namespace_publisher = match publisher.namespace(deployment_id.to_string()).await {
         Ok(namespace_publisher) => namespace_publisher,
         Err(error) => {
-            warn!(log, "failed to prepare deployment log publisher";
-                "deployment_id" => deployment_id.to_string(),
-                "error" => error.to_string()
+            tracing::warn!(
+                deployment_id,
+                error = %error,
+                "failed to prepare deployment log publisher",
             );
             return;
         }
     };
     if let Err(error) = namespace_publisher.log(severity, message).await {
-        warn!(log, "failed to publish deployment log event";
-            "deployment_id" => deployment_id.to_string(),
-            "error" => error.to_string()
+        tracing::warn!(
+            deployment_id,
+            error = %error,
+            "failed to publish deployment log event",
         );
     }
 }

--- a/crates/scoc/Cargo.toml
+++ b/crates/scoc/Cargo.toml
@@ -20,4 +20,4 @@ tokio = { version = "1.49", features = ["full"] }
 tonic = { version = "0.14", features = ["transport"] }
 tower = "0.5"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -302,7 +302,12 @@ impl scop::Conduit for CriConduit {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
     let args = Args::parse();
 
     match args.command {

--- a/crates/scs/Cargo.toml
+++ b/crates/scs/Cargo.toml
@@ -11,9 +11,8 @@ gix-negotiate = "0.27.0"
 gix-packetline = { version = "0.21.1", features = ["async-io"] }
 gix-protocol = { version = "0.57.0", features = ["async-client"] }
 russh = "0.57.0"
-slog = { version = "2.8.2", features = ["anyhow"] }
-slog-async = "2.8.0"
-slog-term = "2.9.2"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio = { version = "1.49.0", features = ["full"] }
 cdb = { path = "../cdb" }
 udb = { path = "../udb" }

--- a/crates/scs/src/main.rs
+++ b/crates/scs/src/main.rs
@@ -16,9 +16,9 @@ use russh::{
     keys::{PrivateKey, ssh_key::PublicKey},
     server::{self, Auth, Config, Handler, Server},
 };
-use slog::{Drain, Logger, debug, info, o};
 use tokio::{io::AsyncReadExt, sync::mpsc, task};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tracing::Instrument;
 
 #[derive(Parser)]
 enum Program {
@@ -39,11 +39,12 @@ enum Program {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-
-    let log = slog::Logger::root(drain, o!());
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     match Program::parse() {
         Program::Daemon {
@@ -61,9 +62,8 @@ async fn main() -> anyhow::Result<()> {
                 .build()
                 .await?;
 
-            info!(log, "listening on {address}");
+            tracing::info!("listening on {address}");
             ConfigServer {
-                log,
                 client,
                 udb_client,
             }
@@ -92,7 +92,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 struct ConfigServer {
-    log: Logger,
     client: cdb::Client,
     udb_client: udb::Client,
 }
@@ -101,8 +100,9 @@ impl Server for ConfigServer {
     type Handler = ConfigHandler;
 
     fn new_client(&mut self, peer_addr: Option<SocketAddr>) -> Self::Handler {
+        let span = tracing::info_span!("peer", peer = ?peer_addr);
         ConfigHandler {
-            log: self.log.new(o!("peer" => peer_addr)),
+            span,
             channels: Default::default(),
             user: None,
             client: self.client.clone(),
@@ -126,7 +126,7 @@ enum ChannelCommand {
 }
 
 struct ConfigHandler {
-    log: Logger,
+    span: tracing::Span,
     channels: BTreeMap<ChannelId, mpsc::Sender<Result<ChannelCommand, clap::Error>>>,
     user: Option<udb::User>,
     client: cdb::Client,
@@ -141,6 +141,7 @@ impl Handler for ConfigHandler {
         username: &str,
         public_key: &PublicKey,
     ) -> Result<Auth, Self::Error> {
+        let _guard = self.span.enter();
         let fingerprint = public_key.fingerprint(Default::default()).to_string();
         let mut user_client = self.udb_client.user(username);
         let user = match user_client.get().await {
@@ -154,9 +155,10 @@ impl Handler for ConfigHandler {
         };
 
         let Some(user) = user else {
-            info!(
-                self.log,
-                "rejecting auth for unknown user"; "username" => username, "fingerprint" => fingerprint
+            tracing::info!(
+                username,
+                fingerprint,
+                "rejecting auth for unknown user",
             );
             return Ok(Auth::Reject {
                 proceed_with_methods: None,
@@ -171,9 +173,10 @@ impl Handler for ConfigHandler {
             .map_err(|err| anyhow!("failed to check pubkey for user {username}: {err}"))?;
 
         if !fingerprint_allowed {
-            info!(
-                self.log,
-                "rejecting auth for unknown pubkey"; "username" => username, "fingerprint" => fingerprint
+            tracing::info!(
+                username,
+                fingerprint,
+                "rejecting auth for unknown pubkey",
             );
             return Ok(Auth::Reject {
                 proceed_with_methods: None,
@@ -181,7 +184,7 @@ impl Handler for ConfigHandler {
             });
         }
 
-        info!(self.log, "accepted auth"; "username" => username, "fingerprint" => fingerprint);
+        tracing::info!(username, fingerprint, "accepted auth");
         self.user = Some(user);
         Ok(Auth::Accept)
     }
@@ -194,7 +197,7 @@ impl Handler for ConfigHandler {
         let (tx, mut rx) = mpsc::channel(1);
         let channel_id = channel.id();
         self.channels.insert(channel_id, tx);
-        let log = self.log.new(o!("ch" => u32::from(channel_id)));
+        let span = tracing::info_span!(parent: &self.span, "channel", ch = %u32::from(channel_id));
         let user = self.user.clone();
         let client = self.client.clone();
         task::spawn(async move {
@@ -209,7 +212,6 @@ impl Handler for ConfigHandler {
                             Err(err)
                         } else {
                             CommandHandler {
-                                log: log.clone(),
                                 _user: user,
                                 channel: &mut channel,
                                 client: client.repo(repo),
@@ -225,7 +227,6 @@ impl Handler for ConfigHandler {
                             Err(err)
                         } else {
                             CommandHandler {
-                                log: log.clone(),
                                 _user: user,
                                 channel: &mut channel,
                                 client: client.repo(repo),
@@ -253,7 +254,7 @@ impl Handler for ConfigHandler {
             }
 
             channel.close().await.unwrap_or_default();
-        });
+        }.instrument(span));
         Ok(true)
     }
 
@@ -307,7 +308,6 @@ async fn ensure_repo_exists(client: &cdb::Client, repo: &RepositoryName) -> anyh
 }
 
 struct CommandHandler<'a> {
-    log: Logger,
     channel: &'a mut Channel<server::Msg>,
     _user: &'a udb::User,
     client: cdb::RepositoryClient,
@@ -908,7 +908,7 @@ impl<'a> CommandHandler<'a> {
                         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, &data)?;
                         let object =
                             gix_object::ObjectRef::from_bytes(kind, &data)?.into_owned()?;
-                        debug!(self.log, "writing {} {}", object.kind(), id);
+                        tracing::debug!("writing {} {}", object.kind(), id);
                         self.client.write_object(id, object).await?;
                         oid_by_offset.insert(pack_offset, id);
                         progress = true;
@@ -933,7 +933,7 @@ impl<'a> CommandHandler<'a> {
                         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, &data)?;
                         let object =
                             gix_object::ObjectRef::from_bytes(kind, &data)?.into_owned()?;
-                        debug!(self.log, "writing {} {}", object.kind(), id);
+                        tracing::debug!("writing {} {}", object.kind(), id);
                         self.client.write_object(id, object).await?;
                         oid_by_offset.insert(pack_offset, id);
                         progress = true;
@@ -960,7 +960,7 @@ impl<'a> CommandHandler<'a> {
                         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, &data)?;
                         let object =
                             gix_object::ObjectRef::from_bytes(kind, &data)?.into_owned()?;
-                        debug!(self.log, "writing {} {}", object.kind(), id);
+                        tracing::debug!("writing {} {}", object.kind(), id);
                         self.client.write_object(id, object).await?;
                         oid_by_offset.insert(pack_offset, id);
                         progress = true;


### PR DESCRIPTION
## Summary
This PR replaces the slog logging framework with the tracing framework across multiple crates in the project. This modernizes the logging infrastructure to use the more widely-adopted tracing ecosystem while maintaining structured logging capabilities.

## Key Changes

- **Logging Framework Migration**: Replaced slog with tracing/tracing-subscriber in:
  - `crates/rte` (Resource Transition Engine)
  - `crates/de` (Deployment Engine)
  - `crates/scs` (SSH Config Server)
  - `crates/cli`
  - `crates/plugin_std_container`
  - `crates/plugin_std_random`
  - `crates/scoc`
  - `crates/api`

- **Logger Initialization**: Updated all `main()` functions to initialize tracing-subscriber with:
  - Formatted output via `tracing_subscriber::fmt()`
  - Environment filter support with "info" as default level
  - Fallback to default environment configuration

- **Logging Calls**: Converted all logging statements from slog macros to tracing equivalents:
  - `info!(log, ...)` → `tracing::info!(...)`
  - `warn!(log, ...)` → `tracing::warn!(...)`
  - `error!(log, ...)` → `tracing::error!(...)`
  - `debug!(log, ...)` → `tracing::debug!(...)`

- **Structured Fields**: Updated structured field syntax to match tracing conventions:
  - Named fields: `"key" => value` → `key = value`
  - Display formatting: `"key" => value.to_string()` → `key = %value`
  - Debug formatting: `"key" => format!("{:?}", value)` → `key = ?value`

- **Span-based Context**: Replaced logger child contexts with tracing spans:
  - Removed `log.new(o!(...))` pattern
  - Introduced `tracing::info_span!()` for worker/peer contexts
  - Used `.instrument(span)` to attach spans to async tasks

- **Function Signatures**: Removed `Logger` parameters from functions that no longer need explicit logger passing, relying on tracing's context propagation instead

- **Dependencies**: Updated Cargo.toml files to:
  - Remove slog, slog-async, slog-term dependencies
  - Add tracing and tracing-subscriber with env-filter feature

https://claude.ai/code/session_013JJa7UMuEwRqEtTrATDSMR