### PR TITLE
Add Std/Time standard library module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5290,6 +5290,7 @@ name = "sclc"
 version = "0.1.0"
 dependencies = [
  "cdb",
+ "chrono",
  "ordered-float",
  "peg",
  "serde",

--- a/crates/sclc/Cargo.toml
+++ b/crates/sclc/Cargo.toml
@@ -12,6 +12,7 @@ unicode-segmentation = "1.12.0"
 peg = "0.8.4"
 tokio = { version = "1.49.0", features = ["sync"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
+chrono = "0.4.44"
 
 [lints]
 workspace = true

--- a/crates/sclc/src/std/Time.scl
+++ b/crates/sclc/src/std/Time.scl
@@ -1,0 +1,30 @@
+export type Instant {
+    epochMillis: Int,
+}
+
+export type CalendarDate {
+    year: Int,
+    month: Int,
+    day: Int,
+}
+
+export type ClockTime {
+    hour: Int,
+    minute: Int,
+    second: Int,
+}
+
+export type DateTime {
+    date: CalendarDate,
+    time: ClockTime,
+}
+
+export type Duration {
+    milliseconds: Int?,
+    months: Int?,
+}
+
+export let toISO = extern "Std/Time.toISO": fn(Instant) Str
+export let utc = extern "Std/Time.utc": fn(Instant) DateTime
+export let add = extern "Std/Time.add": fn(Instant, Duration) Instant
+export let subtract = extern "Std/Time.subtract": fn(Instant, Duration) Instant

--- a/crates/sclc/src/std/mod.rs
+++ b/crates/sclc/src/std/mod.rs
@@ -33,6 +33,7 @@ std_modules! {
     num => "Num.scl",
     option => "Option.scl",
     random => "Random.scl",
+    time => "Time.scl",
 }
 
 #[derive(Clone)]

--- a/crates/sclc/src/std/time.rs
+++ b/crates/sclc/src/std/time.rs
@@ -1,0 +1,156 @@
+use chrono::{DateTime, Datelike, Months, Timelike};
+
+use crate::{EvalErrorKind, Record, Value, ValueAssertions};
+
+pub fn register_extern(eval: &mut crate::Eval) {
+    eval.add_extern_fn("Std/Time.toISO", |args, _ctx| {
+        let mut args = args.into_iter();
+        let first = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        first.try_map(|value| {
+            let record = value.assert_record()?;
+            let epoch_millis = *record.get("epochMillis").assert_int_ref()?;
+            let dt = parse_instant(epoch_millis)?;
+            Ok(Value::Str(dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()))
+        })
+    });
+
+    eval.add_extern_fn("Std/Time.utc", |args, _ctx| {
+        let mut args = args.into_iter();
+        let first = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        first.try_map(|value| {
+            let record = value.assert_record()?;
+            let epoch_millis = *record.get("epochMillis").assert_int_ref()?;
+            let dt = parse_instant(epoch_millis)?;
+
+            let mut date = Record::default();
+            date.insert("year".into(), Value::Int(dt.year() as i64));
+            date.insert("month".into(), Value::Int(dt.month() as i64));
+            date.insert("day".into(), Value::Int(dt.day() as i64));
+
+            let mut time = Record::default();
+            time.insert("hour".into(), Value::Int(dt.hour() as i64));
+            time.insert("minute".into(), Value::Int(dt.minute() as i64));
+            time.insert("second".into(), Value::Int(dt.second() as i64));
+
+            let mut datetime = Record::default();
+            datetime.insert("date".into(), Value::Record(date));
+            datetime.insert("time".into(), Value::Record(time));
+
+            Ok(Value::Record(datetime))
+        })
+    });
+
+    eval.add_extern_fn("Std/Time.add", |args, _ctx| {
+        let mut args = args.into_iter();
+        let instant_arg = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+        let duration_arg = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        let deps = instant_arg
+            .dependencies
+            .union(&duration_arg.dependencies)
+            .cloned()
+            .collect();
+
+        let instant = instant_arg.value.assert_record()?;
+        let duration = duration_arg.value.assert_record()?;
+        let epoch_millis = *instant.get("epochMillis").assert_int_ref()?;
+        let dt = parse_instant(epoch_millis)?;
+
+        let dt = apply_duration(dt, &duration, 1)?;
+
+        let mut result = Record::default();
+        result.insert("epochMillis".into(), Value::Int(dt.timestamp_millis()));
+        Ok(crate::TrackedValue::new(Value::Record(result)).with_dependencies(deps))
+    });
+
+    eval.add_extern_fn("Std/Time.subtract", |args, _ctx| {
+        let mut args = args.into_iter();
+        let instant_arg = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+        let duration_arg = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        let deps = instant_arg
+            .dependencies
+            .union(&duration_arg.dependencies)
+            .cloned()
+            .collect();
+
+        let instant = instant_arg.value.assert_record()?;
+        let duration = duration_arg.value.assert_record()?;
+        let epoch_millis = *instant.get("epochMillis").assert_int_ref()?;
+        let dt = parse_instant(epoch_millis)?;
+
+        let dt = apply_duration(dt, &duration, -1)?;
+
+        let mut result = Record::default();
+        result.insert("epochMillis".into(), Value::Int(dt.timestamp_millis()));
+        Ok(crate::TrackedValue::new(Value::Record(result)).with_dependencies(deps))
+    });
+}
+
+fn parse_instant(epoch_millis: i64) -> Result<DateTime<chrono::Utc>, crate::EvalError> {
+    DateTime::from_timestamp_millis(epoch_millis).ok_or_else(|| {
+        EvalErrorKind::Custom(format!("epoch millis {epoch_millis} is out of range")).into()
+    })
+}
+
+/// Apply a Duration to a DateTime. `sign` is 1 for add, -1 for subtract.
+fn apply_duration(
+    mut dt: DateTime<chrono::Utc>,
+    duration: &Record,
+    sign: i64,
+) -> Result<DateTime<chrono::Utc>, crate::EvalError> {
+    // Months (big-to-small: apply months first)
+    let months_val = duration.get("months");
+    if !matches!(months_val, Value::Nil) {
+        let months = *months_val.assert_int_ref()?;
+        let effective = months * sign;
+        if effective >= 0 {
+            dt = dt
+                .checked_add_months(Months::new(effective as u32))
+                .ok_or_else(|| {
+                    EvalErrorKind::Custom(format!(
+                        "adding {effective} months would overflow the date"
+                    ))
+                })?;
+        } else {
+            dt = dt
+                .checked_sub_months(Months::new(effective.unsigned_abs() as u32))
+                .ok_or_else(|| {
+                    EvalErrorKind::Custom(format!(
+                        "subtracting {} months would overflow the date",
+                        effective.unsigned_abs()
+                    ))
+                })?;
+        }
+    }
+
+    // Milliseconds
+    let ms_val = duration.get("milliseconds");
+    if !matches!(ms_val, Value::Nil) {
+        let ms = *ms_val.assert_int_ref()?;
+        let effective = ms * sign;
+        dt = dt
+            .checked_add_signed(chrono::Duration::milliseconds(effective))
+            .ok_or_else(|| {
+                EvalErrorKind::Custom(format!(
+                    "adding {effective} milliseconds would overflow the date"
+                ))
+            })?;
+    }
+
+    Ok(dt)
+}

--- a/docs/scl/stdlib.md
+++ b/docs/scl/stdlib.md
@@ -641,6 +641,37 @@ let big = Num.toHex(65535) // "ffff"
 
 Returns lowercase hexadecimal without prefix.
 
+## Std/Time
+
+Time utilities.
+
+### Instant
+
+A point in time, represented as milliseconds since the Unix epoch:
+
+```scl
+import Std/Time
+
+let t: Time.Instant = { epochMillis: 1700000000000 }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epochMillis` | `Int` | Milliseconds since 1970-01-01T00:00:00Z |
+
+### toISO
+
+Format an `Instant` as a UTC ISO 8601 string with second precision:
+
+```scl
+let iso = Time.toISO({ epochMillis: 1700000000000 })
+// "2023-11-14T22:13:20Z"
+```
+
+**Type:** `fn(Instant) Str`
+
+Returns a string in the format `YYYY-MM-DDTHH:MM:SSZ`.
+
 ## Using Multiple Modules
 
 Combine modules for more complex configurations:


### PR DESCRIPTION
Introduces a new SCL standard library module `Std/Time` with types and
functions for working with points in time:

Types:
- Instant { epochMillis: Int } — a point in time as milliseconds since
  the Unix epoch
- CalendarDate { year, month, day }
- ClockTime { hour, minute, second }
- DateTime { date: CalendarDate, time: ClockTime }
- Duration { milliseconds: Int?, months: Int? }

Functions:
- toISO(Instant) Str — formats an instant as a UTC ISO 8601 string
- utc(Instant) DateTime — decomposes an instant into calendar date and
  clock time components in UTC
- add(Instant, Duration) Instant — moves an instant forward by a
  duration (months first, then milliseconds; negative values move
  backward)
- subtract(Instant, Duration) Instant — moves an instant backward by a
  duration (months first, then milliseconds; negative values move
  forward)

The Rust implementation uses chrono for all date/time arithmetic,
including month-aware addition/subtraction via chrono::Months.

https://claude.ai/code/session_01W7q1MTgCa8XXm9UobDSPYs