### PR TITLE
Add try-catch exception handling syntax and semantics

### DIFF
--- a/crates/sclc/src/ast.rs
+++ b/crates/sclc/src/ast.rs
@@ -108,6 +108,18 @@ impl Expr {
             Expr::PropertyAccess(property_access) => property_access.expr.as_ref().free_vars(),
             Expr::Exception(_) => HashSet::new(),
             Expr::Raise(raise_expr) => raise_expr.expr.as_ref().free_vars(),
+            Expr::Try(try_expr) => {
+                let mut vars = try_expr.expr.as_ref().free_vars();
+                for catch in &try_expr.catches {
+                    vars.insert(catch.exception_var.name.as_str());
+                    let mut catch_vars = catch.body.as_ref().free_vars();
+                    if let Some(catch_arg) = &catch.catch_arg {
+                        catch_vars.remove(catch_arg.name.as_str());
+                    }
+                    vars.extend(catch_vars);
+                }
+                vars
+            }
         }
     }
 }
@@ -142,6 +154,7 @@ pub enum Expr {
     PropertyAccess(PropertyAccessExpr),
     Exception(ExceptionExpr),
     Raise(RaiseExpr),
+    Try(TryExpr),
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -393,6 +406,19 @@ pub struct ExceptionExpr {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RaiseExpr {
     pub expr: Box<Loc<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TryExpr {
+    pub expr: Box<Loc<Expr>>,
+    pub catches: Vec<CatchClause>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatchClause {
+    pub exception_var: Loc<Var>,
+    pub catch_arg: Option<Loc<Var>>,
+    pub body: Loc<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -326,6 +326,33 @@ impl crate::Diag for NotAnException {
 }
 
 #[derive(Error, Debug)]
+#[error("catch variable must be an exception or function returning an exception, got {ty}")]
+pub struct InvalidCatchTarget {
+    pub module_id: crate::ModuleId,
+    pub ty: Type,
+    pub span: crate::Span,
+}
+
+impl crate::Diag for InvalidCatchTarget {
+    fn locate(&self) -> (crate::ModuleId, crate::Span) {
+        (self.module_id.clone(), self.span)
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("catch argument provided but exception is not a function type")]
+pub struct UnexpectedCatchArg {
+    pub module_id: crate::ModuleId,
+    pub span: crate::Span,
+}
+
+impl crate::Diag for UnexpectedCatchArg {
+    fn locate(&self) -> (crate::ModuleId, crate::Span) {
+        (self.module_id.clone(), self.span)
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum TypeCheckError {
     #[error("module id missing during type checking")]
     ModuleIdMissing,
@@ -1039,6 +1066,83 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                 }
                 let ty = self
                     .apply_expected_type(env, expr.span(), Type::Never, expected_type)?
+                    .unpack(&mut diags);
+                Ok(Diagnosed::new(ty, diags))
+            }
+            ast::Expr::Try(try_expr) => {
+                let mut diags = DiagList::new();
+                let try_ty = self
+                    .check_expr(env, try_expr.expr.as_ref(), expected_type)?
+                    .unpack(&mut diags)
+                    .unfold();
+
+                for catch in &try_expr.catches {
+                    let catch_var_ty = self
+                        .check_expr(
+                            env,
+                            &crate::Loc::new(
+                                ast::Expr::Var(catch.exception_var.clone()),
+                                catch.exception_var.span(),
+                            ),
+                            None,
+                        )?
+                        .unpack(&mut diags)
+                        .unfold();
+
+                    match &catch_var_ty {
+                        Type::Exception(_) => {
+                            if catch.catch_arg.is_some() {
+                                diags.push(UnexpectedCatchArg {
+                                    module_id: env.module_id()?,
+                                    span: catch.catch_arg.as_ref().unwrap().span(),
+                                });
+                            }
+                            self.check_expr(env, &catch.body, Some(&try_ty))?
+                                .unpack(&mut diags);
+                        }
+                        Type::Fn(fn_ty) => {
+                            let ret_ty = fn_ty.ret.as_ref().clone().unfold();
+                            if !matches!(ret_ty, Type::Exception(_)) {
+                                diags.push(InvalidCatchTarget {
+                                    module_id: env.module_id()?,
+                                    ty: catch_var_ty.clone(),
+                                    span: catch.exception_var.span(),
+                                });
+                            }
+                            if let Some(catch_arg) = &catch.catch_arg {
+                                let param_ty = fn_ty
+                                    .params
+                                    .first()
+                                    .cloned()
+                                    .unwrap_or(Type::Never);
+                                let inner_env =
+                                    env.with_local(catch_arg.name.as_str(), param_ty);
+                                self.check_expr(&inner_env, &catch.body, Some(&try_ty))?
+                                    .unpack(&mut diags);
+                            } else {
+                                self.check_expr(env, &catch.body, Some(&try_ty))?
+                                    .unpack(&mut diags);
+                            }
+                        }
+                        Type::Never => {
+                            // If the type is Never (e.g., undefined variable), skip further checks
+                            self.check_expr(env, &catch.body, Some(&try_ty))?
+                                .unpack(&mut diags);
+                        }
+                        _ => {
+                            diags.push(InvalidCatchTarget {
+                                module_id: env.module_id()?,
+                                ty: catch_var_ty,
+                                span: catch.exception_var.span(),
+                            });
+                            self.check_expr(env, &catch.body, Some(&try_ty))?
+                                .unpack(&mut diags);
+                        }
+                    }
+                }
+
+                let ty = self
+                    .apply_expected_type(env, expr.span(), try_ty, expected_type)?
                     .unpack(&mut diags);
                 Ok(Diagnosed::new(ty, diags))
             }

--- a/crates/sclc/src/eval.rs
+++ b/crates/sclc/src/eval.rs
@@ -753,6 +753,86 @@ impl Eval {
                     other => Err(EvalError::UnexpectedValue(other)),
                 }
             }
+            ast::Expr::Try(try_expr) => {
+                match self.eval_expr(env, try_expr.expr.as_ref()) {
+                    Ok(value) => Ok(value),
+                    Err(EvalError::Exception(raised)) => {
+                        for catch in &try_expr.catches {
+                            let catch_target = self.eval_expr(env, &crate::Loc::new(
+                                ast::Expr::Var(catch.exception_var.clone()),
+                                catch.exception_var.span(),
+                            ))?;
+
+                            match catch_target.value {
+                                Value::Exception(exc) => {
+                                    if exc.exception_id == raised.exception_id {
+                                        return self.eval_expr(env, &catch.body);
+                                    }
+                                }
+                                Value::ExternFn(func) => {
+                                    let arg_value = TrackedValue::new(raised.payload.clone());
+                                    let call_result = func.call(vec![arg_value], &self.ctx)?;
+                                    match call_result.value {
+                                        Value::Exception(exc) => {
+                                            if exc.exception_id == raised.exception_id {
+                                                if let Some(catch_arg) = &catch.catch_arg {
+                                                    let inner_env = env.with_local(
+                                                        catch_arg.name.as_str(),
+                                                        TrackedValue::new(raised.payload.clone()),
+                                                    );
+                                                    return self.eval_expr(&inner_env, &catch.body);
+                                                } else {
+                                                    return self.eval_expr(env, &catch.body);
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            return Err(EvalError::UnexpectedValue(call_result.value));
+                                        }
+                                    }
+                                }
+                                Value::Fn(function) => {
+                                    let arg_value = TrackedValue::new(raised.payload.clone());
+                                    let frame = StackFrame {
+                                        module_id: env.module_id.cloned().unwrap_or_default(),
+                                        span: catch.exception_var.span(),
+                                        parent: env.stack,
+                                    };
+                                    let call_env = function.env.as_eval_env(
+                                        &[arg_value],
+                                        Some(&frame),
+                                    );
+                                    let call_result = self.eval_expr(&call_env, &function.body)?;
+                                    match call_result.value {
+                                        Value::Exception(exc) => {
+                                            if exc.exception_id == raised.exception_id {
+                                                if let Some(catch_arg) = &catch.catch_arg {
+                                                    let inner_env = env.with_local(
+                                                        catch_arg.name.as_str(),
+                                                        TrackedValue::new(raised.payload.clone()),
+                                                    );
+                                                    return self.eval_expr(&inner_env, &catch.body);
+                                                } else {
+                                                    return self.eval_expr(env, &catch.body);
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            return Err(EvalError::UnexpectedValue(call_result.value));
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    return Err(EvalError::UnexpectedValue(catch_target.value));
+                                }
+                            }
+                        }
+                        // No catch matched, re-raise
+                        Err(EvalError::Exception(raised))
+                    }
+                    Err(other) => Err(other),
+                }
+            }
         }
     }
 

--- a/crates/sclc/src/lexer.rs
+++ b/crates/sclc/src/lexer.rs
@@ -43,6 +43,8 @@ pub enum Token<'a> {
     FalseKeyword,
     ExceptionKeyword,
     RaiseKeyword,
+    TryKeyword,
+    CatchKeyword,
     QuestionMark,
     Int(&'a str),
     Float(&'a str),
@@ -337,6 +339,10 @@ impl<'a> Iterator for Lexer<'a> {
                 Token::ExceptionKeyword
             } else if symbol == "raise" {
                 Token::RaiseKeyword
+            } else if symbol == "try" {
+                Token::TryKeyword
+            } else if symbol == "catch" {
+                Token::CatchKeyword
             } else {
                 Token::Symbol(symbol)
             }

--- a/crates/sclc/src/parser.rs
+++ b/crates/sclc/src/parser.rs
@@ -4,11 +4,12 @@ use peg::{Parse, ParseElem, RuleResult};
 use thiserror::Error;
 
 use crate::{
-    BinaryExpr, BinaryOp, Bool, CallExpr, Diag, DiagList, Diagnosed, DictEntry, DictExpr,
-    DictTypeExpr, ExceptionExpr, Expr, FileMod, Float, FnExpr, FnParam, IfExpr, ImportStmt, Int,
-    InterpExpr, LetBind, LetExpr, Lexer, ListExpr, ListForItem, ListIfItem, ListItem, Loc, ModStmt,
-    ModuleId, Position, PropertyAccessExpr, RaiseExpr, RecordExpr, RecordField, RecordTypeExpr,
-    RecordTypeFieldExpr, ReplLine, Span, StrExpr, Token, TypeExpr, UnaryExpr, UnaryOp, Var,
+    BinaryExpr, BinaryOp, Bool, CallExpr, CatchClause, Diag, DiagList, Diagnosed, DictEntry,
+    DictExpr, DictTypeExpr, ExceptionExpr, Expr, FileMod, Float, FnExpr, FnParam, IfExpr,
+    ImportStmt, Int, InterpExpr, LetBind, LetExpr, Lexer, ListExpr, ListForItem, ListIfItem,
+    ListItem, Loc, ModStmt, ModuleId, Position, PropertyAccessExpr, RaiseExpr, RecordExpr,
+    RecordField, RecordTypeExpr, RecordTypeFieldExpr, ReplLine, Span, StrExpr, Token, TryExpr,
+    TypeExpr, UnaryExpr, UnaryOp, Var,
 };
 
 #[derive(Error, Debug)]
@@ -145,6 +146,7 @@ peg::parser! {
             / fn_expr:fn_expr() { fn_expr }
             / extern_expr:extern_expr() { extern_expr }
             / raise_expr:raise_expr() { raise_expr }
+            / try_expr:try_expr() { try_expr }
             / logical_or_expr()
 
         rule logical_or_expr() -> Loc<Expr>
@@ -389,6 +391,34 @@ peg::parser! {
                     Expr::Raise(RaiseExpr { expr: Box::new(expr) }),
                     Span::new(raise_kw_span.start(), end),
                 )
+            }
+
+        rule try_expr() -> Loc<Expr>
+            = try_kw_span:try_keyword() expr:expr() catches:catch_clause()+ {
+                let end = catches.last().map(|c| c.body.span().end()).unwrap_or_else(|| expr.span().end());
+                Loc::new(
+                    Expr::Try(TryExpr {
+                        expr: Box::new(expr),
+                        catches,
+                    }),
+                    Span::new(try_kw_span.start(), end),
+                )
+            }
+
+        rule catch_clause() -> CatchClause
+            = catch_keyword() exception_var:var() open_paren() catch_arg:var() close_paren() colon() body:expr() {
+                CatchClause {
+                    exception_var,
+                    catch_arg: Some(catch_arg),
+                    body,
+                }
+            }
+            / catch_keyword() exception_var:var() colon() body:expr() {
+                CatchClause {
+                    exception_var,
+                    catch_arg: None,
+                    body,
+                }
             }
 
         rule exception_expr() -> Loc<Expr>
@@ -670,6 +700,18 @@ peg::parser! {
                 [token if matches!(token.as_ref(), Token::RaiseKeyword)] { token.span() }
             }
             / expected!("raise keyword")
+
+        rule try_keyword() -> Span
+            = quiet!{
+                [token if matches!(token.as_ref(), Token::TryKeyword)] { token.span() }
+            }
+            / expected!("try keyword")
+
+        rule catch_keyword() -> Span
+            = quiet!{
+                [token if matches!(token.as_ref(), Token::CatchKeyword)] { token.span() }
+            }
+            / expected!("catch keyword")
 
         rule equals() -> Span
             = quiet!{


### PR DESCRIPTION
## Summary
This PR implements try-catch exception handling for the language, allowing developers to catch and handle exceptions with optional exception filtering via function types.

## Key Changes

- **Lexer**: Added `TryKeyword` and `CatchKeyword` tokens to recognize `try` and `catch` keywords
- **AST**: 
  - Added `TryExpr` struct to represent try-catch expressions with a body expression and list of catch clauses
  - Added `CatchClause` struct to represent individual catch handlers with an exception variable, optional catch argument, and handler body
  - Updated `Expr` enum to include the `Try` variant
  - Updated `free_vars()` to properly track variable scoping in try-catch blocks
- **Parser**: 
  - Added `try_expr()` rule to parse try-catch syntax
  - Added `catch_clause()` rule to parse catch handlers with optional argument syntax: `catch exception_var: body` or `catch exception_var(arg): body`
  - Integrated try-catch parsing into the expression hierarchy
- **Type Checker**:
  - Added `InvalidCatchTarget` diagnostic for catch variables that are neither exceptions nor functions returning exceptions
  - Added `UnexpectedCatchArg` diagnostic for catch arguments provided when the exception is not a function type
  - Implemented type checking for try-catch expressions that validates:
    - Exception variables are either `Exception` types or functions returning exceptions
    - Catch arguments are only provided for function-type exceptions
    - Handler bodies have the expected return type
- **Evaluator**: 
  - Implemented try-catch evaluation that catches exceptions and matches them against catch clauses
  - Supports both direct exception matching and function-based exception filtering
  - Properly handles catch argument binding when provided
  - Re-raises exceptions if no catch clause matches

## Implementation Details

The try-catch implementation supports two patterns:
1. Direct exception matching: `catch MyException: handler_expr`
2. Function-based filtering: `catch filter_fn(payload): handler_expr` where `filter_fn` is a function that takes the exception payload and returns an exception

The evaluator iterates through catch clauses in order and executes the first matching handler, supporting both `ExternFn` and user-defined `Fn` types as exception filters.

https://claude.ai/code/session_01Lx6qDXu68GGK9dCXgT33om