### PR TITLE
feat: add volatile resource markers and UP deployment state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "rdb",
  "regex",
  "russh",
+ "sclc",
  "serde_json",
  "sha2 0.10.9",
  "tokio",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 ids = { path = "../ids" }
 cdb = { path = "../cdb" }
 rdb = { path = "../rdb" }
+sclc = { path = "../sclc" }
 udb = { path = "../udb" }
 ldb = { path = "../ldb" }
 adb = { path = "../adb" }

--- a/crates/api/schema.graphql
+++ b/crates/api/schema.graphql
@@ -9,6 +9,11 @@ enum DeploymentState {
   UNDESIRED
   LINGERING
   DESIRED
+  UP
+}
+
+enum ResourceMarker {
+  VOLATILE
 }
 
 enum Severity {
@@ -81,6 +86,7 @@ type Resource {
   outputs: JSON
   owner: Deployment
   dependencies: [Resource!]!
+  markers: [ResourceMarker!]!
 }
 
 type Subscription {

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -664,6 +664,15 @@ impl Resource {
 
         Ok(dependencies)
     }
+
+    fn markers(&self) -> Vec<ResourceMarker> {
+        self.resource
+            .markers
+            .iter()
+            .copied()
+            .map(ResourceMarker::from)
+            .collect()
+    }
 }
 
 #[derive(Clone, Copy, juniper::GraphQLEnum)]
@@ -676,6 +685,8 @@ enum DeploymentState {
     Lingering,
     #[graphql(name = "DESIRED")]
     Desired,
+    #[graphql(name = "UP")]
+    Up,
 }
 
 impl From<cdb::DeploymentState> for DeploymentState {
@@ -685,6 +696,21 @@ impl From<cdb::DeploymentState> for DeploymentState {
             cdb::DeploymentState::Undesired => DeploymentState::Undesired,
             cdb::DeploymentState::Lingering => DeploymentState::Lingering,
             cdb::DeploymentState::Desired => DeploymentState::Desired,
+            cdb::DeploymentState::Up => DeploymentState::Up,
+        }
+    }
+}
+
+#[derive(Clone, Copy, juniper::GraphQLEnum)]
+enum ResourceMarker {
+    #[graphql(name = "VOLATILE")]
+    Volatile,
+}
+
+impl From<sclc::Marker> for ResourceMarker {
+    fn from(marker: sclc::Marker) -> Self {
+        match marker {
+            sclc::Marker::Volatile => ResourceMarker::Volatile,
         }
     }
 }

--- a/crates/cdb/src/deployment.rs
+++ b/crates/cdb/src/deployment.rs
@@ -40,6 +40,7 @@ pub enum DeploymentState {
     Undesired,
     Lingering,
     Desired,
+    Up,
 }
 
 impl fmt::Display for DeploymentState {
@@ -49,6 +50,7 @@ impl fmt::Display for DeploymentState {
             Self::Undesired => write!(f, "UNDESIRED"),
             Self::Lingering => write!(f, "LINGERING"),
             Self::Desired => write!(f, "DESIRED"),
+            Self::Up => write!(f, "UP"),
         }
     }
 }
@@ -66,6 +68,7 @@ impl FromStr for DeploymentState {
             "UNDESIRED" => Ok(DeploymentState::Undesired),
             "LINGERING" => Ok(DeploymentState::Lingering),
             "DESIRED" => Ok(DeploymentState::Desired),
+            "UP" => Ok(DeploymentState::Up),
             v => Err(InvalidDeploymentState(v.to_string())),
         }
     }

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -263,6 +263,32 @@ impl Worker {
                                 superseded.set(DeploymentState::Undesired).await?;
                             }
                         }
+
+                        // Check if all owned resources are non-volatile.
+                        // If so, transition to Up (no further reconciliation needed).
+                        let owner_deployment_qid = deployment.deployment_qid().to_string();
+                        let mut has_volatile = false;
+                        let mut resources = self
+                            .namespace
+                            .list_resources_by_owner(&owner_deployment_qid)
+                            .await?;
+                        while let Some(resource) = resources.try_next().await? {
+                            if resource.markers.contains(&sclc::Marker::Volatile) {
+                                has_volatile = true;
+                                break;
+                            }
+                        }
+                        drop(resources);
+
+                        if !has_volatile {
+                            tracing::info!(
+                                "{short_id} all resources non-volatile; transitioning to UP"
+                            );
+                            self.client.set(DeploymentState::Up).await?;
+                            self.log_publisher
+                                .info(format!("{short_id} is up (all resources non-volatile)"))
+                                .await;
+                        }
                     }
                     EvalCompleteness::Partial => {
                         tracing::info!(
@@ -271,6 +297,11 @@ impl Worker {
                     }
                 }
 
+                Ok(())
+            }
+
+            DeploymentState::Up => {
+                tracing::debug!("{short_id} up; no reconciliation needed");
                 Ok(())
             }
 
@@ -370,7 +401,10 @@ impl Worker {
                         break;
                     }
 
-                    if superseding_deployment.state == DeploymentState::Desired {
+                    if matches!(
+                        superseding_deployment.state,
+                        DeploymentState::Desired | DeploymentState::Up
+                    ) {
                         self.client
                             .mark_superseded_by(&superseding_deployment.deployment)
                             .await?;
@@ -446,6 +480,7 @@ impl Worker {
                     inputs: resource.inputs.unwrap_or_default(),
                     outputs: resource.outputs.unwrap_or_default(),
                     dependencies: resource.dependencies,
+                    markers: resource.markers,
                 },
             );
         }

--- a/crates/plugin_std_artifact/src/main.rs
+++ b/crates/plugin_std_artifact/src/main.rs
@@ -114,6 +114,7 @@ impl ArtifactPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: Default::default(),
         })
     }
 

--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -19,6 +19,7 @@ mod node_registry;
 mod subnet_allocator;
 mod vip_allocator;
 
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -294,6 +295,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -330,6 +332,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -454,6 +457,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::from([sclc::Marker::Volatile]),
         })
     }
 
@@ -509,6 +513,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::from([sclc::Marker::Volatile]),
         })
     }
 
@@ -683,6 +688,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::from([sclc::Marker::Volatile]),
         })
     }
 
@@ -720,6 +726,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::from([sclc::Marker::Volatile]),
         })
     }
 
@@ -857,6 +864,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -892,6 +900,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -1007,6 +1016,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -1042,6 +1052,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -1150,6 +1161,7 @@ impl ContainerPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 
@@ -1185,6 +1197,7 @@ impl ContainerPlugin {
             inputs,
             outputs: prev_outputs,
             dependencies: vec![],
+            markers: BTreeSet::new(),
         })
     }
 

--- a/crates/plugin_std_crypto/src/main.rs
+++ b/crates/plugin_std_crypto/src/main.rs
@@ -54,6 +54,7 @@ impl CryptoPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: Default::default(),
         })
     }
 }

--- a/crates/plugin_std_random/src/main.rs
+++ b/crates/plugin_std_random/src/main.rs
@@ -43,6 +43,7 @@ impl RandomPlugin {
             inputs,
             outputs,
             dependencies: vec![],
+            markers: Default::default(),
         })
     }
 }

--- a/crates/rdb/src/lib.rs
+++ b/crates/rdb/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -64,6 +65,7 @@ prepared_statements! {
                 inputs_json TEXT,
                 outputs_json TEXT,
                 dependencies_json TEXT,
+                markers_json TEXT,
                 owner TEXT,
                 PRIMARY KEY ((namespace), resource_type, id)
             )
@@ -72,19 +74,19 @@ prepared_statements! {
 
     PreparedStatements {
         get_resource = r#"
-            SELECT inputs_json, outputs_json, dependencies_json, owner
+            SELECT inputs_json, outputs_json, dependencies_json, markers_json, owner
             FROM rdb.resources
             WHERE namespace = ?
             AND resource_type = ?
             AND id = ?
         "#,
         list_resources = r#"
-            SELECT resource_type, id, inputs_json, outputs_json, dependencies_json, owner
+            SELECT resource_type, id, inputs_json, outputs_json, dependencies_json, markers_json, owner
             FROM rdb.resources
             WHERE namespace = ?
         "#,
         list_resources_by_owner = r#"
-            SELECT resource_type, id, inputs_json, outputs_json, dependencies_json, owner
+            SELECT resource_type, id, inputs_json, outputs_json, dependencies_json, markers_json, owner
             FROM rdb.resources
             WHERE namespace = ?
             AND owner = ?
@@ -112,6 +114,13 @@ prepared_statements! {
             AND resource_type = ?
             AND id = ?
         "#,
+        set_resource_markers = r#"
+            UPDATE rdb.resources
+            SET markers_json = ?
+            WHERE namespace = ?
+            AND resource_type = ?
+            AND id = ?
+        "#,
         delete_resource = r#"
             DELETE FROM rdb.resources
             WHERE namespace = ?
@@ -128,10 +137,12 @@ type ResourceRow = (
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<String>,
 );
 
 fn map_resource_row(namespace: &str, row: ResourceRow) -> Result<Resource, ResourceError> {
-    let (resource_type, id, inputs_json, outputs_json, dependencies_json, owner) = row;
+    let (resource_type, id, inputs_json, outputs_json, dependencies_json, markers_json, owner) =
+        row;
     Ok(Resource {
         namespace: namespace.to_owned(),
         resource_type,
@@ -139,6 +150,7 @@ fn map_resource_row(namespace: &str, row: ResourceRow) -> Result<Resource, Resou
         inputs: decode_record(inputs_json)?,
         outputs: decode_record(outputs_json)?,
         dependencies: decode_dependencies(dependencies_json)?,
+        markers: decode_markers(markers_json)?,
         owner,
     })
 }
@@ -284,8 +296,9 @@ impl ResourceClient {
             .execute_iter(self.statements().get_resource.clone(), self.key())
             .await?;
 
-        let (inputs_json, outputs_json, dependencies_json, owner) = match pager
+        let (inputs_json, outputs_json, dependencies_json, markers_json, owner) = match pager
             .rows_stream::<(
+                Option<String>,
                 Option<String>,
                 Option<String>,
                 Option<String>,
@@ -305,6 +318,7 @@ impl ResourceClient {
             inputs: decode_record(inputs_json)?,
             outputs: decode_record(outputs_json)?,
             dependencies: decode_dependencies(dependencies_json)?,
+            markers: decode_markers(markers_json)?,
             owner,
         }))
     }
@@ -358,6 +372,23 @@ impl ResourceClient {
         self.get().await?.ok_or(ResourceError::MissingAfterWrite)
     }
 
+    pub async fn set_markers(
+        &self,
+        markers: &BTreeSet<sclc::Marker>,
+    ) -> Result<Resource, ResourceError> {
+        let markers_json = encode_markers(markers)?;
+        let (namespace, resource_type, id) = self.key();
+
+        self.session()
+            .execute_unpaged(
+                &self.statements().set_resource_markers,
+                (markers_json, namespace, resource_type, id),
+            )
+            .await?;
+
+        self.get().await?.ok_or(ResourceError::MissingAfterWrite)
+    }
+
     pub async fn delete(&self) -> Result<(), ResourceError> {
         self.session()
             .execute_unpaged(&self.statements().delete_resource, self.key())
@@ -375,6 +406,7 @@ pub struct Resource {
     pub inputs: Option<Record>,
     pub outputs: Option<Record>,
     pub dependencies: Vec<sclc::ResourceId>,
+    pub markers: BTreeSet<sclc::Marker>,
     pub owner: Option<String>,
 }
 
@@ -415,10 +447,22 @@ fn decode_dependencies(value: Option<String>) -> Result<Vec<sclc::ResourceId>, R
     }
 }
 
+fn decode_markers(value: Option<String>) -> Result<BTreeSet<sclc::Marker>, ResourceError> {
+    match value {
+        None => Ok(BTreeSet::new()),
+        Some(text) if text.is_empty() => Ok(BTreeSet::new()),
+        Some(text) => Ok(serde_json::from_str(&text)?),
+    }
+}
+
 fn encode_record(value: &Record) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
 }
 
 fn encode_dependencies(value: &[sclc::ResourceId]) -> Result<String, ResourceError> {
+    Ok(serde_json::to_string(value)?)
+}
+
+fn encode_markers(value: &BTreeSet<sclc::Marker>) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
 }

--- a/crates/rte/src/main.rs
+++ b/crates/rte/src/main.rs
@@ -366,6 +366,18 @@ async fn handle_create(
         return Ok(());
     }
 
+    if let Err(error) = resource_client.set_markers(&resource.markers).await {
+        tracing::warn!(
+            environment_qid = %message.resource.environment_qid,
+            resource_type = %message.resource.resource_type,
+            resource_id = %message.resource.resource_id,
+            error = %error,
+            "failed to persist created resource markers",
+        );
+        delivery.nack(false).await?;
+        return Ok(());
+    }
+
     tracing::info!(
         environment_qid = %message.resource.environment_qid,
         resource_type = %message.resource.resource_type,
@@ -646,6 +658,7 @@ async fn handle_update_inputs(
 
     let mut inputs_to_persist = prev_inputs.clone();
     let mut outputs_to_persist = current.outputs.clone();
+    let mut markers_to_persist = None;
 
     if prev_inputs != desired_inputs {
         let Some((plugin_name, mut plugin)) = resolve_plugin(&resource.resource_type, &ctx.plugins)
@@ -693,6 +706,7 @@ async fn handle_update_inputs(
         };
         inputs_to_persist = updated.inputs;
         outputs_to_persist = Some(updated.outputs);
+        markers_to_persist = Some(updated.markers);
     } else {
         tracing::info!(
             environment_qid = %resource.environment_qid,
@@ -749,6 +763,19 @@ async fn handle_update_inputs(
             resource_id = %resource.resource_id,
             "{operation} resource has no outputs to persist",
         );
+    }
+    if let Some(markers) = markers_to_persist
+        && let Err(error) = resource_client.set_markers(&markers).await
+    {
+        tracing::warn!(
+            environment_qid = %resource.environment_qid,
+            resource_type = %resource.resource_type,
+            resource_id = %resource.resource_id,
+            error = %error,
+            "failed to persist {operation} resource markers",
+        );
+        delivery.nack(false).await?;
+        return Ok(None);
     }
 
     Ok(Some(target_dep_qid))

--- a/crates/rtp/proto/rtp.proto
+++ b/crates/rtp/proto/rtp.proto
@@ -32,11 +32,16 @@ message CreateResourceRequest {
   string deployment_id = 5;
 }
 
+enum Marker {
+  VOLATILE = 0;
+}
+
 message Resource {
   string type = 1;
   string id = 2;
   string inputs_json = 3;
   string outputs_json = 4;
+  repeated Marker markers = 5;
 }
 
 message CreateResourceResponse {

--- a/crates/rtp/src/lib.rs
+++ b/crates/rtp/src/lib.rs
@@ -569,6 +569,7 @@ impl PluginClient {
                     id: id.id,
                     inputs_json: current_inputs_json,
                     outputs_json: current_outputs_json,
+                    markers: vec![],
                 }),
                 inputs_json,
                 environment_qid: environment_qid.to_string(),
@@ -609,6 +610,7 @@ impl PluginClient {
                     id: id.id,
                     inputs_json,
                     outputs_json,
+                    markers: vec![],
                 }),
                 environment_qid: environment_qid.to_string(),
                 deployment_id: deployment_id.to_string(),
@@ -644,6 +646,19 @@ impl PluginClient {
     }
 }
 
+fn encode_marker(marker: &sclc::Marker) -> i32 {
+    match marker {
+        sclc::Marker::Volatile => proto::Marker::Volatile as i32,
+    }
+}
+
+fn decode_marker(value: i32) -> Option<sclc::Marker> {
+    match proto::Marker::try_from(value) {
+        Ok(proto::Marker::Volatile) => Some(sclc::Marker::Volatile),
+        Err(_) => None,
+    }
+}
+
 fn encode_resource(
     id: sclc::ResourceId,
     resource: sclc::Resource,
@@ -652,11 +667,13 @@ fn encode_resource(
         .map_err(|error| tonic::Status::internal(error.to_string()))?;
     let outputs_json = serde_json::to_string(&resource.outputs)
         .map_err(|error| tonic::Status::internal(error.to_string()))?;
+    let markers = resource.markers.iter().map(encode_marker).collect();
     Ok(Resource {
         r#type: id.ty,
         id: id.id,
         inputs_json,
         outputs_json,
+        markers,
     })
 }
 
@@ -665,10 +682,16 @@ fn decode_resource(resource: Resource) -> Result<sclc::Resource, tonic::Status> 
         .map_err(|error| tonic::Status::invalid_argument(error.to_string()))?;
     let outputs: sclc::Record = serde_json::from_str(&resource.outputs_json)
         .map_err(|error| tonic::Status::invalid_argument(error.to_string()))?;
+    let markers = resource
+        .markers
+        .iter()
+        .filter_map(|&v| decode_marker(v))
+        .collect();
     Ok(sclc::Resource {
         inputs,
         outputs,
         dependencies: vec![],
+        markers,
     })
 }
 

--- a/crates/sclc/src/eval.rs
+++ b/crates/sclc/src/eval.rs
@@ -1506,6 +1506,7 @@ mod tests {
                 inputs: inputs.clone(),
                 outputs: crate::Record::default(),
                 dependencies: vec![],
+                markers: Default::default(),
             },
         );
         let dependency = ResourceId {
@@ -1556,6 +1557,7 @@ mod tests {
                 inputs: inputs.clone(),
                 outputs: crate::Record::default(),
                 dependencies: vec![dependency.clone()],
+                markers: Default::default(),
             },
         );
         let mut dependencies = std::collections::BTreeSet::new();

--- a/crates/sclc/src/resource.rs
+++ b/crates/sclc/src/resource.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::Record;
 
 #[derive(
@@ -8,9 +10,23 @@ pub struct ResourceId {
     pub id: String,
 }
 
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum Marker {
+    Volatile,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Resource {
     pub inputs: Record,
     pub outputs: Record,
     pub dependencies: Vec<ResourceId>,
+    pub markers: BTreeSet<Marker>,
+}
+
+impl Resource {
+    pub fn is_volatile(&self) -> bool {
+        self.markers.contains(&Marker::Volatile)
+    }
 }

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -41,7 +41,17 @@ When you push a new commit, the deployment starts in the **Desired** state. Skyr
 3. Adopts existing resources that match your configuration
 4. Updates resources whose inputs have changed
 
-The deployment stays in this state as long as you want it running.
+The deployment stays in this state until it either converges (transitions to Up) or is superseded by a new push.
+
+### Up
+
+Once a Desired deployment has fully converged — meaning its configuration has been evaluated with no new resource changes — Skyr checks whether any of its resources are **volatile**. If none are, the deployment transitions to the **Up** state.
+
+An Up deployment is still the active deployment for its environment, but Skyr no longer re-evaluates it on each reconciliation cycle. This avoids unnecessary work for deployments that consist entirely of stable resources like random numbers, crypto keys, or artifacts.
+
+If any resource is volatile (e.g., pods or containers), the deployment remains Desired and continues to be reconciled, since volatile resources may change or disappear externally.
+
+When you push a new commit, an Up deployment is superseded just like a Desired one — it transitions to Lingering and follows the normal rollout process.
 
 ### Lingering
 
@@ -70,7 +80,7 @@ When you push a new commit to an environment that already has an active deployme
 
 ```
 Before push:
-  main → commit A (Desired)
+  main → commit A (Desired or Up)
 
 After push:
   main → commit A (Lingering) ──superseded by──→ commit B (Desired)
@@ -156,6 +166,31 @@ The container depends on both the pod and the image. During teardown:
 3. Then the image
 
 A resource won't be destroyed until all resources that depend on it are gone.
+
+## Volatile Resources
+
+Resources in Skyr can be marked as **volatile** by their plugin. A volatile resource represents external state that may change or disappear independently of Skyr — for example, a running container or pod that could be restarted, evicted, or destroyed by an external system.
+
+Non-volatile resources are stable data that, once created, won't change unless Skyr explicitly updates them. Examples include random numbers, cryptographic keys, and build artifacts.
+
+The distinction affects how Skyr manages deployments:
+
+- A deployment with **only non-volatile resources** transitions to the Up state once converged, and is not re-evaluated until a new push.
+- A deployment with **at least one volatile resource** remains in the Desired state and continues to be reconciled periodically, ensuring that volatile resources are kept in sync with the desired configuration.
+
+The built-in resource types have the following volatility:
+
+| Resource Type | Volatile |
+|---------------|----------|
+| `Std/Random.Int` | No |
+| `Std/Crypto.*` | No |
+| `Std/Artifact.File` | No |
+| `Std/Container.Image` | No |
+| `Std/Container.Pod` | Yes |
+| `Std/Container.Pod.Container` | Yes |
+| `Std/Container.Pod.Port` | No |
+| `Std/Container.Host` | No |
+| `Std/Container.Host.Port` | No |
 
 ## Viewing Deployment Status
 


### PR DESCRIPTION
Introduce a Marker enum on resources (starting with Volatile) that
plugins declare in create/update RPC responses. The DE uses this to
transition DESIRED deployments to a new UP state when all owned
resources are non-volatile, avoiding unnecessary reconciliation cycles.

- Proto: Add Marker enum and repeated markers field to Resource message
- sclc: Add Marker enum with Volatile variant, markers field on Resource
- RTP: Thread markers through encode/decode between proto and sclc types
- RDB: Add markers_json column, set_markers method
- RTE: Persist markers after create and update plugin calls
- CDB: Add Up variant to DeploymentState
- DE: Transition Desired → Up when complete with no volatile resources;
  accept Up as valid supersession terminus in Lingering handler
- Container plugin: Mark Pod and Container resources as Volatile
- API: Expose UP state and ResourceMarker enum in GraphQL schema
- Docs: Document Up state and volatile resources in deployments.md

https://claude.ai/code/session_018KDbkP5H252A7yYWNLQ3XG