### PR TITLE
Add lld to nix devShell to fix scoc cross-compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             cargo
             gnumake
             protobuf
+            lld
           ];
           shellHook = ''
             export RUSTUP_TOOLCHAIN=nightly


### PR DESCRIPTION
Rust nightly 1.96.0 now uses lld as the default linker on
x86_64-linux-gnu. The nix ld-wrapper tries to invoke ld.lld during
host-side proc-macro compilation but it was not available in the
devShell, causing the cross build to fail.

https://claude.ai/code/session_01DiarGhRrJQSJ6zpwzJGzLh