### PR TITLE
Add Option.default function

### DIFF
--- a/crates/sclc/src/std/Option.scl
+++ b/crates/sclc/src/std/Option.scl
@@ -13,3 +13,9 @@ export let unwrap = fn<T>(value: T?)
 		uncheckedUnwrap<T>(value)
 	else
 		raise UnexpectedNil
+
+export let default = fn<T>(value: T?, fallback: T)
+	if (value != nil)
+		uncheckedUnwrap<T>(value)
+	else
+		fallback


### PR DESCRIPTION
Adds a pure SCL implementation of Option.default with signature
fn<T>(T?, T) T that returns the unwrapped optional value if present,
otherwise returns the provided fallback.

https://claude.ai/code/session_01UKFFzLQv8XE1VkuRhU4UKW