### PR TITLE
Change exception payload syntax from `exception: T` to `exception(T)`

### DIFF
--- a/crates/sclc/src/parser.rs
+++ b/crates/sclc/src/parser.rs
@@ -431,13 +431,12 @@ peg::parser! {
             }
 
         rule exception_expr() -> Loc<Expr>
-            = exception_kw_span:exception_keyword() colon() ty:type_expr() {
+            = exception_kw_span:exception_keyword() open_paren() ty:type_expr() end:close_paren() {
                 let id = *exception_id;
                 *exception_id += 1;
-                let end = ty.span().end();
                 Loc::new(
                     Expr::Exception(ExceptionExpr { exception_id: id, ty: Some(ty) }),
-                    Span::new(exception_kw_span.start(), end),
+                    Span::new(exception_kw_span.start(), end.end()),
                 )
             }
             / exception_kw_span:exception_keyword() {

--- a/docs/scl/syntax.md
+++ b/docs/scl/syntax.md
@@ -327,10 +327,10 @@ Define exception types with the `exception` keyword:
 let MyError = exception
 ```
 
-Exceptions can optionally carry a typed payload (note the colon):
+Exceptions can optionally carry a typed payload:
 
 ```scl
-let ParseError = exception: Str
+let ParseError = exception(Str)
 ```
 
 #### Raising Exceptions

--- a/docs/scl/types.md
+++ b/docs/scl/types.md
@@ -179,7 +179,7 @@ Exception types are defined with the `exception` keyword and can optionally carr
 
 ```scl
 let NotFound = exception           // No payload
-let ParseError = exception: Str    // Carries a Str (note the colon)
+let ParseError = exception(Str)    // Carries a Str payload
 ```
 
 Exceptions are raised with `raise` and caught with `try`/`catch` (see [Syntax Reference](syntax.md#exceptions)).


### PR DESCRIPTION
The colon-based syntax for exception payloads is replaced with
parenthesized syntax, making it visually consistent with function
call syntax. Bare `exception` without payload remains valid.

https://claude.ai/code/session_01KKz5cQeR6R6bTvtXtmNRoq