### PR TITLE
Handle Never type in function call type checking

### DIFF
--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -1124,6 +1124,9 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                     .unpack(&mut diags)
                     .unfold();
                 let callee_ty = env.resolve_var_bound(&raw_callee_ty).unfold();
+                if matches!(callee_ty, Type::Never) {
+                    return Ok(Diagnosed::new(Type::Never, diags));
+                }
                 let Type::Fn(fn_ty) = callee_ty else {
                     diags.push(NotAFunction {
                         module_id: env.module_id()?,


### PR DESCRIPTION
## Summary
Added early return handling for the `Never` type when type-checking function calls, preventing unnecessary error diagnostics when the callee expression has type `Never`.

## Key Changes
- Added a type check after resolving the callee type to detect if it is `Type::Never`
- When `Never` type is detected, the function immediately returns with `Type::Never` result and accumulated diagnostics
- This prevents the subsequent "not a function" error from being reported, since `Never` is a valid (bottom) type that represents unreachable code

## Implementation Details
The check is inserted right after resolving the callee type variable bounds and before the pattern match that expects a function type. This allows code paths that legitimately have `Never` type (e.g., from diverging expressions) to propagate that type correctly without generating spurious type errors.

https://claude.ai/code/session_01L3isHRyYJ85vR5xJ8Dff1p