### PR TITLE
Add Std/Crypto.CertificationRequest resource for PKCS#10 CSRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,6 +4193,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "const-oid 0.9.6",
+ "der 0.7.10",
  "ed25519-dalek",
  "p256 0.13.2",
  "p384",
@@ -4202,10 +4204,13 @@ dependencies = [
  "rsa 0.9.10",
  "rtp",
  "sclc",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "spki 0.7.3",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "x509-cert",
 ]
 
 [[package]]
@@ -4922,6 +4927,7 @@ dependencies = [
  "pkcs1 0.7.5",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -7179,7 +7185,10 @@ checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
+ "sha1 0.10.6",
+ "signature 2.2.0",
  "spki 0.7.3",
+ "tls_codec",
 ]
 
 [[package]]

--- a/crates/plugin_std_crypto/Cargo.toml
+++ b/crates/plugin_std_crypto/Cargo.toml
@@ -11,19 +11,24 @@ path = "src/main.rs"
 anyhow = "1.0.102"
 async-trait = "0.1.89"
 clap = { version = "4.5.48", features = ["derive"] }
+const-oid = { version = "0.9", features = ["db"] }
+der = { version = "0.7", features = ["pem", "flagset"] }
 ed25519-dalek = { version = "2", features = ["pkcs8", "pem", "rand_core"] }
-p256 = { version = "0.13", features = ["pkcs8", "pem"] }
-p384 = { version = "0.13", features = ["pkcs8", "pem"] }
-p521 = { version = "0.13", features = ["pkcs8", "pem"] }
+p256 = { version = "0.13", features = ["pkcs8", "pem", "ecdsa"] }
+p384 = { version = "0.13", features = ["pkcs8", "pem", "ecdsa"] }
+p521 = { version = "0.13", features = ["pkcs8", "pem", "ecdsa"] }
 pkcs8 = { version = "0.10", features = ["pem"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
-rsa = { version = "0.9", features = ["pem"] }
+rsa = { version = "0.9", features = ["pem", "sha2"] }
 rtp = { path = "../rtp" }
 sclc = { path = "../sclc" }
+sha2 = "0.10"
+signature = "2"
 spki = { version = "0.7", features = ["pem"] }
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
+x509-cert = { version = "0.2", features = ["builder", "pem"] }
 
 [lints]
 workspace = true

--- a/crates/plugin_std_crypto/src/main.rs
+++ b/crates/plugin_std_crypto/src/main.rs
@@ -5,6 +5,7 @@ use tracing::info;
 const ED25519_RESOURCE_TYPE: &str = "Std/Crypto.ED25519PrivateKey";
 const ECDSA_RESOURCE_TYPE: &str = "Std/Crypto.ECDSAPrivateKey";
 const RSA_RESOURCE_TYPE: &str = "Std/Crypto.RSAPrivateKey";
+const CSR_RESOURCE_TYPE: &str = "Std/Crypto.CertificationRequest";
 
 #[derive(Parser)]
 struct Args {
@@ -24,6 +25,10 @@ impl CryptoPlugin {
         id: &sclc::ResourceId,
         inputs: sclc::Record,
     ) -> anyhow::Result<sclc::Resource> {
+        if id.ty == CSR_RESOURCE_TYPE {
+            return self.dispatch_csr(id, inputs).await;
+        }
+
         let (private_pem, public_pem) = match id.ty.as_str() {
             ED25519_RESOURCE_TYPE => generate_ed25519()?,
             ECDSA_RESOURCE_TYPE => {
@@ -49,6 +54,31 @@ impl CryptoPlugin {
         let mut outputs = sclc::Record::default();
         outputs.insert(String::from("pem"), sclc::Value::Str(private_pem));
         outputs.insert(String::from("publicKeyPem"), sclc::Value::Str(public_pem));
+
+        Ok(sclc::Resource {
+            inputs,
+            outputs,
+            dependencies: vec![],
+            markers: Default::default(),
+        })
+    }
+
+    async fn dispatch_csr(
+        &self,
+        id: &sclc::ResourceId,
+        inputs: sclc::Record,
+    ) -> anyhow::Result<sclc::Resource> {
+        let inputs_clone = inputs.clone();
+        let csr_pem = tokio::task::spawn_blocking(move || generate_csr(&inputs_clone)).await??;
+
+        info!(
+            resource_type = id.ty.as_str(),
+            resource_id = id.id.as_str(),
+            "generated certification request"
+        );
+
+        let mut outputs = sclc::Record::default();
+        outputs.insert(String::from("pem"), sclc::Value::Str(csr_pem));
 
         Ok(sclc::Resource {
             inputs,
@@ -111,6 +141,238 @@ fn generate_rsa(size: usize) -> anyhow::Result<(String, String)> {
         .to_public_key_pem(pkcs8::LineEnding::LF)?;
 
     Ok((private_pem, public_pem))
+}
+
+/// Build a CSR using the given signer, subject name, and inputs (for extensions).
+///
+/// Uses the higher-level `build` API for signers whose signature type implements
+/// `SignatureBitStringEncoding` (ECDSA, RSA).
+fn build_and_sign_csr<S, Sig>(
+    signer: &S,
+    name: x509_cert::name::Name,
+    inputs: &sclc::Record,
+) -> anyhow::Result<String>
+where
+    S: signature::Keypair + spki::DynSignatureAlgorithmIdentifier + signature::Signer<Sig>,
+    S::VerifyingKey: spki::EncodePublicKey,
+    Sig: spki::SignatureBitStringEncoding,
+{
+    use der::EncodePem;
+    use x509_cert::builder::{Builder, RequestBuilder};
+
+    let mut builder = RequestBuilder::new(name, signer)?;
+    add_csr_extensions(&mut builder, inputs)?;
+    let csr = builder.build::<Sig>()?;
+    Ok(csr.to_pem(der::pem::LineEnding::LF)?)
+}
+
+/// Build a CSR using an Ed25519 signer.
+///
+/// Ed25519 signatures don't implement `SignatureBitStringEncoding`, so we use
+/// the lower-level `finalize`/`assemble` API from the `Builder` trait.
+fn build_and_sign_csr_ed25519(
+    signer: &ed25519_dalek::SigningKey,
+    name: x509_cert::name::Name,
+    inputs: &sclc::Record,
+) -> anyhow::Result<String> {
+    use der::EncodePem;
+    use signature::Signer;
+    use x509_cert::builder::{Builder, RequestBuilder};
+
+    let mut builder = RequestBuilder::new(name, signer)?;
+    add_csr_extensions(&mut builder, inputs)?;
+
+    let blob = builder.finalize()?;
+    let sig: ed25519_dalek::Signature = signer.sign(&blob);
+    let bit_string = der::asn1::BitString::from_bytes(&sig.to_bytes())?;
+    let csr = builder.assemble(bit_string)?;
+    Ok(csr.to_pem(der::pem::LineEnding::LF)?)
+}
+
+fn generate_csr(inputs: &sclc::Record) -> anyhow::Result<String> {
+    use pkcs8::DecodePrivateKey;
+
+    let private_key_pem = inputs.get("privateKeyPem").assert_str_ref()?;
+    let subject = inputs.get("subject").assert_record_ref()?;
+    let name = build_subject_name(subject)?;
+
+    // Try Ed25519
+    if let Ok(signing_key) = ed25519_dalek::SigningKey::from_pkcs8_pem(private_key_pem) {
+        return build_and_sign_csr_ed25519(&signing_key, name, inputs);
+    }
+
+    // Try ECDSA P-256
+    if let Ok(secret_key) = p256::SecretKey::from_pkcs8_pem(private_key_pem) {
+        let signing_key = p256::ecdsa::SigningKey::from(secret_key);
+        return build_and_sign_csr::<_, p256::ecdsa::DerSignature>(&signing_key, name, inputs);
+    }
+
+    // Try ECDSA P-384
+    if let Ok(secret_key) = p384::SecretKey::from_pkcs8_pem(private_key_pem) {
+        let signing_key = p384::ecdsa::SigningKey::from(secret_key);
+        return build_and_sign_csr::<_, p384::ecdsa::DerSignature>(&signing_key, name, inputs);
+    }
+
+    // P-521 key detection: fail with a clear message since the p521 crate doesn't
+    // yet support the traits required by the x509-cert builder.
+    if p521::SecretKey::from_pkcs8_pem(private_key_pem).is_ok() {
+        anyhow::bail!("P-521 keys are not yet supported for certification requests");
+    }
+
+    // Try RSA
+    if let Ok(private_key) = rsa::RsaPrivateKey::from_pkcs8_pem(private_key_pem) {
+        let signing_key = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(private_key);
+        return build_and_sign_csr::<_, rsa::pkcs1v15::Signature>(&signing_key, name, inputs);
+    }
+
+    anyhow::bail!("unsupported private key type in PEM")
+}
+
+fn build_subject_name(subject: &sclc::Record) -> anyhow::Result<x509_cert::name::Name> {
+    let cn = subject.get("commonName").assert_str_ref()?;
+
+    // Build RFC 4514 distinguished name string, most-specific-first
+    let mut parts = vec![format!("CN={}", rfc4514_escape(cn))];
+
+    if let Ok(ou) = subject.get("organizationalUnit").assert_str_ref() {
+        parts.push(format!("OU={}", rfc4514_escape(ou)));
+    }
+    if let Ok(o) = subject.get("organization").assert_str_ref() {
+        parts.push(format!("O={}", rfc4514_escape(o)));
+    }
+    if let Ok(l) = subject.get("locality").assert_str_ref() {
+        parts.push(format!("L={}", rfc4514_escape(l)));
+    }
+    if let Ok(st) = subject.get("state").assert_str_ref() {
+        parts.push(format!("ST={}", rfc4514_escape(st)));
+    }
+    if let Ok(c) = subject.get("country").assert_str_ref() {
+        parts.push(format!("C={}", rfc4514_escape(c)));
+    }
+
+    let dn_string = parts.join(",");
+    dn_string
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid distinguished name: {e}"))
+}
+
+fn rfc4514_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for (i, c) in s.chars().enumerate() {
+        match c {
+            '"' | '+' | ',' | ';' | '<' | '>' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            '#' if i == 0 => {
+                out.push('\\');
+                out.push(c);
+            }
+            ' ' if i == 0 || i == s.len() - 1 => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn add_csr_extensions<S>(
+    builder: &mut x509_cert::builder::RequestBuilder<'_, S>,
+    inputs: &sclc::Record,
+) -> anyhow::Result<()>
+where
+    S: signature::Keypair + spki::DynSignatureAlgorithmIdentifier,
+    S::VerifyingKey: spki::EncodePublicKey,
+{
+    use x509_cert::ext::pkix::{KeyUsage, KeyUsages};
+
+    // Subject Alternative Names
+    if let sclc::Value::List(sans) = inputs.get("subjectAlternativeNames") {
+        let mut general_names = vec![];
+        for san_value in sans {
+            let san = san_value.assert_str_ref()?;
+            let general_name = parse_san(san)?;
+            general_names.push(general_name);
+        }
+        if !general_names.is_empty() {
+            let san_ext = x509_cert::ext::pkix::SubjectAltName(general_names);
+            builder
+                .add_extension(&san_ext)
+                .map_err(|e| anyhow::anyhow!("failed to add SAN extension: {e}"))?;
+        }
+    }
+
+    // Key Usage
+    if let sclc::Value::List(usages) = inputs.get("keyUsage") {
+        let mut ku: der::flagset::FlagSet<KeyUsages> = None.into();
+        for usage_value in usages {
+            let usage = usage_value.assert_str_ref()?;
+            ku |= match usage {
+                "digitalSignature" => KeyUsages::DigitalSignature,
+                "nonRepudiation" | "contentCommitment" => KeyUsages::NonRepudiation,
+                "keyEncipherment" => KeyUsages::KeyEncipherment,
+                "dataEncipherment" => KeyUsages::DataEncipherment,
+                "keyAgreement" => KeyUsages::KeyAgreement,
+                "keyCertSign" => KeyUsages::KeyCertSign,
+                "cRLSign" => KeyUsages::CRLSign,
+                "encipherOnly" => KeyUsages::EncipherOnly,
+                "decipherOnly" => KeyUsages::DecipherOnly,
+                _ => anyhow::bail!("unsupported key usage: {usage}"),
+            };
+        }
+        builder
+            .add_extension(&KeyUsage(ku))
+            .map_err(|e| anyhow::anyhow!("failed to add KeyUsage extension: {e}"))?;
+    }
+
+    // Extended Key Usage
+    if let sclc::Value::List(usages) = inputs.get("extendedKeyUsage") {
+        let mut eku_oids = vec![];
+        for usage_value in usages {
+            let usage = usage_value.assert_str_ref()?;
+            let oid = match usage {
+                "serverAuth" => const_oid::db::rfc5280::ID_KP_SERVER_AUTH,
+                "clientAuth" => const_oid::db::rfc5280::ID_KP_CLIENT_AUTH,
+                "codeSigning" => const_oid::db::rfc5280::ID_KP_CODE_SIGNING,
+                "emailProtection" => const_oid::db::rfc5280::ID_KP_EMAIL_PROTECTION,
+                "timeStamping" => const_oid::db::rfc5280::ID_KP_TIME_STAMPING,
+                "ocspSigning" => const_oid::db::rfc5280::ID_KP_OCSP_SIGNING,
+                _ => anyhow::bail!("unsupported extended key usage: {usage}"),
+            };
+            eku_oids.push(oid);
+        }
+        if !eku_oids.is_empty() {
+            let eku = x509_cert::ext::pkix::ExtendedKeyUsage(eku_oids);
+            builder
+                .add_extension(&eku)
+                .map_err(|e| anyhow::anyhow!("failed to add ExtendedKeyUsage extension: {e}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_san(san: &str) -> anyhow::Result<x509_cert::ext::pkix::name::GeneralName> {
+    use x509_cert::ext::pkix::name::GeneralName;
+
+    // Try parsing as IP address
+    if let Ok(ip) = san.parse::<std::net::IpAddr>() {
+        let bytes = match ip {
+            std::net::IpAddr::V4(v4) => v4.octets().to_vec(),
+            std::net::IpAddr::V6(v6) => v6.octets().to_vec(),
+        };
+        return Ok(GeneralName::IpAddress(der::asn1::OctetString::new(bytes)?));
+    }
+
+    // Check for email (contains @)
+    if san.contains('@') {
+        return Ok(GeneralName::Rfc822Name(der::asn1::Ia5String::new(san)?));
+    }
+
+    // Default: DNS name
+    Ok(GeneralName::DnsName(der::asn1::Ia5String::new(san)?))
 }
 
 #[async_trait::async_trait]

--- a/crates/sclc/src/std/Crypto.scl
+++ b/crates/sclc/src/std/Crypto.scl
@@ -20,3 +20,20 @@ export let RSAPrivateKey = extern "Std/Crypto.RSAPrivateKey": fn({
     pem: Str,
     publicKeyPem: Str,
 }
+
+export let CertificationRequest = extern "Std/Crypto.CertificationRequest": fn({
+    privateKeyPem: Str,
+    subject: {
+        commonName: Str,
+        organization: Str?,
+        organizationalUnit: Str?,
+        country: Str?,
+        state: Str?,
+        locality: Str?,
+    },
+    subjectAlternativeNames: [Str]?,
+    keyUsage: [Str]?,
+    extendedKeyUsage: [Str]?,
+}) {
+    pem: Str,
+}

--- a/crates/sclc/src/std/crypto.rs
+++ b/crates/sclc/src/std/crypto.rs
@@ -1,6 +1,7 @@
 const ED25519_RESOURCE_TYPE: &str = "Std/Crypto.ED25519PrivateKey";
 const ECDSA_RESOURCE_TYPE: &str = "Std/Crypto.ECDSAPrivateKey";
 const RSA_RESOURCE_TYPE: &str = "Std/Crypto.RSAPrivateKey";
+const CSR_RESOURCE_TYPE: &str = "Std/Crypto.CertificationRequest";
 
 fn extract_key_outputs(
     outputs: &crate::Record,
@@ -93,6 +94,86 @@ pub fn register_extern(eval: &mut crate::Eval) {
         };
 
         let out = extract_key_outputs(&outputs)?;
+        argument_dependencies.insert(resource_id);
+        Ok(crate::TrackedValue::new(crate::Value::Record(out))
+            .with_dependencies(argument_dependencies))
+    });
+
+    eval.add_extern_fn(CSR_RESOURCE_TYPE, |args, eval_ctx| {
+        use crate::ValueAssertions;
+        let mut args = args.into_iter();
+        let config_arg = args
+            .next()
+            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
+        let mut argument_dependencies = config_arg.dependencies.clone();
+
+        let config = config_arg.value.assert_record()?;
+        let private_key_pem = config.get("privateKeyPem").assert_str_ref()?;
+        let subject = config.get("subject").assert_record_ref()?;
+
+        let common_name = subject.get("commonName").assert_str_ref()?;
+
+        let mut subject_record = crate::Record::default();
+        subject_record.insert(
+            String::from("commonName"),
+            crate::Value::Str(common_name.to_owned()),
+        );
+        for field in [
+            "organization",
+            "organizationalUnit",
+            "country",
+            "state",
+            "locality",
+        ] {
+            subject_record.insert(String::from(field), subject.get(field).clone());
+        }
+
+        let mut inputs = crate::Record::default();
+        inputs.insert(
+            String::from("privateKeyPem"),
+            crate::Value::Str(private_key_pem.to_owned()),
+        );
+        inputs.insert(
+            String::from("subject"),
+            crate::Value::Record(subject_record),
+        );
+        inputs.insert(
+            String::from("subjectAlternativeNames"),
+            config.get("subjectAlternativeNames").clone(),
+        );
+        inputs.insert(
+            String::from("keyUsage"),
+            config.get("keyUsage").clone(),
+        );
+        inputs.insert(
+            String::from("extendedKeyUsage"),
+            config.get("extendedKeyUsage").clone(),
+        );
+
+        let mut hasher = std::hash::DefaultHasher::new();
+        std::hash::Hash::hash(&format!("{:?}", inputs), &mut hasher);
+        let id = format!("{:x}", std::hash::Hasher::finish(&hasher));
+
+        let resource_id = crate::ResourceId {
+            ty: CSR_RESOURCE_TYPE.to_owned(),
+            id: id.clone(),
+        };
+
+        let Some(outputs) = eval_ctx.resource(
+            CSR_RESOURCE_TYPE,
+            &id,
+            &inputs,
+            argument_dependencies.clone(),
+        )?
+        else {
+            argument_dependencies.insert(resource_id);
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        };
+
+        let pem = outputs.get("pem").assert_str_ref()?;
+        let mut out = crate::Record::default();
+        out.insert(String::from("pem"), crate::Value::Str(pem.to_owned()));
+
         argument_dependencies.insert(resource_id);
         Ok(crate::TrackedValue::new(crate::Value::Record(out))
             .with_dependencies(argument_dependencies))

--- a/docs/scl/stdlib.md
+++ b/docs/scl/stdlib.md
@@ -394,6 +394,55 @@ let key = Crypto.RSAPrivateKey({
 | `pem` | `Str` | Private key in PKCS#8 PEM format |
 | `publicKeyPem` | `Str` | Public key in SPKI PEM format |
 
+### CertificationRequest
+
+Generate a PKCS#10 Certificate Signing Request (CSR) from an existing private key:
+
+```scl
+let key = Crypto.ECDSAPrivateKey({ name: "tls-key", curve: "P-256" })
+
+let csr = Crypto.CertificationRequest({
+    privateKeyPem: key.pem,
+    subject: {
+        commonName: "example.com",
+        organization: "My Corp",
+        country: "US",
+    },
+    subjectAlternativeNames: ["example.com", "*.example.com", "192.168.1.1"],
+    keyUsage: ["digitalSignature", "keyEncipherment"],
+    extendedKeyUsage: ["serverAuth", "clientAuth"],
+})
+```
+
+The resource is identified by a hash of its inputs rather than an explicit name, so changing any input produces a new CSR.
+
+**Inputs:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `privateKeyPem` | `Str` | Private key PEM (from any `*PrivateKey` resource) |
+| `subject.commonName` | `Str` | Common Name (CN) |
+| `subject.organization` | `Str?` | Organization (O) |
+| `subject.organizationalUnit` | `Str?` | Organizational Unit (OU) |
+| `subject.country` | `Str?` | Country (C) |
+| `subject.state` | `Str?` | State or Province (ST) |
+| `subject.locality` | `Str?` | Locality (L) |
+| `subjectAlternativeNames` | `[Str]?` | SANs — auto-detected as DNS, IP, or email |
+| `keyUsage` | `[Str]?` | Key usage flags (e.g. `"digitalSignature"`, `"keyEncipherment"`) |
+| `extendedKeyUsage` | `[Str]?` | Extended key usage OIDs (e.g. `"serverAuth"`, `"clientAuth"`) |
+
+**Supported `keyUsage` values:** `digitalSignature`, `nonRepudiation`, `contentCommitment`, `keyEncipherment`, `dataEncipherment`, `keyAgreement`, `keyCertSign`, `cRLSign`, `encipherOnly`, `decipherOnly`
+
+**Supported `extendedKeyUsage` values:** `serverAuth`, `clientAuth`, `codeSigning`, `emailProtection`, `timeStamping`, `ocspSigning`
+
+**Outputs:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pem` | `Str` | Signed CSR in PEM format |
+
+> **Note:** P-521 keys are not currently supported for certification requests.
+
 ## Std/Encoding
 
 Serialize and deserialize data.


### PR DESCRIPTION
Adds a new CertificationRequest resource to the Std/Crypto module that
generates PKCS#10 Certificate Signing Requests. The resource accepts a
private key PEM (from any existing key resource), subject DN fields,
SANs, key usage, and extended key usage, and returns a signed CSR PEM.

Supports Ed25519, ECDSA P-256/P-384, and RSA keys. The resource ID is
derived from a hash of the inputs rather than an explicit name field.

https://claude.ai/code/session_016W4tCb57exjX7zij4Tnh4w