### PR TITLE
Propagate parse diagnostics instead of converting to errors

### DIFF
--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -43,7 +43,7 @@ pub async fn run_program(root: PathBuf, package: String) -> anyhow::Result<()> {
         }
     });
 
-    program.evaluate(&module_id, &eval).await?;
+    report(program.evaluate(&module_id, &eval).await?);
 
     effects_task.await?;
     Ok(())

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -634,8 +634,25 @@ impl Worker {
             .instrument(tracing::Span::current()),
         );
 
-        if let Err(e) = program.evaluate(&module_id, &eval).await {
-            self.log_publisher.error(format!("{e}")).await;
+        match program.evaluate(&module_id, &eval).await {
+            Ok(eval_diagnosed) => {
+                for diag in eval_diagnosed.diags().iter() {
+                    let (module_id, span) = diag.locate();
+                    self.log_publisher
+                        .log(
+                            match diag.level() {
+                                sclc::DiagLevel::Error => ldb::Severity::Error,
+                                sclc::DiagLevel::Warning => ldb::Severity::Warning,
+                            },
+                            format!("{module_id}:{span}: {diag}"),
+                        )
+                        .await
+                        .unwrap_or_default();
+                }
+            }
+            Err(e) => {
+                self.log_publisher.error(format!("{e}")).await;
+            }
         }
         drop(eval);
         let completeness = effects_task.await?;

--- a/crates/sclc/src/compile.rs
+++ b/crates/sclc/src/compile.rs
@@ -20,7 +20,9 @@ pub async fn compile<S: SourceRepo>(source: S) -> Result<Diagnosed<Program<S>>, 
     let mut diags = DiagList::new();
     let mut program = Program::new();
     let package = program.open_package(source).await;
-    let _ = package.open("Main.scl").await?;
+    if package.open("Main.scl").await?.unpack(&mut diags).is_none() {
+        return Ok(Diagnosed::new(program, diags));
+    }
 
     program.resolve_imports().await?.unpack(&mut diags);
     program.check_types()?.unpack(&mut diags);

--- a/crates/sclc/src/package.rs
+++ b/crates/sclc/src/package.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use thiserror::Error;
 
-use crate::{FileMod, ImportStmt, Loc, ModStmt, SourceRepo, parse_file_mod};
+use crate::{DiagList, Diagnosed, FileMod, ImportStmt, Loc, ModStmt, SourceRepo, parse_file_mod};
 
 #[derive(Clone)]
 pub struct Package<S> {
@@ -21,9 +21,6 @@ pub enum OpenError {
 
     #[error("encoding error: {0}")]
     Encoding(#[from] std::string::FromUtf8Error),
-
-    #[error("parse error: {0}")]
-    Parse(String),
 }
 
 impl<S> Package<S> {
@@ -58,13 +55,20 @@ impl<S: SourceRepo> Package<S> {
         SourceRepo::package_id(&self.source)
     }
 
-    pub async fn open(&mut self, path: impl AsRef<Path>) -> Result<&FileMod, OpenError> {
+    pub async fn open(
+        &mut self,
+        path: impl AsRef<Path>,
+    ) -> Result<Diagnosed<Option<&FileMod>>, OpenError> {
         let path = path.as_ref().to_path_buf();
         if self.files.contains_key(&path) {
-            return Ok(self
-                .files
-                .get(&path)
-                .expect("cached file must be present in package map"));
+            return Ok(Diagnosed::new(
+                Some(
+                    self.files
+                        .get(&path)
+                        .expect("cached file must be present in package map"),
+                ),
+                DiagList::new(),
+            ));
         }
 
         let source_data = SourceRepo::read_file(&self.source, &path)
@@ -75,19 +79,15 @@ impl<S: SourceRepo> Package<S> {
         let package_id = self.package_id();
         let module_id = module_id_for_path(&package_id, &path);
         let diagnosed = parse_file_mod(&source, &module_id);
-        if diagnosed.as_ref().is_none() {
-            let message = diagnosed
-                .diags()
-                .iter()
-                .next()
-                .map(|diag| diag.to_string())
-                .unwrap_or_else(|| "parse error".to_string());
-            return Err(OpenError::Parse(message));
+        let mut diags = DiagList::new();
+        let parsed = diagnosed.unpack(&mut diags);
+        match parsed {
+            Some(file_mod) => {
+                let file_mod = self.files.entry(path.clone()).or_insert(file_mod);
+                Ok(Diagnosed::new(Some(file_mod), diags))
+            }
+            None => Ok(Diagnosed::new(None, diags)),
         }
-        let file_mod = diagnosed
-            .into_inner()
-            .expect("checked parse result before unwrapping");
-        Ok(self.files.entry(path.clone()).or_insert(file_mod))
     }
 }
 

--- a/crates/sclc/src/program.rs
+++ b/crates/sclc/src/program.rs
@@ -113,7 +113,12 @@ impl<S: SourceRepo> Program<S> {
             }
 
             for (import_path, import_stmt) in pending_imports {
-                if self.resolve_import(&import_path).await?.is_none() {
+                if self
+                    .resolve_import(&import_path)
+                    .await?
+                    .unpack(&mut diags)
+                    .is_none()
+                {
                     diags.push(InvalidImport {
                         module_id: import_path,
                         import: import_stmt,
@@ -128,16 +133,16 @@ impl<S: SourceRepo> Program<S> {
     pub async fn resolve_import(
         &mut self,
         import_path: &ModuleId,
-    ) -> Result<Option<&crate::ast::FileMod>, ResolveImportError> {
+    ) -> Result<Diagnosed<Option<&crate::ast::FileMod>>, ResolveImportError> {
         let Some(package_name) = self.package_name_for_import(import_path) else {
-            return Ok(None);
+            return Ok(Diagnosed::new(None, DiagList::new()));
         };
 
         let Some(module_segments) = import_path.suffix_after(&package_name) else {
-            return Ok(None);
+            return Ok(Diagnosed::new(None, DiagList::new()));
         };
         if module_segments.is_empty() {
-            return Ok(None);
+            return Ok(Diagnosed::new(None, DiagList::new()));
         }
 
         let module_path = module_segments
@@ -147,12 +152,12 @@ impl<S: SourceRepo> Program<S> {
             .to_path_buf_with_extension("scl");
 
         let Some(package) = self.packages.get_mut(&package_name) else {
-            return Ok(None);
+            return Ok(Diagnosed::new(None, DiagList::new()));
         };
 
         match package.open(&module_path).await {
-            Ok(file_mod) => Ok(Some(file_mod)),
-            Err(OpenError::NotFound(_)) => Ok(None),
+            Ok(diagnosed) => Ok(diagnosed),
+            Err(OpenError::NotFound(_)) => Ok(Diagnosed::new(None, DiagList::new())),
             Err(source) => Err(ResolveImportError::Open {
                 import_path: import_path.clone(),
                 package_name,
@@ -174,7 +179,9 @@ impl<S: SourceRepo> Program<S> {
         &mut self,
         module_id: &ModuleId,
         eval: &crate::Eval,
-    ) -> Result<(), EvaluateError> {
+    ) -> Result<Diagnosed<()>, EvaluateError> {
+        let mut diags = DiagList::new();
+
         let Some(package_name) = self.package_name_for_import(module_id) else {
             return Err(EvaluateError::ModuleNotLoaded(module_id.clone()));
         };
@@ -196,11 +203,15 @@ impl<S: SourceRepo> Program<S> {
             let Some(package) = self.packages.get_mut(&package_name) else {
                 return Err(EvaluateError::ModuleNotLoaded(module_id.clone()));
             };
-            package
+            let open_result = package
                 .open(&module_path)
                 .await
                 .map_err(|err| EvaluateError::Open(module_id.clone(), err))?
-                .clone()
+                .unpack(&mut diags);
+            match open_result {
+                Some(file_mod) => file_mod.clone(),
+                None => return Ok(Diagnosed::new((), diags)),
+            }
         };
         let imports = self.find_imports(&file_mod);
 
@@ -209,7 +220,7 @@ impl<S: SourceRepo> Program<S> {
             .with_imports(&imports);
         eval.eval_file_mod(&env, &file_mod)
             .map_err(|err| EvaluateError::Eval(module_id.clone(), err))?;
-        Ok(())
+        Ok(Diagnosed::new((), diags))
     }
 
     fn find_imports<'a>(


### PR DESCRIPTION
## Summary
This PR refactors error handling in the package and program modules to propagate parse diagnostics as warnings/errors rather than converting them to fatal `OpenError::Parse` errors. This allows the compilation process to continue and report multiple diagnostics to the user instead of failing fast.

## Key Changes

- **Removed `OpenError::Parse` variant**: Parse errors are no longer converted to fatal errors in `Package::open()`. Instead, diagnostics are collected and returned alongside the parse result.

- **Updated `Package::open()` return type**: Changed from `Result<&FileMod, OpenError>` to `Result<Diagnosed<Option<&FileMod>>, OpenError>` to return both the parsed file (if successful) and any diagnostics encountered.

- **Updated `Program::resolve_import()` return type**: Changed to return `Result<Diagnosed<Option<&FileMod>>, ResolveImportError>` to propagate diagnostics from file opening.

- **Updated `Program::evaluate()` return type**: Changed to return `Result<Diagnosed<()>, EvaluateError>` to collect and propagate diagnostics during evaluation.

- **Diagnostic collection in callers**: Updated all callers of these functions to unpack diagnostics and accumulate them:
  - `Program::resolve_imports()` now collects diagnostics from `resolve_import()`
  - `Program::evaluate()` collects diagnostics from `package.open()`
  - `compile()` collects diagnostics from `package.open()`
  - CLI and DE worker now report collected diagnostics with appropriate severity levels

## Notable Implementation Details

- The `Diagnosed<T>` wrapper type is used consistently to carry both a result value and associated diagnostics
- Parse failures no longer prevent the program from attempting to load other modules or continue compilation
- Diagnostics are reported with their location information (module ID and span) in the DE worker
- The `unpack()` method is used to extract the inner value while transferring diagnostics to a `DiagList`

https://claude.ai/code/session_011xqgta2XeSWgxuctqnsZj1