### PR TITLE
Fix spelling: supercede → supersede across the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Fix any warnings or errors before pushing.
 - For ADB operations, configure endpoint/bucket via CLI args or environment variables.
 - For LDB logging, use `NamespacePublisher` with deployment QID as namespace.
 - The `ids` crate defines the four-level namespace hierarchy (Org → Repo → Environment → Deployment). Use its typed IDs and QIDs rather than raw strings when working with identifiers. Namespace strings (for RDB, LDB, ADB) are QID `.to_string()` values — use environment QIDs for RDB namespaces and deployment QIDs for LDB/ADB namespaces.
-- Note: spelling is consistently `supercede/supercession` in schema/API names.
+- Note: spelling is consistently `supersede/supersession` in schema/API names.
 - When adding new SCL language features (syntax, types, standard library modules/functions, etc.), update the corresponding end-user documentation in `docs/scl/`:
   - `docs/scl/syntax.md` — for new syntax constructs (operators, expressions, statements, keywords)
   - `docs/scl/types.md` — for type system changes (new types, subtyping rules, inference behavior)

--- a/crates/cdb/README.md
+++ b/crates/cdb/README.md
@@ -22,7 +22,7 @@ SCS → CDB ← DE
 
 - Store and query deployments keyed by repository QID (`org/repo`), environment ID, and deployment ID.
 - Update deployment states (Desired, Lingering, Undesired, Down).
-- Record and look up supercession relationships between deployments.
+- Record and look up supersession relationships between deployments.
 - Look up deployments by their full deployment QID (`org/repo::env@deploy`).
 
 ### Data Model
@@ -46,7 +46,7 @@ Used by DE to load `Main.scl` and resolve imports during compilation.
 
 CDB manages its own keyspace and table creation. When changing the schema, update both table creation statements and prepared statements together.
 
-Note: the codebase consistently uses the spelling `supercede`/`supercession` in schema and API names.
+Note: the codebase uses the correct spelling `supersede`/`supersession` in schema and API names.
 
 ## Related Crates
 

--- a/crates/cdb/src/client.rs
+++ b/crates/cdb/src/client.rs
@@ -120,14 +120,14 @@ prepared_statements! {
             )
         "#,
 
-        create_supercessions_table = r#"
-            CREATE TABLE IF NOT EXISTS cdb.supercessions (
+        create_supersessions_table = r#"
+            CREATE TABLE IF NOT EXISTS cdb.supersessions (
                 organization TEXT,
                 repository TEXT,
                 environment_id TEXT,
-                superceding_commit_hash BLOB,
-                superceded_commit_hash BLOB,
-                PRIMARY KEY ((organization), repository, environment_id, superceded_commit_hash)
+                superseding_commit_hash BLOB,
+                superseded_commit_hash BLOB,
+                PRIMARY KEY ((organization), repository, environment_id, superseded_commit_hash)
             )
         "#,
     }
@@ -227,32 +227,32 @@ prepared_statements! {
             AND commit_hash = ?
         "#,
 
-        create_supercession = r#"
-            UPDATE cdb.supercessions
-            SET superceding_commit_hash = ?
+        create_supersession = r#"
+            UPDATE cdb.supersessions
+            SET superseding_commit_hash = ?
             WHERE organization = ?
             AND repository = ?
             AND environment_id = ?
-            AND superceded_commit_hash = ?
+            AND superseded_commit_hash = ?
         "#,
 
-        get_superceded_commits = r#"
-            SELECT superceded_commit_hash
-            FROM cdb.supercessions
+        get_superseded_commits = r#"
+            SELECT superseded_commit_hash
+            FROM cdb.supersessions
             WHERE organization = ?
             AND repository = ?
             AND environment_id = ?
-            AND superceding_commit_hash = ?
+            AND superseding_commit_hash = ?
             ALLOW FILTERING
         "#,
 
-        get_superceding_commit = r#"
-            SELECT superceding_commit_hash
-            FROM cdb.supercessions
+        get_superseding_commit = r#"
+            SELECT superseding_commit_hash
+            FROM cdb.supersessions
             WHERE organization = ?
             AND repository = ?
             AND environment_id = ?
-            AND superceded_commit_hash = ?
+            AND superseded_commit_hash = ?
         "#,
     }
 }
@@ -289,7 +289,7 @@ impl ClientBuilder {
             session.execute_unpaged(&statements.create_active_deployments_table, ()),
             session.execute_unpaged(&statements.create_deployments_by_id_table, ()),
             session.execute_unpaged(&statements.create_objects_table, ()),
-            session.execute_unpaged(&statements.create_supercessions_table, ()),
+            session.execute_unpaged(&statements.create_supersessions_table, ()),
         );
         r0?;
         r1?;
@@ -1020,19 +1020,19 @@ pub enum SetDeploymentError {
 }
 
 impl DeploymentClient {
-    pub async fn mark_superceded_by(
+    pub async fn mark_superseded_by(
         &self,
-        superceding_commit: &DeploymentId,
+        superseding_commit: &DeploymentId,
     ) -> Result<(), SetDeploymentError> {
-        let superceding_oid = deployment_id_to_oid(superceding_commit);
+        let superseding_oid = deployment_id_to_oid(superseding_commit);
         let this_oid = self.commit_hash();
         self.repo
             .client
             .session
             .execute_unpaged(
-                &self.repo.client.statements.create_supercession,
+                &self.repo.client.statements.create_supersession,
                 (
-                    superceding_oid.as_bytes(),
+                    superseding_oid.as_bytes(),
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
                     self.environment.as_str(),
@@ -1043,14 +1043,14 @@ impl DeploymentClient {
         Ok(())
     }
 
-    pub async fn superceded(&self) -> Result<Vec<DeploymentClient>, DeploymentQueryError> {
+    pub async fn superseded(&self) -> Result<Vec<DeploymentClient>, DeploymentQueryError> {
         let this_oid = self.commit_hash();
         let pager = self
             .repo
             .client
             .session
             .execute_iter(
-                self.repo.client.statements.get_superceded_commits.clone(),
+                self.repo.client.statements.get_superseded_commits.clone(),
                 (
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
@@ -1060,7 +1060,7 @@ impl DeploymentClient {
             )
             .await?;
 
-        let superceded = pager
+        let superseded = pager
             .rows_stream::<(Vec<u8>,)>()?
             .map(|row| {
                 let (commit_hash,) = row?;
@@ -1073,17 +1073,17 @@ impl DeploymentClient {
             .try_collect::<Vec<_>>()
             .await?;
 
-        Ok(superceded)
+        Ok(superseded)
     }
 
-    pub async fn get_superceding(&self) -> Result<Option<DeploymentClient>, DeploymentQueryError> {
+    pub async fn get_superseding(&self) -> Result<Option<DeploymentClient>, DeploymentQueryError> {
         let this_oid = self.commit_hash();
         let r = self
             .repo
             .client
             .session
             .execute_unpaged(
-                &self.repo.client.statements.get_superceding_commit,
+                &self.repo.client.statements.get_superseding_commit,
                 (
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
@@ -1096,8 +1096,8 @@ impl DeploymentClient {
         Ok(r.into_rows_result()?
             .single_row::<(Vec<u8>,)>()
             .ok()
-            .and_then(|(superceding,)| {
-                let deploy_id = DeploymentId::from_bytes(&superceding).ok()?;
+            .and_then(|(superseding,)| {
+                let deploy_id = DeploymentId::from_bytes(&superseding).ok()?;
                 Some(self.repo.deployment(self.environment.clone(), deploy_id))
             }))
     }

--- a/crates/de/README.md
+++ b/crates/de/README.md
@@ -21,8 +21,8 @@ CDB → DE → SCLC (compile)
 
 | State | Behavior |
 |-------|----------|
-| **Desired** | Compiles `Main.scl`, evaluates the resource DAG against current RDB state, and emits transition requests. Once evaluation is complete (no pending effects), marks superceded deployments as Undesired. |
-| **Lingering** | Follows the supercession chain to find the active Desired deployment, then marks itself as superceded by it. Includes cycle detection to prevent infinite loops. |
+| **Desired** | Compiles `Main.scl`, evaluates the resource DAG against current RDB state, and emits transition requests. Once evaluation is complete (no pending effects), marks superseded deployments as Undesired. |
+| **Lingering** | Follows the supersession chain to find the active Desired deployment, then marks itself as superseded by it. Includes cycle detection to prevent infinite loops. |
 | **Undesired** | Tears down owned resources by enqueuing Destroy messages. Blocks teardown for resources that still have living dependents. Transitions to Down when all owned resources are destroyed. |
 | **Down** | Idles. |
 
@@ -42,11 +42,11 @@ When a deployment is in the **Desired** state, DE performs a full reconciliation
 | `UpdateResource` (owned by another deployment) | **Adopt** — transfer ownership and optionally update inputs |
 | `TouchResource` (owned by another deployment) | **Adopt** — transfer ownership without input changes |
 
-5. **Completeness**: If no effects were emitted, evaluation is **Complete** and superceded deployments can be transitioned to Undesired. If effects were emitted, evaluation is **Partial** and supercession teardown is deferred until the next loop iteration.
+5. **Completeness**: If no effects were emitted, evaluation is **Complete** and superseded deployments can be transitioned to Undesired. If effects were emitted, evaluation is **Partial** and supersession teardown is deferred until the next loop iteration.
 
-## Supercession
+## Supersession
 
-When a Desired deployment finishes a complete evaluation, it transitions any Lingering deployments it supercedes to Undesired, triggering their teardown. Lingering deployments follow the supercession chain (via `get_superceding()`) to find the active Desired deployment and record the relationship.
+When a Desired deployment finishes a complete evaluation, it transitions any Lingering deployments it supersedes to Undesired, triggering their teardown. Lingering deployments follow the supersession chain (via `get_superseding()`) to find the active Desired deployment and record the relationship.
 
 During **Undesired** teardown, DE enqueues Destroy messages for owned resources but blocks destruction of resources that still have living dependents from other deployments. This ensures correct teardown ordering.
 

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -207,16 +207,16 @@ impl Worker {
 
                 match completeness {
                     EvalCompleteness::Complete => {
-                        for superceded in self.client.superceded().await? {
-                            let superceded_deployment = superceded.get().await?;
-                            if superceded_deployment.state == DeploymentState::Lingering {
-                                superceded.set(DeploymentState::Undesired).await?;
+                        for superseded in self.client.superseded().await? {
+                            let superseded_deployment = superseded.get().await?;
+                            if superseded_deployment.state == DeploymentState::Lingering {
+                                superseded.set(DeploymentState::Undesired).await?;
                             }
                         }
                     }
                     EvalCompleteness::Partial => {
                         tracing::info!(
-                            "evaluation incomplete; deferring superceded deployment teardown"
+                            "evaluation incomplete; deferring superseded deployment teardown"
                         );
                     }
                 }
@@ -315,23 +315,23 @@ impl Worker {
                 let mut cursor = self.client.clone();
                 let mut seen = HashSet::new();
 
-                while let Some(superceding) = cursor.get_superceding().await? {
-                    let superceding_deployment = superceding.get().await?;
-                    let commit_hash = superceding_deployment.deployment.clone();
+                while let Some(superseding) = cursor.get_superseding().await? {
+                    let superseding_deployment = superseding.get().await?;
+                    let commit_hash = superseding_deployment.deployment.clone();
 
                     if !seen.insert(commit_hash.clone()) {
-                        tracing::warn!("detected supercession cycle while lingering");
+                        tracing::warn!("detected supersession cycle while lingering");
                         break;
                     }
 
-                    if superceding_deployment.state == DeploymentState::Desired {
+                    if superseding_deployment.state == DeploymentState::Desired {
                         self.client
-                            .mark_superceded_by(&superceding_deployment.deployment)
+                            .mark_superseded_by(&superseding_deployment.deployment)
                             .await?;
                         break;
                     }
 
-                    cursor = superceding;
+                    cursor = superseding;
                 }
 
                 Ok(())

--- a/crates/scs/README.md
+++ b/crates/scs/README.md
@@ -28,7 +28,7 @@ When a user pushes:
 4. Marks new deployments as **Desired** (active).
 5. Marks replaced deployments as **Lingering** (superseded by the new deployment).
 6. Marks deleted environments as **Undesired** (scheduled for teardown).
-7. Records the supercession relationship between old and new deployments.
+7. Records the supersession relationship between old and new deployments.
 
 ### Fetch (`git-upload-pack`)
 

--- a/crates/scs/src/main.rs
+++ b/crates/scs/src/main.rs
@@ -1001,7 +1001,7 @@ impl<'a> CommandHandler<'a> {
                     .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
                 let (r1, r2) = futures::join!(
                     deployment.set(state),
-                    deployment.mark_superceded_by(&new_deployment_id),
+                    deployment.mark_superseded_by(&new_deployment_id),
                 );
                 r1?;
                 r2?;


### PR DESCRIPTION
The correct spelling is "supersede"/"supersession", not
"supercede"/"supercession". Fixed all occurrences in code
(identifiers, CQL schema strings) and documentation.

https://claude.ai/code/session_01WSTEZetyBEaFSdPHC7nU61