### PR TITLE
Add volatile resource health check via new Check RTQ message

### DIFF
--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -492,6 +492,7 @@ impl Worker {
         let mut eval =
             sclc::Eval::new::<DeploymentClient>(effects_tx, owner_deployment_qid.clone());
         let mut unowned_resource_owner_by_id = HashMap::new();
+        let mut volatile_resource_ids = HashSet::new();
         let mut resources = self.namespace.list_resources().await?;
         while let Some(resource) = resources.try_next().await? {
             let resource_id = sclc::ResourceId {
@@ -502,6 +503,9 @@ impl Worker {
                 && let Some(owner) = resource.owner.clone()
             {
                 unowned_resource_owner_by_id.insert(resource_id.clone(), owner);
+            }
+            if resource.markers.contains(&sclc::Marker::Volatile) {
+                volatile_resource_ids.insert(resource_id.clone());
             }
 
             eval.add_resource(
@@ -620,46 +624,72 @@ impl Worker {
                                 inputs,
                                 dependencies,
                             } => {
-                                let Some(from_owner_deployment_qid) =
+                                if let Some(from_owner_deployment_qid) =
                                     unowned_resource_owner_by_id.get(&id).cloned()
-                                else {
-                                    continue;
-                                };
-                                had_effect = true;
-                                let Some(desired_inputs) = serialize_inputs(&id, &inputs, "touch")
-                                else {
-                                    continue;
-                                };
-                                let message = rtq::Message::Adopt(rtq::AdoptMessage {
-                                    resource: resource_ref(&namespace_id, &id),
-                                    from_deployment_id: extract_deployment_id(
-                                        from_owner_deployment_qid,
-                                    ),
-                                    to_deployment_id: deployment_id.clone(),
-                                    desired_inputs,
-                                    dependencies: map_dependencies(&namespace_id, dependencies),
-                                });
-                                if let Err(error) = rtq_publisher.enqueue(&message).await {
-                                    tracing::error!(
-                                        error = %error,
-                                        "failed to publish touch adopt message",
+                                {
+                                    had_effect = true;
+                                    let Some(desired_inputs) =
+                                        serialize_inputs(&id, &inputs, "touch")
+                                    else {
+                                        continue;
+                                    };
+                                    let message = rtq::Message::Adopt(rtq::AdoptMessage {
+                                        resource: resource_ref(&namespace_id, &id),
+                                        from_deployment_id: extract_deployment_id(
+                                            from_owner_deployment_qid,
+                                        ),
+                                        to_deployment_id: deployment_id.clone(),
+                                        desired_inputs,
+                                        dependencies: map_dependencies(&namespace_id, dependencies),
+                                    });
+                                    if let Err(error) = rtq_publisher.enqueue(&message).await {
+                                        tracing::error!(
+                                            error = %error,
+                                            "failed to publish touch adopt message",
+                                        );
+
+                                        log_publisher
+                                            .error(format!(
+                                                "Failed to enqueue ADOPT {}.{}: {}",
+                                                id.ty, id.id, error
+                                            ))
+                                            .await;
+                                        continue;
+                                    }
+
+                                    tracing::info!(
+                                        resource_type = %id.ty,
+                                        resource_id = %id.id,
+                                        inputs = ?inputs,
+                                        "effect touch resource adopt",
                                     );
+                                } else if volatile_resource_ids.contains(&id) {
+                                    had_effect = true;
+                                    let message = rtq::Message::Check(rtq::CheckMessage {
+                                        resource: resource_ref(&namespace_id, &id),
+                                        deployment_id: deployment_id.clone(),
+                                    });
+                                    if let Err(error) = rtq_publisher.enqueue(&message).await {
+                                        tracing::error!(
+                                            error = %error,
+                                            "failed to publish touch check message",
+                                        );
 
-                                    log_publisher
-                                        .error(format!(
-                                            "Failed to enqueue ADOPT {}.{}: {}",
-                                            id.ty, id.id, error
-                                        ))
-                                        .await;
-                                    continue;
+                                        log_publisher
+                                            .error(format!(
+                                                "Failed to enqueue CHECK {}.{}: {}",
+                                                id.ty, id.id, error
+                                            ))
+                                            .await;
+                                        continue;
+                                    }
+
+                                    tracing::info!(
+                                        resource_type = %id.ty,
+                                        resource_id = %id.id,
+                                        "effect touch resource check",
+                                    );
                                 }
-
-                                tracing::info!(
-                                    resource_type = %id.ty,
-                                    resource_id = %id.id,
-                                    inputs = ?inputs,
-                                    "effect touch resource adopt",
-                                );
                             }
                         }
                     }

--- a/crates/rte/src/main.rs
+++ b/crates/rte/src/main.rs
@@ -195,6 +195,9 @@ async fn worker_loop_iteration(
         rtq::Message::Restore(message) => {
             handle_restore(message, &delivery, ctx).await?;
         }
+        rtq::Message::Check(message) => {
+            handle_check(message, &delivery, ctx).await?;
+        }
     }
 
     // Placeholder behavior until transition execution is implemented.
@@ -887,12 +890,183 @@ async fn handle_restore(
     Ok(())
 }
 
+async fn handle_check(
+    message: &rtq::CheckMessage,
+    delivery: &rtq::Delivery,
+    ctx: &WorkerContext,
+) -> anyhow::Result<()> {
+    let resource_client = ctx
+        .rdb_client
+        .namespace(message.resource.environment_qid.clone())
+        .resource(
+            message.resource.resource_type.clone(),
+            message.resource.resource_id.clone(),
+        );
+    let dep_qid = deployment_qid(&message.resource.environment_qid, &message.deployment_id);
+
+    let current = match resource_client.get().await {
+        Ok(Some(resource)) => {
+            if resource.owner.as_deref() != Some(dep_qid.as_str()) {
+                tracing::info!(
+                    environment_qid = %message.resource.environment_qid,
+                    resource_type = %message.resource.resource_type,
+                    resource_id = %message.resource.resource_id,
+                    message_owner = %dep_qid,
+                    current_owner = ?resource.owner,
+                    "dropping check for non-matching owner",
+                );
+                delivery.ack().await?;
+                return Ok(());
+            }
+            resource
+        }
+        Ok(None) => {
+            tracing::info!(
+                environment_qid = %message.resource.environment_qid,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "dropping check for missing resource",
+            );
+            delivery.ack().await?;
+            return Ok(());
+        }
+        Err(error) => {
+            tracing::warn!(
+                environment_qid = %message.resource.environment_qid,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                error = %error,
+                "failed to read resource state before check",
+            );
+            delivery.nack(false).await?;
+            return Ok(());
+        }
+    };
+
+    let inputs = match current.inputs {
+        Some(inputs) => inputs,
+        None => {
+            tracing::warn!(
+                environment_qid = %message.resource.environment_qid,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "missing current inputs for check",
+            );
+            delivery.nack(false).await?;
+            return Ok(());
+        }
+    };
+    let outputs = match current.outputs {
+        Some(outputs) => outputs,
+        None => {
+            tracing::warn!(
+                environment_qid = %message.resource.environment_qid,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                "missing current outputs for check",
+            );
+            delivery.nack(false).await?;
+            return Ok(());
+        }
+    };
+
+    let Some((plugin_name, mut plugin)) =
+        resolve_plugin(&message.resource.resource_type, &ctx.plugins)
+    else {
+        tracing::warn!(
+            environment_qid = %message.resource.environment_qid,
+            resource_type = %message.resource.resource_type,
+            "no plugin available for resource type on check",
+        );
+        delivery.nack(false).await?;
+        return Ok(());
+    };
+
+    let id = resource_id_from_ref(&message.resource);
+    let resource = sclc::Resource {
+        inputs,
+        outputs,
+        dependencies: current
+            .dependencies
+            .iter()
+            .map(|d| sclc::ResourceId {
+                ty: d.ty.clone(),
+                id: d.id.clone(),
+            })
+            .collect(),
+        markers: current.markers,
+    };
+
+    tracing::info!(
+        plugin = plugin_name,
+        environment_qid = %message.resource.environment_qid,
+        resource_type = %message.resource.resource_type,
+        resource_id = %message.resource.resource_id,
+        "calling plugin check",
+    );
+    let checked = match plugin
+        .check(
+            &message.resource.environment_qid,
+            &message.deployment_id,
+            id.clone(),
+            resource,
+        )
+        .await
+    {
+        Ok(resource) => resource,
+        Err(error) => {
+            tracing::warn!(
+                environment_qid = %message.resource.environment_qid,
+                resource_type = %message.resource.resource_type,
+                resource_id = %message.resource.resource_id,
+                error = %error,
+                "check plugin call failed",
+            );
+            delivery.nack(false).await?;
+            return Ok(());
+        }
+    };
+
+    if let Err(error) = resource_client.set_output(checked.outputs).await {
+        tracing::warn!(
+            environment_qid = %message.resource.environment_qid,
+            resource_type = %message.resource.resource_type,
+            resource_id = %message.resource.resource_id,
+            error = %error,
+            "failed to persist checked resource outputs",
+        );
+        delivery.nack(false).await?;
+        return Ok(());
+    }
+
+    tracing::info!(
+        environment_qid = %message.resource.environment_qid,
+        resource_type = %message.resource.resource_type,
+        resource_id = %message.resource.resource_id,
+        "checked resource",
+    );
+    log_deployment_event(
+        &ctx.ldb_publisher,
+        &dep_qid,
+        Severity::Info,
+        format!(
+            "Checked {}.{} for {}",
+            message.resource.resource_type,
+            message.resource.resource_id,
+            &message.deployment_id[..8]
+        ),
+    )
+    .await;
+    Ok(())
+}
+
 fn message_meta(message: &rtq::Message) -> (&'static str, &rtq::ResourceRef) {
     match message {
         rtq::Message::Create(msg) => ("CREATE", &msg.resource),
         rtq::Message::Destroy(msg) => ("DESTROY", &msg.resource),
         rtq::Message::Adopt(msg) => ("ADOPT", &msg.resource),
         rtq::Message::Restore(msg) => ("RESTORE", &msg.resource),
+        rtq::Message::Check(msg) => ("CHECK", &msg.resource),
     }
 }
 

--- a/crates/rtp/proto/rtp.proto
+++ b/crates/rtp/proto/rtp.proto
@@ -9,7 +9,7 @@ service ResourceTransitionPlugin {
   rpc CreateResource(CreateResourceRequest) returns (CreateResourceResponse);
   rpc UpdateResource(UpdateResourceRequest) returns (UpdateResourceResponse);
   rpc DeleteResource(DeleteResourceRequest) returns (google.protobuf.Empty);
-  rpc Health(HealthRequest) returns (HealthResponse);
+  rpc Check(CheckRequest) returns (CheckResponse);
 }
 
 message CapabilityRequest {
@@ -66,12 +66,12 @@ message DeleteResourceRequest {
   string deployment_id = 3;
 }
 
-message HealthRequest {
+message CheckRequest {
   Resource resource = 1;
   string environment_qid = 2;
   string deployment_id = 3;
 }
 
-message HealthResponse {
+message CheckResponse {
   Resource resource = 1;
 }

--- a/crates/rtp/src/lib.rs
+++ b/crates/rtp/src/lib.rs
@@ -14,8 +14,8 @@ pub mod proto {
 }
 
 use proto::{
-    CapabilityRequest, CapabilityResponse, CreateResourceRequest, CreateResourceResponse,
-    DeleteResourceRequest, HealthRequest, HealthResponse, Resource, UpdateResourceRequest,
+    CapabilityRequest, CapabilityResponse, CheckRequest, CheckResponse, CreateResourceRequest,
+    CreateResourceResponse, DeleteResourceRequest, Resource, UpdateResourceRequest,
     UpdateResourceResponse,
 };
 
@@ -54,7 +54,7 @@ pub trait Plugin: Send + Sync + 'static {
         Ok(())
     }
 
-    async fn health(
+    async fn check(
         &self,
         environment_qid: &str,
         deployment_id: &str,
@@ -443,16 +443,16 @@ where
         Ok(tonic::Response::new(()))
     }
 
-    async fn health(
+    async fn check(
         &self,
-        request: tonic::Request<HealthRequest>,
-    ) -> Result<tonic::Response<HealthResponse>, tonic::Status> {
+        request: tonic::Request<CheckRequest>,
+    ) -> Result<tonic::Response<CheckResponse>, tonic::Status> {
         self.ensure_peer_capabilities().await?;
 
         let request = request.into_inner();
         let resource = request
             .resource
-            .ok_or_else(|| tonic::Status::invalid_argument("missing health resource"))?;
+            .ok_or_else(|| tonic::Status::invalid_argument("missing check resource"))?;
         let id = sclc::ResourceId {
             ty: resource.r#type.clone(),
             id: resource.id.clone(),
@@ -460,8 +460,8 @@ where
         let parsed = decode_resource(resource)?;
 
         let plugin = self.plugin.read().await;
-        let healthy = plugin
-            .health(
+        let checked = plugin
+            .check(
                 &request.environment_qid,
                 &request.deployment_id,
                 id.clone(),
@@ -473,13 +473,13 @@ where
                     resource_type = id.ty.as_str(),
                     resource_id = id.id.as_str(),
                     err = %error,
-                    "plugin health failed"
+                    "plugin check failed"
                 );
                 tonic::Status::internal(error.to_string())
             })?;
 
-        Ok(tonic::Response::new(HealthResponse {
-            resource: Some(encode_resource(id, healthy)?),
+        Ok(tonic::Response::new(CheckResponse {
+            resource: Some(encode_resource(id, checked)?),
         }))
     }
 }
@@ -623,7 +623,7 @@ impl PluginClient {
         Ok(())
     }
 
-    pub async fn health(
+    pub async fn check(
         &mut self,
         environment_qid: &str,
         deployment_id: &str,
@@ -632,7 +632,7 @@ impl PluginClient {
     ) -> anyhow::Result<sclc::Resource> {
         let response = self
             .inner
-            .health(HealthRequest {
+            .check(CheckRequest {
                 resource: Some(encode_resource(id, resource)?),
                 environment_qid: environment_qid.to_string(),
                 deployment_id: deployment_id.to_string(),
@@ -641,7 +641,7 @@ impl PluginClient {
             .into_inner();
         let resource = response
             .resource
-            .context("missing resource in health response")?;
+            .context("missing resource in check response")?;
         decode_resource(resource).map_err(Into::into)
     }
 }

--- a/crates/rtq/src/lib.rs
+++ b/crates/rtq/src/lib.rs
@@ -25,6 +25,7 @@ pub enum Message {
     Restore(RestoreMessage),
     Adopt(AdoptMessage),
     Destroy(DestroyMessage),
+    Check(CheckMessage),
 }
 
 impl Message {
@@ -42,6 +43,7 @@ impl Message {
             Message::Restore(msg) => &msg.resource,
             Message::Adopt(msg) => &msg.resource,
             Message::Destroy(msg) => &msg.resource,
+            Message::Check(msg) => &msg.resource,
         }
     }
 }
@@ -89,6 +91,12 @@ pub struct AdoptMessage {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DestroyMessage {
+    pub resource: ResourceRef,
+    pub deployment_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckMessage {
     pub resource: ResourceRef,
     pub deployment_id: String,
 }


### PR DESCRIPTION
When a Touch effect fires for a volatile resource that is already owned
by the executing deployment, emit a Check RTQ message instead of
silently skipping it. The RTE handles Check by forwarding to the RTP
plugin's Check RPC (renamed from Health), which returns up-to-date
outputs that are then persisted to the RDB.

Changes:
- rtq: Add Check(CheckMessage) variant to the Message enum
- de: Track volatile resource IDs during evaluation setup; emit Check
  for owned volatile resources on Touch, Adopt for unowned resources
- rtp proto: Rename Health RPC to Check (HealthRequest/Response →
  CheckRequest/Response)
- rtp lib: Rename Plugin::health → Plugin::check, update server and
  client implementations accordingly
- rte: Add handle_check that reads resource state from RDB, calls
  plugin check, and persists the returned outputs

https://claude.ai/code/session_01As85sTGDzS7HP8ZGorcqZp