### PR TITLE
feat(web): render README files below the file browser directory listing

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "graphql": "^16.9.0",
         "graphql-ws": "^5.16.0",
+        "marked": "^17.0.4",
         "shiki": "^4.0.2"
       },
       "devDependencies": {
@@ -20,6 +21,7 @@
         "@sveltejs/adapter-static": "^3.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.0.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
@@ -2995,6 +2997,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
@@ -3843,6 +3858,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -5576,6 +5604,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/marked": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -6129,6 +6169,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/property-information": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "graphql": "^16.9.0",
     "graphql-ws": "^5.16.0",
+    "marked": "^17.0.4",
     "shiki": "^4.0.2"
   },
   "devDependencies": {
@@ -23,6 +24,7 @@
     "@sveltejs/adapter-static": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/typography';

--- a/web/src/lib/components/FileBrowser.svelte
+++ b/web/src/lib/components/FileBrowser.svelte
@@ -7,6 +7,7 @@
 		type DeploymentTreeQuery
 	} from '$lib/graphql/generated';
 	import { highlight, type HighlightedLine } from '$lib/highlight';
+	import { marked } from 'marked';
 	import type { ThemedToken } from 'shiki';
 
 	type SourceFrame = {
@@ -51,8 +52,18 @@
 	let highlightBg = $state<string>('#0d1117');
 	let loading = $state(true);
 	let error = $state<string | null>(null);
+	let readmeContent = $state<string | null>(null);
+	let readmeIsMarkdown = $state(false);
 
 	let pathString = $derived(currentPath.join('/'));
+
+	let renderedReadme = $derived.by(() => {
+		if (!readmeContent) return null;
+		if (readmeIsMarkdown) {
+			return marked.parse(readmeContent, { async: false }) as string;
+		}
+		return null;
+	});
 
 	let queryVars = $derived({ org: orgName, repo: repoName, env: envName, commit: commitHash });
 
@@ -61,11 +72,13 @@
 		error = null;
 		blobContent = null;
 		highlightedLines = null;
+		readmeContent = null;
 		try {
 			const data = await query(DeploymentRootTreeDocument, queryVars);
 			const dep = data.organization.repository.environment.deployment;
 			const rawEntries = dep.commit.tree.entries;
 			entries = sortEntries(rawEntries);
+			loadReadme(rawEntries);
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load tree';
 		} finally {
@@ -89,6 +102,7 @@
 			if (entry.__typename === 'Tree') {
 				entries = sortEntries(entry.entries);
 				blobContent = null;
+				loadReadme(entry.entries);
 			} else {
 				blobContent = entry;
 				entries = [];
@@ -110,6 +124,33 @@
 			highlightBg = result.bg;
 		} catch {
 			// Highlighting failed — fall back to plain text (highlightedLines stays null)
+		}
+	}
+
+	function findReadme(dirEntries: TreeEntry[]): string | null {
+		for (const name of ['README.md', 'readme.md', 'Readme.md', 'README', 'readme']) {
+			if (dirEntries.some((e) => e.__typename === 'Blob' && e.name === name)) return name;
+		}
+		return null;
+	}
+
+	async function loadReadme(dirEntries: TreeEntry[]) {
+		readmeContent = null;
+		readmeIsMarkdown = false;
+		const readmeName = findReadme(dirEntries);
+		if (!readmeName) return;
+		try {
+			const readmePath = currentPath.length > 0
+				? currentPath.join('/') + '/' + readmeName
+				: readmeName;
+			const data = await query(DeploymentTreeDocument, { ...queryVars, path: readmePath });
+			const entry = data.organization.repository.environment.deployment.commit.treeEntry;
+			if (entry?.__typename === 'Blob' && entry.content != null) {
+				readmeContent = entry.content;
+				readmeIsMarkdown = readmeName.toLowerCase().endsWith('.md');
+			}
+		} catch {
+			// README fetch failed — not critical, just skip
 		}
 	}
 
@@ -346,5 +387,16 @@
 				<div class="p-8 text-center text-gray-500">Empty directory</div>
 			{/if}
 		</div>
+
+		<!-- README -->
+		{#if readmeContent}
+			<div class="border-t border-gray-800 px-6 py-5">
+				{#if renderedReadme}
+					<div class="prose prose-invert prose-sm max-w-none">{@html renderedReadme}</div>
+				{:else}
+					<pre class="text-sm text-gray-300 whitespace-pre-wrap font-mono">{readmeContent}</pre>
+				{/if}
+			</div>
+		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
Detects README.md/README in the current directory and renders it below the file listing — Markdown is parsed via `marked` and styled with `@tailwindcss/typography`; plain-text READMEs are shown in a monospace pre block.