### PR TITLE
feat: add VXLAN overlay network and Pod.Port firewall enforcement

### DIFF
--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -783,14 +783,20 @@ impl ContainerPlugin {
         id: sclc::ResourceId,
         inputs: sclc::Record,
     ) -> anyhow::Result<sclc::Resource> {
-        let pod_name = inputs
-            .get("podName")
+        let pod_id = inputs
+            .get("podId")
             .assert_str_ref()
-            .map_err(|e| PluginError::InvalidInput(format!("podName: {e}")))?;
+            .map_err(|e| PluginError::InvalidInput(format!("podId: {e}")))?
+            .to_string();
         let pod_address = inputs
             .get("podAddress")
             .assert_str_ref()
             .map_err(|e| PluginError::InvalidInput(format!("podAddress: {e}")))?
+            .to_string();
+        let node_name = inputs
+            .get("node")
+            .assert_str_ref()
+            .map_err(|e| PluginError::InvalidInput(format!("node: {e}")))?
             .to_string();
         let port = inputs
             .get("port")
@@ -805,15 +811,26 @@ impl ContainerPlugin {
         info!(
             resource_type = %id.ty,
             resource_id = %id.id,
-            pod_name = %pod_name,
+            pod_id = %pod_id,
+            node = %node_name,
             port = %port,
             protocol = %protocol,
             "creating pod port"
         );
 
+        // Open the firewall port on the target node via SCOC
+        let mut conduit = self.get_conduit(&node_name).await?;
+        conduit
+            .open_port(scop::OpenPortRequest {
+                pod_id,
+                port: *port as i32,
+                protocol: protocol.clone(),
+            })
+            .await
+            .map_err(|e| PluginError::Connect(format!("open_port failed: {e}")))?;
+
         // Build outputs — the port resource records which address/port/protocol
-        // is now open. Actual firewall rule application is handled by SCOC when
-        // network namespaces are in place.
+        // is now open.
         let mut outputs = sclc::Record::default();
         outputs.insert(String::from("address"), Value::Str(pod_address));
         outputs.insert(String::from("port"), Value::Int(*port));
@@ -865,11 +882,50 @@ impl ContainerPlugin {
     async fn delete_port(
         &self,
         id: sclc::ResourceId,
-        _inputs: sclc::Record,
+        inputs: sclc::Record,
         _outputs: sclc::Record,
     ) -> anyhow::Result<()> {
-        // Firewall rule cleanup will be handled by SCOC in a future phase.
-        // For now, the port resource is purely declarative.
+        let pod_id = inputs.get("podId").assert_str_ref().ok().map(String::from);
+        let node_name = inputs.get("node").assert_str_ref().ok().map(String::from);
+        let port = inputs.get("port").assert_int_ref().ok().copied();
+        let protocol = inputs
+            .get("protocol")
+            .assert_str_ref()
+            .ok()
+            .map(String::from);
+
+        if let (Some(pod_id), Some(node_name), Some(port), Some(protocol)) =
+            (pod_id, node_name, port, protocol)
+        {
+            match self.get_conduit(&node_name).await {
+                Ok(mut conduit) => {
+                    if let Err(e) = conduit
+                        .close_port(scop::ClosePortRequest {
+                            pod_id: pod_id.clone(),
+                            port: port as i32,
+                            protocol,
+                        })
+                        .await
+                    {
+                        warn!(
+                            resource_id = %id.id,
+                            pod_id = %pod_id,
+                            error = %e,
+                            "failed to close port (pod may already be gone)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        resource_id = %id.id,
+                        node = %node_name,
+                        error = %e,
+                        "failed to connect to node for port close (node may be gone)"
+                    );
+                }
+            }
+        }
+
         info!(
             resource_type = %id.ty,
             resource_id = %id.id,
@@ -971,6 +1027,33 @@ fn extract_allowed_destinations(
         other => Err(PluginError::InvalidInput(format!(
             "allow: expected List? but got {other}"
         ))),
+    }
+}
+
+/// Extract the host IP from a conduit address like "http://192.168.1.10:50054".
+fn extract_overlay_endpoint(addr: &str) -> Option<String> {
+    let without_scheme = addr.split("://").nth(1).unwrap_or(addr);
+    let authority = without_scheme.split('/').next().unwrap_or(without_scheme);
+    if authority.starts_with('[') {
+        // IPv6
+        Some(
+            authority
+                .split(']')
+                .next()
+                .unwrap_or(authority)
+                .trim_start_matches('[')
+                .to_owned(),
+        )
+    } else {
+        let host = authority
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(authority);
+        if host.is_empty() {
+            None
+        } else {
+            Some(host.to_owned())
+        }
     }
 }
 
@@ -1128,6 +1211,16 @@ impl scop::Orchestrator for ContainerPlugin {
             max_pods: capacity.max_pods,
         };
 
+        // Extract overlay endpoint (host IP) from conduit address
+        let overlay_endpoint = extract_overlay_endpoint(&request.conduit_address)
+            .unwrap_or_default();
+
+        // List existing nodes before registering (for peer notification)
+        let existing_nodes = {
+            let mut registry = self.inner.node_registry.write().await;
+            registry.list().await.unwrap_or_default()
+        };
+
         let mut registry = self.inner.node_registry.write().await;
         match registry
             .register(
@@ -1135,6 +1228,8 @@ impl scop::Orchestrator for ContainerPlugin {
                 &request.conduit_address,
                 node_capacity,
                 request.labels,
+                &pod_cidr,
+                &overlay_endpoint,
             )
             .await
         {
@@ -1142,8 +1237,74 @@ impl scop::Orchestrator for ContainerPlugin {
                 info!(
                     node_name = %node.name,
                     pod_cidr = %pod_cidr,
+                    overlay_endpoint = %overlay_endpoint,
                     "node registered successfully"
                 );
+                // Drop registry lock before peer notification
+                drop(registry);
+
+                // Notify existing nodes about the new peer, and the new node
+                // about existing peers (overlay mesh setup)
+                if !overlay_endpoint.is_empty() {
+                    for existing in &existing_nodes {
+                        if existing.overlay_endpoint.is_empty() {
+                            continue;
+                        }
+
+                        // Tell existing node about new peer
+                        match scop::ConduitClient::connect(existing.address.clone()).await {
+                            Ok(mut client) => {
+                                if let Err(e) = client
+                                    .add_overlay_peer(scop::AddOverlayPeerRequest {
+                                        peer_host_ip: overlay_endpoint.clone(),
+                                    })
+                                    .await
+                                {
+                                    warn!(
+                                        node = %existing.name,
+                                        peer = %overlay_endpoint,
+                                        error = %e,
+                                        "failed to notify existing node about new peer"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    node = %existing.name,
+                                    error = %e,
+                                    "failed to connect to existing node for peer notification"
+                                );
+                            }
+                        }
+
+                        // Tell new node about existing peer
+                        match scop::ConduitClient::connect(request.conduit_address.clone()).await {
+                            Ok(mut client) => {
+                                if let Err(e) = client
+                                    .add_overlay_peer(scop::AddOverlayPeerRequest {
+                                        peer_host_ip: existing.overlay_endpoint.clone(),
+                                    })
+                                    .await
+                                {
+                                    warn!(
+                                        node = %request.node_name,
+                                        peer = %existing.overlay_endpoint,
+                                        error = %e,
+                                        "failed to notify new node about existing peer"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    node = %request.node_name,
+                                    error = %e,
+                                    "failed to connect to new node for peer notification"
+                                );
+                            }
+                        }
+                    }
+                }
+
                 Ok(scop::RegisterNodeResponse {
                     success: true,
                     error: String::new(),
@@ -1153,6 +1314,7 @@ impl scop::Orchestrator for ContainerPlugin {
             }
             Err(e) => {
                 // Release the subnet on registry failure
+                drop(registry);
                 let mut allocator = self.inner.subnet_allocator.write().await;
                 allocator.release(&request.node_name);
 
@@ -1198,6 +1360,17 @@ impl scop::Orchestrator for ContainerPlugin {
     ) -> Result<scop::UnregisterNodeResponse, scop::tonic::Status> {
         info!(node_name = %request.node_name, "unregistering node");
 
+        // Read departing node info before unregistering (for overlay endpoint)
+        let departing_endpoint = {
+            let mut registry = self.inner.node_registry.write().await;
+            registry
+                .get(&request.node_name)
+                .await
+                .ok()
+                .map(|n| n.overlay_endpoint.clone())
+                .unwrap_or_default()
+        };
+
         // Release the node's subnet allocation
         {
             let mut allocator = self.inner.subnet_allocator.write().await;
@@ -1208,6 +1381,43 @@ impl scop::Orchestrator for ContainerPlugin {
         match registry.unregister(&request.node_name).await {
             Ok(()) => {
                 info!(node_name = %request.node_name, "node unregistered successfully");
+
+                // Notify remaining nodes to remove the departing peer
+                if !departing_endpoint.is_empty() {
+                    let remaining_nodes = registry.list().await.unwrap_or_default();
+                    drop(registry);
+
+                    for node in &remaining_nodes {
+                        if node.overlay_endpoint.is_empty() {
+                            continue;
+                        }
+                        match scop::ConduitClient::connect(node.address.clone()).await {
+                            Ok(mut client) => {
+                                if let Err(e) = client
+                                    .remove_overlay_peer(scop::RemoveOverlayPeerRequest {
+                                        peer_host_ip: departing_endpoint.clone(),
+                                    })
+                                    .await
+                                {
+                                    warn!(
+                                        node = %node.name,
+                                        peer = %departing_endpoint,
+                                        error = %e,
+                                        "failed to notify node about peer removal"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    node = %node.name,
+                                    error = %e,
+                                    "failed to connect to node for peer removal"
+                                );
+                            }
+                        }
+                    }
+                }
+
                 Ok(scop::UnregisterNodeResponse { success: true })
             }
             Err(e) => {

--- a/crates/plugin_std_container/src/node_registry.rs
+++ b/crates/plugin_std_container/src/node_registry.rs
@@ -100,6 +100,12 @@ pub struct Node {
     pub labels: HashMap<String, String>,
     /// Last heartbeat timestamp (Unix epoch seconds).
     pub last_heartbeat: u64,
+    /// Pod CIDR assigned to this node (e.g., "10.42.1.0/24").
+    #[serde(default)]
+    pub pod_cidr: String,
+    /// Host IP for VXLAN overlay underlay traffic.
+    #[serde(default)]
+    pub overlay_endpoint: String,
 }
 
 #[derive(Clone)]
@@ -125,6 +131,8 @@ impl Client {
         address: impl Into<String>,
         capacity: NodeCapacity,
         labels: HashMap<String, String>,
+        pod_cidr: impl Into<String>,
+        overlay_endpoint: impl Into<String>,
     ) -> Result<Node, NodeError> {
         let name = name.into();
         let node = Node {
@@ -134,6 +142,8 @@ impl Client {
             usage: NodeUsage::default(),
             labels,
             last_heartbeat: now_secs(),
+            pod_cidr: pod_cidr.into(),
+            overlay_endpoint: overlay_endpoint.into(),
         };
 
         let data = serde_json::to_string(&node)?;

--- a/crates/sclc/src/std/container.rs
+++ b/crates/sclc/src/std/container.rs
@@ -181,19 +181,21 @@ fn pod_extern_fn(
 
     // Create the Container function that captures the pod's context
     let container_fn = create_container_fn(
-        pod_id,
+        pod_id.clone(),
         name.clone(),
         namespace.clone(),
-        node,
+        node.clone(),
         resource_id.clone(),
     );
     result.insert(String::from("Container"), Value::ExternFn(container_fn));
 
     // Create the Port function that captures the pod's context
     let port_fn = create_port_fn(
+        pod_id,
         name.clone(),
         namespace,
         address,
+        node,
         resource_id.clone(),
     );
     result.insert(String::from("Port"), Value::ExternFn(port_fn));
@@ -286,9 +288,11 @@ fn create_container_fn(
 /// The returned function captures the pod's context (name, namespace, address)
 /// and uses them when creating Pod.Port resources.
 fn create_port_fn(
+    pod_id: String,
     pod_name: String,
     pod_namespace: String,
     pod_address: String,
+    node: String,
     pod_resource_id: ResourceId,
 ) -> ExternFnValue {
     ExternFnValue::new(Box::new(move |args: Vec<TrackedValue>, eval_ctx: &EvalCtx| {
@@ -325,9 +329,11 @@ fn create_port_fn(
 
         // Build inputs for the RTP plugin
         let mut inputs = Record::default();
+        inputs.insert(String::from("podId"), Value::Str(pod_id.clone()));
         inputs.insert(String::from("podName"), Value::Str(pod_name.clone()));
         inputs.insert(String::from("podNamespace"), Value::Str(pod_namespace.clone()));
         inputs.insert(String::from("podAddress"), Value::Str(pod_address.clone()));
+        inputs.insert(String::from("node"), Value::Str(node.clone()));
         inputs.insert(String::from("port"), Value::Int(port));
         inputs.insert(String::from("protocol"), Value::Str(protocol.clone()));
         if let Some(ref name) = port_name {

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -148,6 +148,8 @@ struct PodInfo {
     name: String,
     /// Allocated IP address for the pod.
     ip: Ipv4Addr,
+    /// Path to the pod's network namespace (for port opening/closing).
+    netns_path: String,
 }
 
 /// Tracked container info for log streaming lifecycle.
@@ -385,6 +387,7 @@ impl scop::Conduit for CriConduit {
                     environment_qid: config.environment_qid,
                     name: config.name,
                     ip,
+                    netns_path,
                 },
             );
         }
@@ -515,6 +518,55 @@ impl scop::Conduit for CriConduit {
         }
 
         Ok(scop::RemoveContainerResponse {})
+    }
+
+    async fn add_overlay_peer(
+        &self,
+        request: scop::AddOverlayPeerRequest,
+    ) -> Result<scop::AddOverlayPeerResponse, scop::tonic::Status> {
+        net::add_overlay_peer(&request.peer_host_ip)
+            .map_err(|e| scop::tonic::Status::internal(format!("add overlay peer failed: {e:#}")))?;
+        Ok(scop::AddOverlayPeerResponse {})
+    }
+
+    async fn remove_overlay_peer(
+        &self,
+        request: scop::RemoveOverlayPeerRequest,
+    ) -> Result<scop::RemoveOverlayPeerResponse, scop::tonic::Status> {
+        net::remove_overlay_peer(&request.peer_host_ip)
+            .map_err(|e| scop::tonic::Status::internal(format!("remove overlay peer failed: {e:#}")))?;
+        Ok(scop::RemoveOverlayPeerResponse {})
+    }
+
+    async fn open_port(
+        &self,
+        request: scop::OpenPortRequest,
+    ) -> Result<scop::OpenPortResponse, scop::tonic::Status> {
+        let pods = self.pods.lock().await;
+        let pod = pods.get(&request.pod_id).ok_or_else(|| {
+            scop::tonic::Status::not_found(format!("pod not found: {}", request.pod_id))
+        })?;
+        net::open_port(&pod.netns_path, request.port, &request.protocol)
+            .map_err(|e| scop::tonic::Status::internal(format!("open port failed: {e:#}")))?;
+        Ok(scop::OpenPortResponse {})
+    }
+
+    async fn close_port(
+        &self,
+        request: scop::ClosePortRequest,
+    ) -> Result<scop::ClosePortResponse, scop::tonic::Status> {
+        let pods = self.pods.lock().await;
+        let Some(pod) = pods.get(&request.pod_id) else {
+            // Pod already gone — treat as success (idempotent)
+            tracing::warn!(
+                pod_id = %request.pod_id,
+                "close_port: pod not found, treating as success"
+            );
+            return Ok(scop::ClosePortResponse {});
+        };
+        net::close_port(&pod.netns_path, request.port, &request.protocol)
+            .map_err(|e| scop::tonic::Status::internal(format!("close port failed: {e:#}")))?;
+        Ok(scop::ClosePortResponse {})
     }
 }
 
@@ -675,6 +727,10 @@ async fn main() -> Result<()> {
             // Set up the pod bridge network with the assigned CIDR
             net::setup_bridge(&pod_cidr)?;
 
+            // Set up VXLAN overlay for cross-node pod communication
+            let local_ip = extract_host_from_address(&conduit_address);
+            net::setup_vxlan(&local_ip)?;
+
             let ipam = net::Ipam::new(pod_cidr);
             let dns_servers = net::host_nameservers();
             tracing::info!("DNS servers for pods: {:?}", dns_servers);
@@ -730,6 +786,9 @@ async fn main() -> Result<()> {
 
             // Cancel heartbeat task
             heartbeat_handle.abort();
+
+            // Tear down VXLAN overlay
+            let _ = net::teardown_vxlan();
 
             // Tear down pod bridge network
             if let Err(e) = net::teardown_bridge(&pod_cidr) {
@@ -832,4 +891,33 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Extract the host IP from a conduit address like "http://192.168.1.10:50054".
+fn extract_host_from_address(addr: &str) -> String {
+    // Strip scheme (e.g., "http://")
+    let without_scheme = addr
+        .split("://")
+        .nth(1)
+        .unwrap_or(addr);
+    // Strip path
+    let authority = without_scheme.split('/').next().unwrap_or(without_scheme);
+    // Strip port
+    // Handle IPv6 addresses in brackets: [::1]:port
+    if authority.starts_with('[') {
+        // IPv6: [host]:port
+        authority
+            .split(']')
+            .next()
+            .unwrap_or(authority)
+            .trim_start_matches('[')
+            .to_owned()
+    } else {
+        // IPv4 or hostname: host:port
+        authority
+            .rsplit_once(':')
+            .map(|(host, _)| host)
+            .unwrap_or(authority)
+            .to_owned()
+    }
 }

--- a/crates/scoc/src/net.rs
+++ b/crates/scoc/src/net.rs
@@ -17,6 +17,15 @@ use tracing::{debug, info, warn};
 /// Bridge interface name used for pod networking.
 const BRIDGE_NAME: &str = "skyr0";
 
+/// VXLAN interface name for overlay networking.
+const VXLAN_NAME: &str = "vxlan1";
+
+/// VXLAN Network Identifier.
+const VXLAN_VNI: u32 = 42;
+
+/// VXLAN UDP destination port.
+const VXLAN_PORT: u16 = 4789;
+
 // ============================================================================
 // IPAM — per-node IP address management
 // ============================================================================
@@ -469,6 +478,143 @@ fn setup_pod_egress_rules(
     );
 
     Ok(())
+}
+
+// ============================================================================
+// VXLAN overlay
+// ============================================================================
+
+/// Set up a VXLAN interface and attach it to the pod bridge.
+///
+/// This enables cross-node pod communication. The VXLAN uses the bridge's
+/// L2 learning for MAC-to-VTEP resolution after BUM traffic is flooded
+/// to all peers via FDB entries.
+pub fn setup_vxlan(local_ip: &str) -> Result<()> {
+    let vni = VXLAN_VNI.to_string();
+    let port = VXLAN_PORT.to_string();
+
+    info!(
+        vxlan = VXLAN_NAME,
+        local_ip = %local_ip,
+        vni = %vni,
+        "setting up VXLAN overlay"
+    );
+
+    run_cmd(
+        "ip",
+        &[
+            "link", "add", VXLAN_NAME,
+            "type", "vxlan",
+            "id", &vni,
+            "dstport", &port,
+            "local", local_ip,
+            "nolearning",
+        ],
+    )
+    .context("failed to create VXLAN interface")?;
+
+    run_cmd("ip", &["link", "set", VXLAN_NAME, "master", BRIDGE_NAME])
+        .context("failed to attach VXLAN to bridge")?;
+
+    run_cmd("ip", &["link", "set", VXLAN_NAME, "up"])
+        .context("failed to bring VXLAN interface up")?;
+
+    info!("VXLAN overlay setup complete");
+    Ok(())
+}
+
+/// Tear down the VXLAN interface.
+pub fn teardown_vxlan() -> Result<()> {
+    info!(vxlan = VXLAN_NAME, "tearing down VXLAN overlay");
+    let _ = run_cmd("ip", &["link", "del", VXLAN_NAME]);
+    Ok(())
+}
+
+/// Add a VXLAN overlay peer.
+///
+/// Adds an FDB entry that directs BUM (broadcast, unknown-unicast, multicast)
+/// traffic to the peer's underlay IP. This enables ARP resolution across nodes.
+pub fn add_overlay_peer(peer_ip: &str) -> Result<()> {
+    info!(peer_ip = %peer_ip, "adding overlay peer");
+    run_cmd(
+        "bridge",
+        &[
+            "fdb", "append",
+            "00:00:00:00:00:00",
+            "dev", VXLAN_NAME,
+            "dst", peer_ip,
+        ],
+    )
+    .with_context(|| format!("failed to add overlay peer {peer_ip}"))
+}
+
+/// Remove a VXLAN overlay peer.
+pub fn remove_overlay_peer(peer_ip: &str) -> Result<()> {
+    info!(peer_ip = %peer_ip, "removing overlay peer");
+    run_cmd(
+        "bridge",
+        &[
+            "fdb", "del",
+            "00:00:00:00:00:00",
+            "dev", VXLAN_NAME,
+            "dst", peer_ip,
+        ],
+    )
+    .with_context(|| format!("failed to remove overlay peer {peer_ip}"))
+}
+
+// ============================================================================
+// Ingress port management
+// ============================================================================
+
+/// Open an ingress firewall port on a pod.
+///
+/// Appends an iptables INPUT ACCEPT rule for the specified port/protocol
+/// in the pod's network namespace.
+pub fn open_port(netns_path: &str, port: i32, protocol: &str) -> Result<()> {
+    let port_str = port.to_string();
+    info!(
+        netns = %netns_path,
+        port = %port,
+        protocol = %protocol,
+        "opening ingress port"
+    );
+    nsenter_run(
+        netns_path,
+        "iptables",
+        &[
+            "-A", "INPUT",
+            "-p", protocol,
+            "--dport", &port_str,
+            "-j", "ACCEPT",
+        ],
+    )
+    .with_context(|| format!("failed to open port {port}/{protocol}"))
+}
+
+/// Close an ingress firewall port on a pod.
+///
+/// Deletes the matching iptables INPUT ACCEPT rule from the pod's
+/// network namespace.
+pub fn close_port(netns_path: &str, port: i32, protocol: &str) -> Result<()> {
+    let port_str = port.to_string();
+    info!(
+        netns = %netns_path,
+        port = %port,
+        protocol = %protocol,
+        "closing ingress port"
+    );
+    nsenter_run(
+        netns_path,
+        "iptables",
+        &[
+            "-D", "INPUT",
+            "-p", protocol,
+            "--dport", &port_str,
+            "-j", "ACCEPT",
+        ],
+    )
+    .with_context(|| format!("failed to close port {port}/{protocol}"))
 }
 
 // ============================================================================

--- a/crates/scop/proto/scop.proto
+++ b/crates/scop/proto/scop.proto
@@ -133,6 +133,18 @@ service Conduit {
 
   // RemoveContainer removes a container.
   rpc RemoveContainer(RemoveContainerRequest) returns (RemoveContainerResponse);
+
+  // AddOverlayPeer adds a VXLAN overlay peer for cross-node pod communication.
+  rpc AddOverlayPeer(AddOverlayPeerRequest) returns (AddOverlayPeerResponse);
+
+  // RemoveOverlayPeer removes a VXLAN overlay peer.
+  rpc RemoveOverlayPeer(RemoveOverlayPeerRequest) returns (RemoveOverlayPeerResponse);
+
+  // OpenPort opens an ingress firewall port on a pod.
+  rpc OpenPort(OpenPortRequest) returns (OpenPortResponse);
+
+  // ClosePort closes an ingress firewall port on a pod.
+  rpc ClosePort(ClosePortRequest) returns (ClosePortResponse);
 }
 
 // ============================================================================
@@ -249,3 +261,51 @@ message KeyValue {
   string key = 1;
   string value = 2;
 }
+
+// ============================================================================
+// Overlay Network Messages
+// ============================================================================
+
+// Request to add a VXLAN overlay peer.
+message AddOverlayPeerRequest {
+  // The remote node's underlay IP address for VXLAN tunneling.
+  string peer_host_ip = 1;
+}
+
+// Response from adding an overlay peer.
+message AddOverlayPeerResponse {}
+
+// Request to remove a VXLAN overlay peer.
+message RemoveOverlayPeerRequest {
+  // The remote node's underlay IP address.
+  string peer_host_ip = 1;
+}
+
+// Response from removing an overlay peer.
+message RemoveOverlayPeerResponse {}
+
+// Request to open an ingress firewall port on a pod.
+message OpenPortRequest {
+  // The pod identifier.
+  string pod_id = 1;
+  // The port number to open.
+  int32 port = 2;
+  // The protocol: "tcp" or "udp".
+  string protocol = 3;
+}
+
+// Response from opening a port.
+message OpenPortResponse {}
+
+// Request to close an ingress firewall port on a pod.
+message ClosePortRequest {
+  // The pod identifier.
+  string pod_id = 1;
+  // The port number to close.
+  int32 port = 2;
+  // The protocol: "tcp" or "udp".
+  string protocol = 3;
+}
+
+// Response from closing a port.
+message ClosePortResponse {}

--- a/crates/scop/src/lib.rs
+++ b/crates/scop/src/lib.rs
@@ -67,10 +67,12 @@ pub mod proto {
 
 // Re-export commonly used types
 pub use proto::{
-    AllowedDestination, ContainerConfig, CreateContainerRequest, CreateContainerResponse,
+    AddOverlayPeerRequest, AddOverlayPeerResponse, AllowedDestination, ClosePortRequest,
+    ClosePortResponse, ContainerConfig, CreateContainerRequest, CreateContainerResponse,
     CreatePodRequest, CreatePodResponse, HeartbeatRequest, HeartbeatResponse, KeyValue,
-    NodeCapacity, NodeUsage, PodConfig, RegisterNodeRequest, RegisterNodeResponse,
-    RemoveContainerRequest, RemoveContainerResponse, RemovePodRequest, RemovePodResponse,
+    NodeCapacity, NodeUsage, OpenPortRequest, OpenPortResponse, PodConfig, RegisterNodeRequest,
+    RegisterNodeResponse, RemoveContainerRequest, RemoveContainerResponse, RemovePodRequest,
+    RemovePodResponse, RemoveOverlayPeerRequest, RemoveOverlayPeerResponse,
     StartContainerRequest, StartContainerResponse, StopContainerRequest, StopContainerResponse,
     UnregisterNodeRequest, UnregisterNodeResponse,
 };
@@ -295,6 +297,30 @@ pub trait Conduit: Send + Sync + 'static {
         &self,
         request: RemoveContainerRequest,
     ) -> Result<RemoveContainerResponse, tonic::Status>;
+
+    /// Add a VXLAN overlay peer for cross-node pod communication.
+    async fn add_overlay_peer(
+        &self,
+        request: AddOverlayPeerRequest,
+    ) -> Result<AddOverlayPeerResponse, tonic::Status>;
+
+    /// Remove a VXLAN overlay peer.
+    async fn remove_overlay_peer(
+        &self,
+        request: RemoveOverlayPeerRequest,
+    ) -> Result<RemoveOverlayPeerResponse, tonic::Status>;
+
+    /// Open an ingress firewall port on a pod.
+    async fn open_port(
+        &self,
+        request: OpenPortRequest,
+    ) -> Result<OpenPortResponse, tonic::Status>;
+
+    /// Close an ingress firewall port on a pod.
+    async fn close_port(
+        &self,
+        request: ClosePortRequest,
+    ) -> Result<ClosePortResponse, tonic::Status>;
 }
 
 struct ConduitService<C: Conduit> {
@@ -356,6 +382,41 @@ impl<C: Conduit> proto::conduit_server::Conduit for ConduitService<C> {
         request: tonic::Request<RemoveContainerRequest>,
     ) -> Result<tonic::Response<RemoveContainerResponse>, tonic::Status> {
         let response = self.conduit.remove_container(request.into_inner()).await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn add_overlay_peer(
+        &self,
+        request: tonic::Request<AddOverlayPeerRequest>,
+    ) -> Result<tonic::Response<AddOverlayPeerResponse>, tonic::Status> {
+        let response = self.conduit.add_overlay_peer(request.into_inner()).await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn remove_overlay_peer(
+        &self,
+        request: tonic::Request<RemoveOverlayPeerRequest>,
+    ) -> Result<tonic::Response<RemoveOverlayPeerResponse>, tonic::Status> {
+        let response = self
+            .conduit
+            .remove_overlay_peer(request.into_inner())
+            .await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn open_port(
+        &self,
+        request: tonic::Request<OpenPortRequest>,
+    ) -> Result<tonic::Response<OpenPortResponse>, tonic::Status> {
+        let response = self.conduit.open_port(request.into_inner()).await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn close_port(
+        &self,
+        request: tonic::Request<ClosePortRequest>,
+    ) -> Result<tonic::Response<ClosePortResponse>, tonic::Status> {
+        let response = self.conduit.close_port(request.into_inner()).await?;
         Ok(tonic::Response::new(response))
     }
 }


### PR DESCRIPTION
Enable cross-node pod communication via VXLAN overlay and wire up
Pod.Port resources to actually open iptables ingress rules.

Changes:
- SCOP: Add AddOverlayPeer, RemoveOverlayPeer, OpenPort, ClosePort RPCs
- SCOC net.rs: VXLAN setup/teardown, peer FDB management, port open/close
- SCOC main.rs: Implement new RPCs, VXLAN lifecycle, store netns_path in PodInfo
- Plugin: Peer fan-out on register/unregister, firewall calls in create/delete port
- SCL container.rs: Pass podId and node to Port resource inputs
- Node registry: Add pod_cidr and overlay_endpoint fields

https://claude.ai/code/session_01Ckq5PGvpLxE8uwkwSSZCeX