### PR TITLE
Consolidate pod lifecycle: merge stop into remove operation

### DIFF
--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -377,10 +377,10 @@ impl ContainerPlugin {
             "creating pod sandbox"
         );
 
-        // Connect to the target node and run the pod
+        // Connect to the target node and create the pod
         let mut conduit = self.get_conduit(&node_name).await?;
         let response = conduit
-            .run_pod(scop::RunPodRequest {
+            .create_pod(scop::CreatePodRequest {
                 config: Some(scop::PodConfig {
                     environment_qid: environment_qid.to_string(),
                     name: name.clone(),
@@ -486,15 +486,6 @@ impl ContainerPlugin {
 
         let mut conduit = self.get_conduit(node_name).await?;
 
-        // Stop the pod first
-        conduit
-            .stop_pod(scop::StopPodRequest {
-                pod_id: pod_id.to_string(),
-            })
-            .await
-            .map_err(|e| PluginError::ScopOperation(format!("stop_pod: {e}")))?;
-
-        // Then remove it
         conduit
             .remove_pod(scop::RemovePodRequest {
                 pod_id: pod_id.to_string(),

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -71,23 +71,15 @@ enum Command {
 
 #[derive(Subcommand)]
 enum PodAction {
-    /// Create and run a test pod.
-    Run {
+    /// Create a test pod.
+    Create {
         /// Pod name.
         #[arg(long)]
         name: String,
         #[arg(long, default_value = "/run/containerd/containerd.sock")]
         containerd_socket: String,
     },
-    /// Stop a pod.
-    Stop {
-        /// Pod ID.
-        #[arg(long)]
-        id: String,
-        #[arg(long, default_value = "/run/containerd/containerd.sock")]
-        containerd_socket: String,
-    },
-    /// Remove a pod.
+    /// Stop and remove a pod.
     Remove {
         /// Pod ID.
         #[arg(long)]
@@ -291,10 +283,10 @@ impl CriConduit {
 
 #[scop::tonic::async_trait]
 impl scop::Conduit for CriConduit {
-    async fn run_pod(
+    async fn create_pod(
         &self,
-        request: scop::RunPodRequest,
-    ) -> Result<scop::RunPodResponse, scop::tonic::Status> {
+        request: scop::CreatePodRequest,
+    ) -> Result<scop::CreatePodResponse, scop::tonic::Status> {
         let config = request.config.unwrap_or_default();
         let cri_config = Self::to_cri_pod_config(&config);
         let mut cri = self.cri.lock().await;
@@ -315,18 +307,7 @@ impl scop::Conduit for CriConduit {
             );
         }
 
-        Ok(scop::RunPodResponse { pod_id })
-    }
-
-    async fn stop_pod(
-        &self,
-        request: scop::StopPodRequest,
-    ) -> Result<scop::StopPodResponse, scop::tonic::Status> {
-        let mut cri = self.cri.lock().await;
-        cri.stop_pod_sandbox(&request.pod_id)
-            .await
-            .map_err(|e| scop::tonic::Status::internal(e.to_string()))?;
-        Ok(scop::StopPodResponse {})
+        Ok(scop::CreatePodResponse { pod_id })
     }
 
     async fn remove_pod(
@@ -334,6 +315,11 @@ impl scop::Conduit for CriConduit {
         request: scop::RemovePodRequest,
     ) -> Result<scop::RemovePodResponse, scop::tonic::Status> {
         let mut cri = self.cri.lock().await;
+
+        // Stop the pod sandbox first, then remove it
+        cri.stop_pod_sandbox(&request.pod_id)
+            .await
+            .map_err(|e| scop::tonic::Status::internal(e.to_string()))?;
         cri.remove_pod_sandbox(&request.pod_id)
             .await
             .map_err(|e| scop::tonic::Status::internal(e.to_string()))?;
@@ -593,7 +579,7 @@ async fn main() -> Result<()> {
         }
 
         Command::Pod { action } => match action {
-            PodAction::Run {
+            PodAction::Create {
                 name,
                 containerd_socket,
             } => {
@@ -602,19 +588,12 @@ async fn main() -> Result<()> {
                 let pod_id = cri.run_pod_sandbox(config).await?;
                 println!("{pod_id}");
             }
-            PodAction::Stop {
-                id,
-                containerd_socket,
-            } => {
-                let mut cri = CriClient::connect(&containerd_socket).await?;
-                cri.stop_pod_sandbox(&id).await?;
-                println!("Pod stopped");
-            }
             PodAction::Remove {
                 id,
                 containerd_socket,
             } => {
                 let mut cri = CriClient::connect(&containerd_socket).await?;
+                cri.stop_pod_sandbox(&id).await?;
                 cri.remove_pod_sandbox(&id).await?;
                 println!("Pod removed");
             }

--- a/crates/scop/proto/scop.proto
+++ b/crates/scop/proto/scop.proto
@@ -106,13 +106,10 @@ message UnregisterNodeResponse {
 // The Conduit service handles pod and container operations. The container
 // plugin connects to conduits when it needs to execute operations on a node.
 service Conduit {
-  // RunPod creates and starts a pod sandbox.
-  rpc RunPod(RunPodRequest) returns (RunPodResponse);
+  // CreatePod creates and starts a pod sandbox.
+  rpc CreatePod(CreatePodRequest) returns (CreatePodResponse);
 
-  // StopPod stops a running pod sandbox.
-  rpc StopPod(StopPodRequest) returns (StopPodResponse);
-
-  // RemovePod removes a pod sandbox.
+  // RemovePod stops and removes a pod sandbox.
   rpc RemovePod(RemovePodRequest) returns (RemovePodResponse);
 
   // CreateContainer creates a container within a pod.
@@ -132,24 +129,16 @@ service Conduit {
 // Pod Messages
 // ============================================================================
 
-// Request to create and run a pod.
-message RunPodRequest {
+// Request to create a pod.
+message CreatePodRequest {
   PodConfig config = 1;
 }
 
-// Response from running a pod.
-message RunPodResponse {
+// Response from creating a pod.
+message CreatePodResponse {
   // The ID of the created pod.
   string pod_id = 1;
 }
-
-// Request to stop a pod.
-message StopPodRequest {
-  string pod_id = 1;
-}
-
-// Response from stopping a pod.
-message StopPodResponse {}
 
 // Request to remove a pod.
 message RemovePodRequest {

--- a/crates/scop/src/lib.rs
+++ b/crates/scop/src/lib.rs
@@ -31,7 +31,7 @@
 //! struct MyConduit { /* CRI client */ }
 //!
 //! impl Conduit for MyConduit {
-//!     async fn run_pod(&self, request: RunPodRequest) -> Result<RunPodResponse, Status> {
+//!     async fn create_pod(&self, request: CreatePodRequest) -> Result<CreatePodResponse, Status> {
 //!         // Use CRI to create the sandbox
 //!     }
 //! }
@@ -48,7 +48,7 @@
 //!
 //! // Plugin sending commands to conduit
 //! let mut client = ConduitClient::connect("http://node:50054").await?;
-//! client.run_pod(request).await?;
+//! client.create_pod(request).await?;
 //! ```
 
 use std::{net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
@@ -67,12 +67,12 @@ pub mod proto {
 
 // Re-export commonly used types
 pub use proto::{
-    ContainerConfig, CreateContainerRequest, CreateContainerResponse, HeartbeatRequest,
-    HeartbeatResponse, KeyValue, NodeCapacity, NodeUsage, PodConfig, RegisterNodeRequest,
-    RegisterNodeResponse, RemoveContainerRequest, RemoveContainerResponse, RemovePodRequest,
-    RemovePodResponse, RunPodRequest, RunPodResponse, StartContainerRequest,
-    StartContainerResponse, StopContainerRequest, StopContainerResponse, StopPodRequest,
-    StopPodResponse, UnregisterNodeRequest, UnregisterNodeResponse,
+    ContainerConfig, CreateContainerRequest, CreateContainerResponse, CreatePodRequest,
+    CreatePodResponse, HeartbeatRequest, HeartbeatResponse, KeyValue, NodeCapacity, NodeUsage,
+    PodConfig, RegisterNodeRequest, RegisterNodeResponse, RemoveContainerRequest,
+    RemoveContainerResponse, RemovePodRequest, RemovePodResponse, StartContainerRequest,
+    StartContainerResponse, StopContainerRequest, StopContainerResponse, UnregisterNodeRequest,
+    UnregisterNodeResponse,
 };
 
 // Re-export the generated clients
@@ -260,11 +260,11 @@ pub async fn serve_orchestrator<O: Orchestrator>(
 /// Trait implemented by SCOC to handle pod and container operations.
 #[tonic::async_trait]
 pub trait Conduit: Send + Sync + 'static {
-    /// Run a pod.
-    async fn run_pod(&self, request: RunPodRequest) -> Result<RunPodResponse, tonic::Status>;
-
-    /// Stop a pod.
-    async fn stop_pod(&self, request: StopPodRequest) -> Result<StopPodResponse, tonic::Status>;
+    /// Create a pod.
+    async fn create_pod(
+        &self,
+        request: CreatePodRequest,
+    ) -> Result<CreatePodResponse, tonic::Status>;
 
     /// Remove a pod.
     async fn remove_pod(
@@ -311,19 +311,11 @@ impl<C: Conduit> Clone for ConduitService<C> {
 
 #[tonic::async_trait]
 impl<C: Conduit> proto::conduit_server::Conduit for ConduitService<C> {
-    async fn run_pod(
+    async fn create_pod(
         &self,
-        request: tonic::Request<RunPodRequest>,
-    ) -> Result<tonic::Response<RunPodResponse>, tonic::Status> {
-        let response = self.conduit.run_pod(request.into_inner()).await?;
-        Ok(tonic::Response::new(response))
-    }
-
-    async fn stop_pod(
-        &self,
-        request: tonic::Request<StopPodRequest>,
-    ) -> Result<tonic::Response<StopPodResponse>, tonic::Status> {
-        let response = self.conduit.stop_pod(request.into_inner()).await?;
+        request: tonic::Request<CreatePodRequest>,
+    ) -> Result<tonic::Response<CreatePodResponse>, tonic::Status> {
+        let response = self.conduit.create_pod(request.into_inner()).await?;
         Ok(tonic::Response::new(response))
     }
 


### PR DESCRIPTION
## Summary
This PR consolidates the pod lifecycle management by merging the separate `stop_pod` and `remove_pod` operations into a single `remove_pod` operation that handles both stopping and removing a pod sandbox.

## Key Changes

- **Renamed RPC method**: `RunPod` → `CreatePod` to better reflect that it only creates the pod without starting containers
- **Removed `StopPod` RPC**: Eliminated the separate `StopPod` service method from the Conduit trait and proto definition
- **Updated `RemovePod` semantics**: The `remove_pod` operation now stops the pod sandbox first, then removes it, combining both operations into a single call
- **Updated CLI commands**: 
  - Renamed `pod run` subcommand to `pod create`
  - Removed `pod stop` subcommand
  - Updated `pod remove` to handle both stopping and removal
- **Updated proto definitions**: Removed `StopPodRequest` and `StopPodResponse` message types; renamed `RunPodRequest`/`RunPodResponse` to `CreatePodRequest`/`CreatePodResponse`
- **Updated all implementations**: Modified CriConduit, ConduitService, and plugin code to use the new consolidated API

## Implementation Details

The consolidation simplifies the pod lifecycle by eliminating an intermediate state. Previously, users had to explicitly call `stop_pod` before `remove_pod`. Now, `remove_pod` handles both operations atomically, reducing the number of RPC calls and potential error states.

https://claude.ai/code/session_019u8VGCsNhQkXkNSupFvX3R