### PR TITLE
Fix REPL type imports by populating type-level bindings

### DIFF
--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -372,11 +372,18 @@ impl Repl {
         let eval_env = sclc::EvalEnv::new().with_module_id(&import_path);
         let value = self.eval.eval_file_mod(&eval_env, &file_mod)?;
 
-        helper
-            .state
-            .borrow_mut()
-            .bindings
-            .insert(alias, (ty, value));
+        // Extract type-level exports so that imported types are available in subsequent lines.
+        let type_exports = checker
+            .type_level_exports(&type_env, &file_mod)
+            .into_inner();
+
+        let mut state = helper.state.borrow_mut();
+        state.bindings.insert(alias.clone(), (ty, value));
+        if type_exports.iter().next().is_some() {
+            state
+                .type_defs
+                .insert(alias, sclc::Type::Record(type_exports));
+        }
 
         Ok(())
     }

--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -1192,7 +1192,7 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
     }
 
     /// Compute the type-level exports of a module (from `export type` declarations).
-    fn type_level_exports(
+    pub fn type_level_exports(
         &self,
         env: &TypeEnv<'_>,
         file_mod: &ast::FileMod,


### PR DESCRIPTION
When importing a module in the REPL, only value-level bindings were
stored, so imported types (e.g., `MyLib.Config`) were unavailable in
subsequent lines. Now `process_import` also extracts type-level exports
via `type_level_exports` and inserts them into `type_defs`, mirroring
what the compiler does in `populate_import_type_level`.

https://claude.ai/code/session_01UPNj4mdrbpfXA6cbHLrjch