### PR TITLE
feat: implement pod allow lists for egress control (phase 3 of #35)

### DIFF
--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -83,6 +83,8 @@ struct ContainerPluginInner {
     ldb_publisher: ldb::Publisher,
     /// Allocates per-node subnets from the cluster CIDR.
     subnet_allocator: RwLock<subnet_allocator::SubnetAllocator>,
+    /// The cluster-wide CIDR for pod networking, sent to nodes during registration.
+    cluster_cidr: String,
 }
 
 /// The container plugin manages connections to worker nodes.
@@ -101,6 +103,7 @@ impl ContainerPlugin {
         registry_url: String,
         ldb_publisher: ldb::Publisher,
         subnet_allocator: subnet_allocator::SubnetAllocator,
+        cluster_cidr: String,
     ) -> Self {
         Self {
             inner: Arc::new(ContainerPluginInner {
@@ -110,6 +113,7 @@ impl ContainerPlugin {
                 registry_url,
                 ldb_publisher,
                 subnet_allocator: RwLock::new(subnet_allocator),
+                cluster_cidr,
             }),
         }
     }
@@ -347,6 +351,7 @@ impl ContainerPlugin {
     /// - `name`: Pod name (required)
     /// - `uid`: Pod UID (required)
     /// - `node`: Target node name (optional, auto-scheduled if not specified)
+    /// - `allow`: List of port resources this pod can reach (optional)
     ///
     /// Outputs:
     /// - `podId`: The CRI pod sandbox ID
@@ -369,6 +374,9 @@ impl ContainerPlugin {
             .map_err(|e| PluginError::InvalidInput(format!("uid: {e}")))?
             .to_string();
 
+        // Extract the allow list (list of port resource records)
+        let allowed_destinations = extract_allowed_destinations(inputs.get("allow"))?;
+
         // Determine target node: use specified node or auto-schedule
         let node_name = match inputs.get("node") {
             Value::Str(n) => n.clone(),
@@ -387,6 +395,7 @@ impl ContainerPlugin {
             pod_name = %name,
             environment_qid = %environment_qid,
             node = %node_name,
+            num_allowed = %allowed_destinations.len(),
             "creating pod sandbox"
         );
 
@@ -398,6 +407,7 @@ impl ContainerPlugin {
                     environment_qid: environment_qid.to_string(),
                     name: name.clone(),
                     uid,
+                    allowed_destinations,
                 }),
             })
             .await
@@ -433,8 +443,8 @@ impl ContainerPlugin {
     /// Update a pod sandbox.
     ///
     /// Pods are immutable in CRI, so updates that change the pod configuration
-    /// would require destroying and recreating. For now, we only update outputs
-    /// if the node assignment changes.
+    /// would require destroying and recreating. This includes changes to the
+    /// name, uid, or allow list (since egress rules are applied at pod creation).
     async fn update_pod(
         &self,
         environment_qid: &str,
@@ -444,19 +454,27 @@ impl ContainerPlugin {
         inputs: sclc::Record,
     ) -> anyhow::Result<sclc::Resource> {
         // Check if inputs that affect the pod have changed
-        // If name/uid changed, we need to recreate
+        // If name, uid, or allow list changed, we need to recreate
         let prev_name = prev_inputs.get("name").assert_str_ref().ok();
         let prev_uid = prev_inputs.get("uid").assert_str_ref().ok();
 
         let name = inputs.get("name").assert_str_ref().ok();
         let uid = inputs.get("uid").assert_str_ref().ok();
 
-        if prev_name != name || prev_uid != uid {
-            // Pod identity changed - delete old and create new
+        // Check if the allow list has changed
+        let allow_changed = {
+            let prev_allow = serde_json::to_string(prev_inputs.get("allow")).unwrap_or_default();
+            let curr_allow = serde_json::to_string(inputs.get("allow")).unwrap_or_default();
+            prev_allow != curr_allow
+        };
+
+        if prev_name != name || prev_uid != uid || allow_changed {
+            // Pod identity or network config changed - delete old and create new
             warn!(
                 resource_type = %id.ty,
                 resource_id = %id.id,
-                "pod identity changed, recreating"
+                allow_changed = %allow_changed,
+                "pod config changed, recreating"
             );
             self.delete_pod(id.clone(), prev_inputs, prev_outputs)
                 .await?;
@@ -614,6 +632,7 @@ impl ContainerPlugin {
                     environment_qid: environment_qid.to_string(),
                     name: pod_name,
                     uid: pod_uid,
+                    allowed_destinations: vec![],
                 }),
             })
             .await
@@ -908,6 +927,53 @@ fn extract_env_vars(value: &Value) -> Result<Vec<scop::KeyValue>, PluginError> {
     }
 }
 
+/// Extract allowed destinations from the `allow` input value.
+///
+/// The allow list is a `Value::List` of records, each with `address`, `port`,
+/// and `protocol` fields (matching Pod.Port output shape). Returns an empty
+/// list if the value is Nil (allow not provided).
+fn extract_allowed_destinations(
+    value: &Value,
+) -> Result<Vec<scop::AllowedDestination>, PluginError> {
+    match value {
+        Value::Nil => Ok(vec![]),
+        Value::List(list) => {
+            let mut destinations = Vec::with_capacity(list.len());
+            for (i, item) in list.iter().enumerate() {
+                let record = item.assert_record_ref().map_err(|e| {
+                    PluginError::InvalidInput(format!("allow[{i}]: expected record: {e}"))
+                })?;
+                let address = record
+                    .get("address")
+                    .assert_str_ref()
+                    .map_err(|e| {
+                        PluginError::InvalidInput(format!("allow[{i}].address: {e}"))
+                    })?
+                    .to_string();
+                let port = *record.get("port").assert_int_ref().map_err(|e| {
+                    PluginError::InvalidInput(format!("allow[{i}].port: {e}"))
+                })? as i32;
+                let protocol = record
+                    .get("protocol")
+                    .assert_str_ref()
+                    .map_err(|e| {
+                        PluginError::InvalidInput(format!("allow[{i}].protocol: {e}"))
+                    })?
+                    .to_string();
+                destinations.push(scop::AllowedDestination {
+                    address,
+                    port,
+                    protocol,
+                });
+            }
+            Ok(destinations)
+        }
+        other => Err(PluginError::InvalidInput(format!(
+            "allow: expected List? but got {other}"
+        ))),
+    }
+}
+
 /// Check if any inputs have changed between two records.
 fn inputs_changed(prev: &sclc::Record, curr: &sclc::Record) -> bool {
     // Simple comparison: serialize and compare
@@ -1049,6 +1115,7 @@ impl scop::Orchestrator for ContainerPlugin {
                         success: false,
                         error: e,
                         pod_cidr: String::new(),
+                        cluster_cidr: String::new(),
                     });
                 }
             }
@@ -1081,6 +1148,7 @@ impl scop::Orchestrator for ContainerPlugin {
                     success: true,
                     error: String::new(),
                     pod_cidr,
+                    cluster_cidr: self.inner.cluster_cidr.clone(),
                 })
             }
             Err(e) => {
@@ -1094,6 +1162,7 @@ impl scop::Orchestrator for ContainerPlugin {
                     success: false,
                     error,
                     pod_cidr: String::new(),
+                    cluster_cidr: String::new(),
                 })
             }
         }
@@ -1437,6 +1506,7 @@ async fn main() -> Result<()> {
         args.registry_url.clone(),
         ldb_publisher,
         subnet_allocator,
+        cluster_cidr.to_string(),
     );
 
     // Clone for the RTP server (since ContainerPlugin is Clone via Arc)

--- a/crates/sclc/src/std/Container.scl
+++ b/crates/sclc/src/std/Container.scl
@@ -40,10 +40,16 @@ export let Image = extern "Std/Container.Image": fn({
 // Pod resource - creates a pod sandbox on a worker node
 //
 // Each pod runs in its own network namespace with a unique IP address.
-// By default, all ingress traffic is denied. Use Pod.Port and allow lists
-// (in a future phase) to grant network access between pods.
+// By default, all ingress traffic is denied and egress to other pods is
+// blocked. Use Pod.Port to open ingress ports and the `allow` list to
+// grant egress access to specific port resources.
 export let Pod = extern "Std/Container.Pod": fn({
     name: Str,
+    // List of port resources this pod is allowed to reach.
+    // Each entry is a Pod.Port output: { address: Str, port: Int, protocol: Str }.
+    // Pods can always reach the internet; this controls access to cluster-internal
+    // destinations only.
+    allow: [{ address: Str, port: Int, protocol: Str }]?,
 }) {
     podId: Str,
     node: Str,

--- a/crates/sclc/src/std/container.rs
+++ b/crates/sclc/src/std/container.rs
@@ -94,8 +94,8 @@ fn image_extern_fn(
 
 /// Extern function for creating Pod resources.
 ///
-/// Input: `{ name: Str }`
-/// Output: `{ podId: Str, node: Str, name: Str, namespace: Str, Container: fn(...) }`
+/// Input: `{ name: Str, allow: [{ address: Str, port: Int, protocol: Str }]? }`
+/// Output: `{ podId: Str, node: Str, name: Str, namespace: Str, address: Str, Container: fn(...), Port: fn(...) }`
 fn pod_extern_fn(
     args: Vec<TrackedValue>,
     eval_ctx: &EvalCtx,
@@ -116,6 +116,9 @@ fn pod_extern_fn(
         id: name.clone(),
     };
 
+    // Extract the optional allow list (list of port resource records)
+    let allow_value = config.get("allow").clone();
+
     // Build inputs for the RTP plugin
     // The plugin expects: name, namespace, uid, node (optional), labels, annotations
     // For the minimal interface, we only pass name and generate uid/namespace
@@ -131,6 +134,8 @@ fn pod_extern_fn(
         String::from("uid"),
         Value::Str(format!("{}-{}", eval_ctx.namespace(), name)),
     );
+    // Pass the allow list through to the plugin (Value::Nil if not provided)
+    inputs.insert(String::from("allow"), allow_value);
 
     let Some(outputs) = eval_ctx.resource(
         POD_RESOURCE_TYPE,

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -167,6 +167,8 @@ struct CriConduit {
     ipam: Arc<Mutex<net::Ipam>>,
     /// The node's pod subnet (for network setup).
     pod_cidr: Ipv4Net,
+    /// The cluster-wide CIDR (for egress allow-list rules).
+    cluster_cidr: Option<String>,
     /// DNS servers to configure in pods.
     dns_servers: Vec<String>,
 }
@@ -177,6 +179,7 @@ impl CriConduit {
         ldb_publisher: Option<ldb::Publisher>,
         ipam: net::Ipam,
         pod_cidr: Ipv4Net,
+        cluster_cidr: Option<String>,
         dns_servers: Vec<String>,
     ) -> Self {
         Self {
@@ -187,6 +190,7 @@ impl CriConduit {
             containers: Arc::new(Mutex::new(HashMap::new())),
             ipam: Arc::new(Mutex::new(ipam)),
             pod_cidr,
+            cluster_cidr,
             dns_servers,
         }
     }
@@ -352,8 +356,15 @@ impl scop::Conduit for CriConduit {
             }
         };
 
-        // Step 4: Set up pod networking (veth pair, bridge, IP, firewall)
-        if let Err(e) = net::setup_pod_network(&pod_id, ip, &self.pod_cidr, &netns_path) {
+        // Step 4: Set up pod networking (veth pair, bridge, IP, firewall, egress rules)
+        if let Err(e) = net::setup_pod_network(
+            &pod_id,
+            ip,
+            &self.pod_cidr,
+            &netns_path,
+            &config.allowed_destinations,
+            self.cluster_cidr.as_deref(),
+        ) {
             let mut ipam = self.ipam.lock().await;
             ipam.release(&pod_id);
             let _ = cri.stop_pod_sandbox(&pod_id).await;
@@ -611,6 +622,15 @@ async fn main() -> Result<()> {
                 .expect("orchestrator returned invalid pod_cidr");
             tracing::info!("Registered with orchestrator, assigned pod CIDR: {}", pod_cidr);
 
+            // Parse the cluster CIDR for egress allow-list enforcement
+            let cluster_cidr = if register_response.cluster_cidr.is_empty() {
+                tracing::warn!("orchestrator did not provide cluster_cidr, egress allow-list enforcement disabled");
+                None
+            } else {
+                tracing::info!("cluster CIDR for egress rules: {}", register_response.cluster_cidr);
+                Some(register_response.cluster_cidr)
+            };
+
             // Set up the pod bridge network with the assigned CIDR
             net::setup_bridge(&pod_cidr)?;
 
@@ -619,7 +639,7 @@ async fn main() -> Result<()> {
             tracing::info!("DNS servers for pods: {:?}", dns_servers);
 
             // Create the conduit with networking support
-            let conduit = CriConduit::new(cri, ldb_publisher, ipam, pod_cidr, dns_servers);
+            let conduit = CriConduit::new(cri, ldb_publisher, ipam, pod_cidr, cluster_cidr, dns_servers);
 
             // Spawn heartbeat task
             let node_name_heartbeat = node_name.clone();

--- a/crates/scoc/src/net.rs
+++ b/crates/scoc/src/net.rs
@@ -232,12 +232,16 @@ fn bridge_exists() -> Result<bool> {
 ///
 /// Creates a veth pair, attaches the host end to the bridge, moves the pod end
 /// into the pod's network namespace, assigns an IP, configures routes, and
-/// installs deny-all ingress firewall rules.
+/// installs deny-all ingress firewall rules. If an allow list and cluster CIDR
+/// are provided, egress rules are also configured to restrict cluster-internal
+/// traffic to only the allowed destinations.
 pub fn setup_pod_network(
     pod_id: &str,
     ip: Ipv4Addr,
     subnet: &Ipv4Net,
     netns_path: &str,
+    allowed_destinations: &[scop::AllowedDestination],
+    cluster_cidr: Option<&str>,
 ) -> Result<()> {
     let gateway = Ipv4Addr::from(u32::from(subnet.network()) + 1);
     let ip_cidr = format!("{}/{}", ip, subnet.prefix_len());
@@ -293,6 +297,12 @@ pub fn setup_pod_network(
     // Apply deny-all ingress firewall
     setup_pod_firewall(netns_path)
         .with_context(|| format!("failed to set up firewall for pod {pod_id}"))?;
+
+    // Apply egress allow-list rules (restricts cluster-internal traffic)
+    if let Some(cidr) = cluster_cidr {
+        setup_pod_egress_rules(netns_path, allowed_destinations, cidr)
+            .with_context(|| format!("failed to set up egress rules for pod {pod_id}"))?;
+    }
 
     info!(pod_id = %pod_id, "pod network setup complete");
     Ok(())
@@ -372,6 +382,91 @@ fn setup_pod_firewall(netns_path: &str) -> Result<()> {
         "iptables",
         &["-A", "INPUT", "-i", "lo", "-j", "ACCEPT"],
     )?;
+
+    Ok(())
+}
+
+/// Configure egress rules for a pod based on its allow list.
+///
+/// By default pods can reach the internet but not other cluster-internal
+/// destinations. The allow list grants access to specific address:port
+/// pairs within the cluster.
+///
+/// Rules (appended to the OUTPUT chain, which defaults to ACCEPT):
+/// 1. Allow loopback output
+/// 2. Allow established/related outbound connections
+/// 3. For each allowed destination: allow traffic to that address:port/protocol
+/// 4. Drop all other traffic to the cluster CIDR (blocks cluster-internal)
+/// 5. Everything else (internet) falls through to the ACCEPT policy
+fn setup_pod_egress_rules(
+    netns_path: &str,
+    allowed: &[scop::AllowedDestination],
+    cluster_cidr: &str,
+) -> Result<()> {
+    debug!(
+        netns = %netns_path,
+        num_allowed = %allowed.len(),
+        cluster_cidr = %cluster_cidr,
+        "configuring pod egress rules"
+    );
+
+    // Allow loopback output (always needed)
+    nsenter_run(
+        netns_path,
+        "iptables",
+        &["-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"],
+    )?;
+
+    // Allow established/related outbound (for return traffic on accepted connections)
+    nsenter_run(
+        netns_path,
+        "iptables",
+        &[
+            "-A", "OUTPUT",
+            "-m", "conntrack",
+            "--ctstate", "ESTABLISHED,RELATED",
+            "-j", "ACCEPT",
+        ],
+    )?;
+
+    // Allow traffic to each destination in the allow list
+    for dest in allowed {
+        let port_str = dest.port.to_string();
+        nsenter_run(
+            netns_path,
+            "iptables",
+            &[
+                "-A", "OUTPUT",
+                "-d", &dest.address,
+                "-p", &dest.protocol,
+                "--dport", &port_str,
+                "-j", "ACCEPT",
+            ],
+        )?;
+
+        debug!(
+            netns = %netns_path,
+            dest_address = %dest.address,
+            dest_port = %dest.port,
+            dest_protocol = %dest.protocol,
+            "added egress allow rule"
+        );
+    }
+
+    // Drop all other traffic to cluster-internal IPs
+    nsenter_run(
+        netns_path,
+        "iptables",
+        &["-A", "OUTPUT", "-d", cluster_cidr, "-j", "DROP"],
+    )?;
+
+    // Everything else (internet) falls through to OUTPUT ACCEPT policy
+
+    info!(
+        netns = %netns_path,
+        num_allowed = %allowed.len(),
+        "pod egress rules configured"
+    );
 
     Ok(())
 }

--- a/crates/scop/proto/scop.proto
+++ b/crates/scop/proto/scop.proto
@@ -67,6 +67,10 @@ message RegisterNodeResponse {
   // Pod CIDR assigned to this node (e.g., "10.42.1.0/24").
   // The node uses this subnet for pod IP allocation.
   string pod_cidr = 3;
+  // The cluster-wide CIDR for pod networking (e.g., "10.42.0.0/16").
+  // Used by the node to distinguish cluster-internal traffic from internet
+  // traffic when enforcing egress allow lists.
+  string cluster_cidr = 4;
 }
 
 // Heartbeat request to keep registration alive.
@@ -164,6 +168,20 @@ message PodConfig {
   string name = 2;
   // Pod UID.
   string uid = 3;
+  // Network destinations this pod is allowed to reach (egress allow list).
+  // Each entry represents a port resource that this pod can connect to.
+  repeated AllowedDestination allowed_destinations = 4;
+}
+
+// A network destination that a pod is allowed to reach.
+// Corresponds to a Pod.Port resource output.
+message AllowedDestination {
+  // IP address of the destination pod.
+  string address = 1;
+  // Port number.
+  int32 port = 2;
+  // Protocol: "tcp" or "udp".
+  string protocol = 3;
 }
 
 // ============================================================================

--- a/crates/scop/src/lib.rs
+++ b/crates/scop/src/lib.rs
@@ -67,12 +67,12 @@ pub mod proto {
 
 // Re-export commonly used types
 pub use proto::{
-    ContainerConfig, CreateContainerRequest, CreateContainerResponse, CreatePodRequest,
-    CreatePodResponse, HeartbeatRequest, HeartbeatResponse, KeyValue, NodeCapacity, NodeUsage,
-    PodConfig, RegisterNodeRequest, RegisterNodeResponse, RemoveContainerRequest,
-    RemoveContainerResponse, RemovePodRequest, RemovePodResponse, StartContainerRequest,
-    StartContainerResponse, StopContainerRequest, StopContainerResponse, UnregisterNodeRequest,
-    UnregisterNodeResponse,
+    AllowedDestination, ContainerConfig, CreateContainerRequest, CreateContainerResponse,
+    CreatePodRequest, CreatePodResponse, HeartbeatRequest, HeartbeatResponse, KeyValue,
+    NodeCapacity, NodeUsage, PodConfig, RegisterNodeRequest, RegisterNodeResponse,
+    RemoveContainerRequest, RemoveContainerResponse, RemovePodRequest, RemovePodResponse,
+    StartContainerRequest, StartContainerResponse, StopContainerRequest, StopContainerResponse,
+    UnregisterNodeRequest, UnregisterNodeResponse,
 };
 
 // Re-export the generated clients

--- a/docs/scl/stdlib.md
+++ b/docs/scl/stdlib.md
@@ -45,11 +45,19 @@ Create a pod sandbox on a worker node:
 let pod = Container.Pod({ name: "my-pod" })
 ```
 
+To allow a pod to reach another pod's port, pass port resources in the `allow` list:
+
+```scl
+let dbPort = dbPod.Port({ port: 5432, protocol: "tcp" })
+let apiPod = Container.Pod({ name: "api", allow: [dbPort] })
+```
+
 **Inputs:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | `Str` | Pod name |
+| `allow` | `[{ address: Str, port: Int, protocol: Str }]?` | Port resources this pod can reach (optional) |
 
 **Outputs:**
 
@@ -59,9 +67,38 @@ let pod = Container.Pod({ name: "my-pod" })
 | `node` | `Str` | Worker node hosting this pod |
 | `name` | `Str` | Pod name |
 | `namespace` | `Str` | Namespace (deployment ID) |
+| `address` | `Str` | Pod IP address |
 | `Container` | `fn({...}) {...}` | Function to create containers in this pod |
+| `Port` | `fn({...}) {...}` | Function to expose ports on this pod |
 
-A pod is a group of containers that share resources. Use the `Container` method to add containers.
+A pod is a group of containers that share resources. Use the `Container` method to add containers and `Port` to expose network ports.
+
+By default, pods are network-isolated: all ingress is denied, and egress to other cluster pods is blocked. Pods can always reach the internet. To allow a pod to communicate with another pod, use `Pod.Port` to open an ingress port, then pass that port resource in the `allow` list of the pod that needs to connect.
+
+### Port
+
+Expose a port on a pod's firewall. Accessed via `pod.Port`:
+
+```scl
+let httpPort = pod.Port({ port: 8080, protocol: "tcp" })
+```
+
+**Inputs:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `port` | `Int` | Port number to open |
+| `protocol` | `Str` | Protocol: `"tcp"` (default) or `"udp"` |
+
+**Outputs:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | `Str` | The pod's IP address |
+| `port` | `Int` | The opened port number |
+| `protocol` | `Str` | The protocol |
+
+Port resources act as access tokens. Pass them to another pod's `allow` list to grant that pod egress access to this port.
 
 ### Container
 
@@ -101,13 +138,19 @@ let image = Container.Image({
     containerfile: "Containerfile",
 })
 
-// Create a pod
+// Create a pod with a container
 let pod = Container.Pod({ name: "hello-world" })
-
-// Run a container in the pod
 pod.Container({
     name: "app",
     image: image.fullname,
+})
+let httpPort = pod.Port({ port: 8080, protocol: "tcp" })
+
+// Another pod that can access the first pod's HTTP port
+let clientPod = Container.Pod({ name: "client", allow: [httpPort] })
+clientPod.Container({
+    name: "curl",
+    image: "curlimages/curl",
 })
 ```
 


### PR DESCRIPTION
Add the `allow` input to Pod resources, enabling explicit network access
control between pods. Pods can now specify a list of port resources they
are allowed to reach, implementing deny-by-default egress to cluster-
internal destinations while preserving internet access.

Changes across the full stack:

- SCOP proto: Add AllowedDestination message, extend PodConfig with
  allowed_destinations field, add cluster_cidr to RegisterNodeResponse
- SCOC net.rs: Add setup_pod_egress_rules() that configures iptables
  OUTPUT chain rules — allow loopback, allow established/related, allow
  each destination in the allow list, drop all other cluster-internal
- SCOC main.rs: Pass allowed_destinations and cluster_cidr through to
  setup_pod_network(), store cluster_cidr from registration response
- Container plugin: Extract allow list from Pod inputs, convert to
  AllowedDestination protos, send via CreatePodRequest. Detect allow
  list changes in update_pod and trigger recreation. Pass cluster_cidr
  in RegisterNodeResponse.
- SCL: Add optional `allow: [{ address, port, protocol }]?` to Pod
  type definition and pass through extern function to plugin inputs
- Docs: Document allow list, Port resource, and networking examples

https://claude.ai/code/session_01AbUskcR75e3KWWinBnTVVc