### PR TITLE
Fix release job failing to download Docker build cache artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
+          pattern: |
+            skyr-*
+            scoc-*
           merge-multiple: true
 
       - name: Create release


### PR DESCRIPTION
The release job used download-artifact without a pattern filter, causing
it to also download .dockerbuild cache artifacts created by
docker/build-push-action. These are not valid zip files and cause the
download to fail. Filter to only skyr-* and scoc-* binary artifacts.

https://claude.ai/code/session_01VWkYiC44XNYML6bonXeHtX