### PR TITLE
Fix CI linker error for aarch64 cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Build CLI
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
-            nix develop -c cross build --release --target ${{ matrix.target }} -p cli
+            RUSTUP_TOOLCHAIN=nightly cross build --release --target ${{ matrix.target }} -p cli
           else
             nix develop -c cargo build --release --target ${{ matrix.target }} -p cli
           fi
@@ -209,7 +209,7 @@ jobs:
       - name: Build scoc
         run: |
           if [ "${{ matrix.use_cross }}" = "true" ]; then
-            nix develop -c cross build --release --target ${{ matrix.target }} -p scoc
+            RUSTUP_TOOLCHAIN=nightly cross build --release --target ${{ matrix.target }} -p scoc
           else
             nix develop -c cargo build --release --target ${{ matrix.target }} -p scoc
           fi


### PR DESCRIPTION
Run `cross` outside of `nix develop` to avoid the nix ld-wrapper
injecting into the cross Docker container. The nix ld-wrapper tries
to resolve ld.lld at a nix-store path that doesn't exist inside the
container, causing "No such file or directory" linker failures.

The `cross` binary is still installed via `nix develop -c cargo install`,
but invoked directly with RUSTUP_TOOLCHAIN=nightly so it uses the
host's rustup toolchain without nix's linker wrapper interference.

https://claude.ai/code/session_01KxNN2ubvzxqU6yCRT453DQ