### PR TITLE
Update AGENTS.md: add cargo test, docs guidance, remove stale GitHub section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,5 +50,5 @@ For manual testing:
 ## Environment Notes
 
 - `cargo` is not available in the current shell session by default.
-- `flake.nix` defines a dev shell including `rustup`, `cargo`, `qemu`, `cdrtools`, and `curl`; use that shell before Rust builds/checks if needed.
+- `flake.nix` defines a dev shell including `rustup`, `cargo`, `gnumake`, and `protobuf`; use that shell before Rust builds/checks if needed.
 - Running tests/builds typically uses `nix develop -c cargo ...`.


### PR DESCRIPTION
- Add `cargo test` to the pre-commit verification checklist
- Add guidance distinguishing internal docs (READMEs) from external docs
  (docs/ dir), with note that internal-only changes shouldn't update
  external docs
- Remove the GitHub section which contained user-specific instructions
  (MCP references, conversational "If I mention PR" phrasing) that don't
  belong in a general agent guidance file

https://claude.ai/code/session_012ykuRUtcaP2gT6pJbXEb1q