### PR TITLE
fix(cli): update deployment query for Commit type change

### DIFF
--- a/crates/cli/src/deployment.rs
+++ b/crates/cli/src/deployment.rs
@@ -129,7 +129,7 @@ async fn list_deployments(
                 .into_iter()
                 .map(|deployment| DeploymentOutput {
                     r#ref: deployment.ref_,
-                    commit: deployment.commit,
+                    commit: deployment.commit.hash,
                     created_at: deployment.created_at,
                     state: format!("{:?}", deployment.state),
                     resources: deployment

--- a/crates/cli/src/graphql/list_repository_deployments.graphql
+++ b/crates/cli/src/graphql/list_repository_deployments.graphql
@@ -7,7 +7,9 @@ query ListRepositoryDeployments {
       deployments {
         id
         ref
-        commit
+        commit {
+          hash
+        }
         createdAt
         state
         resources {


### PR DESCRIPTION
The `commit` field on `Deployment` changed from `String!` to `Commit!` in the GraphQL schema. Update the query to select `commit { hash }` and access `.commit.hash` in the Rust code.

https://claude.ai/code/session_01Mfgo8dvkhGZgtyQCsS82hU