### PR TITLE
feat: add volatile resource markers and UP deployment state

### DIFF
--- a/crates/api/schema.graphql
+++ b/crates/api/schema.graphql
@@ -14,6 +14,7 @@ enum DeploymentState {
 
 enum ResourceMarker {
   VOLATILE
+  STICKY
 }
 
 enum Severity {

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -705,12 +705,15 @@ impl From<cdb::DeploymentState> for DeploymentState {
 enum ResourceMarker {
     #[graphql(name = "VOLATILE")]
     Volatile,
+    #[graphql(name = "STICKY")]
+    Sticky,
 }
 
 impl From<sclc::Marker> for ResourceMarker {
     fn from(marker: sclc::Marker) -> Self {
         match marker {
             sclc::Marker::Volatile => ResourceMarker::Volatile,
+            sclc::Marker::Sticky => ResourceMarker::Sticky,
         }
     }
 }

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -323,8 +323,14 @@ impl Worker {
                     .collect::<Vec<_>>();
                 let mut emitted = 0usize;
                 let mut blocked = 0usize;
+                // Exclude dependencies from sticky resources owned by this
+                // deployment so they don't block teardown of their own deps.
                 let living_dependency_targets = all_resources
                     .iter()
+                    .filter(|resource| {
+                        !(resource.owner.as_deref() == Some(owner_deployment_qid.as_str())
+                            && resource.markers.contains(&sclc::Marker::Sticky))
+                    })
                     .flat_map(|resource| resource.dependencies.iter().cloned())
                     .collect::<HashSet<_>>();
 
@@ -333,6 +339,16 @@ impl Worker {
                         ty: resource.resource_type.clone(),
                         id: resource.id.clone(),
                     };
+
+                    if resource.markers.contains(&sclc::Marker::Sticky) {
+                        tracing::info!(
+                            resource_type = %resource.resource_type,
+                            resource_id = %resource.id,
+                            "sticky resource; skipping destroy",
+                        );
+                        continue;
+                    }
+
                     if living_dependency_targets.contains(&resource_id) {
                         blocked += 1;
                         tracing::info!(
@@ -364,8 +380,22 @@ impl Worker {
                     return Ok(());
                 }
 
-                if owned_resources.is_empty() {
-                    tracing::info!("{short_id} no more resources, setting state to DOWN");
+                let has_non_sticky = owned_resources
+                    .iter()
+                    .any(|r| !r.markers.contains(&sclc::Marker::Sticky));
+
+                if !has_non_sticky {
+                    for resource in &owned_resources {
+                        self.log_publisher
+                            .info(format!(
+                                "{}.{} will stick around",
+                                resource.resource_type, resource.id
+                            ))
+                            .await;
+                    }
+                    tracing::info!(
+                        "{short_id} no more non-sticky resources, setting state to DOWN"
+                    );
                     self.client.set(DeploymentState::Down).await?;
                     self.log_publisher
                         .info(format!("Undesired {short_id} is fully torn down"))

--- a/crates/rtp/proto/rtp.proto
+++ b/crates/rtp/proto/rtp.proto
@@ -34,6 +34,7 @@ message CreateResourceRequest {
 
 enum Marker {
   VOLATILE = 0;
+  STICKY = 1;
 }
 
 message Resource {

--- a/crates/rtp/src/lib.rs
+++ b/crates/rtp/src/lib.rs
@@ -649,12 +649,14 @@ impl PluginClient {
 fn encode_marker(marker: &sclc::Marker) -> i32 {
     match marker {
         sclc::Marker::Volatile => proto::Marker::Volatile as i32,
+        sclc::Marker::Sticky => proto::Marker::Sticky as i32,
     }
 }
 
 fn decode_marker(value: i32) -> Option<sclc::Marker> {
     match proto::Marker::try_from(value) {
         Ok(proto::Marker::Volatile) => Some(sclc::Marker::Volatile),
+        Ok(proto::Marker::Sticky) => Some(sclc::Marker::Sticky),
         Err(_) => None,
     }
 }

--- a/crates/sclc/src/resource.rs
+++ b/crates/sclc/src/resource.rs
@@ -15,6 +15,7 @@ pub struct ResourceId {
 )]
 pub enum Marker {
     Volatile,
+    Sticky,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -28,5 +29,9 @@ pub struct Resource {
 impl Resource {
     pub fn is_volatile(&self) -> bool {
         self.markers.contains(&Marker::Volatile)
+    }
+
+    pub fn is_sticky(&self) -> bool {
+        self.markers.contains(&Marker::Sticky)
     }
 }

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -192,6 +192,14 @@ The built-in resource types have the following volatility:
 | `Std/Container.Host` | No |
 | `Std/Container.Host.Port` | No |
 
+## Sticky Resources
+
+Resources can be marked as **sticky** by their plugin. A sticky resource is not destroyed when its owning deployment becomes Undesired — it persists as a tombstone even after the deployment transitions to Down.
+
+When a deployment is torn down, Skyr destroys all non-sticky owned resources as usual, but leaves sticky resources in place. The deployment transitions to Down once all its non-sticky resources have been cleaned up. The sticky resources remain in the resource database with their last owner, but since that deployment is Down, they are no longer actively reconciled or health-checked.
+
+A resource can be both sticky and volatile. While its deployment is active (Desired), a sticky+volatile resource is reconciled normally. Once the deployment becomes Undesired and transitions to Down, the resource persists but is no longer repaired if it disappears externally.
+
 ## Viewing Deployment Status
 
 Use the CLI to check on your deployments:


### PR DESCRIPTION
Introduce a Marker enum on resources (starting with Volatile) that
plugins declare in create/update RPC responses. The DE uses this to
transition DESIRED deployments to a new UP state when all owned
resources are non-volatile, avoiding unnecessary reconciliation cycles.

- Proto: Add Marker enum and repeated markers field to Resource message
- sclc: Add Marker enum with Volatile variant, markers field on Resource
- RTP: Thread markers through encode/decode between proto and sclc types
- RDB: Add markers_json column, set_markers method
- RTE: Persist markers after create and update plugin calls
- CDB: Add Up variant to DeploymentState
- DE: Transition Desired → Up when complete with no volatile resources;
  accept Up as valid supersession terminus in Lingering handler
- Container plugin: Mark Pod and Container resources as Volatile
- API: Expose UP state and ResourceMarker enum in GraphQL schema
- Docs: Document Up state and volatile resources in deployments.md

https://claude.ai/code/session_018KDbkP5H252A7yYWNLQ3XG