### PR TITLE
Fix release tag format to use vY.M.D-short-sha instead of commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Compute version tag
+        id: version
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          date_tag="$(date -u +'%Y.%-m.%-d')"
+          echo "tag=v${date_tag}-${short_sha}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
@@ -222,8 +229,8 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2.4.2
         with:
-          tag_name: ${{ github.sha }}
-          name: ${{ github.sha }}
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
           body: |
             Automated release for commit ${{ github.sha }}.
 


### PR DESCRIPTION
GitHub releases don't allow plain commit hashes as tag names. Use a
date-based version tag with the short SHA suffix (e.g. v2026.3.11-abc1234).

https://claude.ai/code/session_019mike2bxy3wcfB2NcYr3hg