### PR TITLE
feat(web): replace manual GraphQL fetching with @tanstack/svelte-query

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "skyr-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/svelte-query": "^6.1.3",
         "graphql": "^16.9.0",
         "graphql-ws": "^5.16.0",
         "marked": "^17.0.4",
@@ -2073,7 +2074,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2084,7 +2084,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2095,7 +2094,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2105,14 +2103,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2632,7 +2628,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -3025,6 +3020,32 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.91.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.91.2.tgz",
+      "integrity": "sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/svelte-query": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/svelte-query/-/svelte-query-6.1.3.tgz",
+      "integrity": "sha512-CUGeiCHClr+8M9M0Ie85Rs/x+wx61jJmboRwL0p+D2A+NiUhTirh85dfLZ+umGopmb1Jvu0L6klJ7FKQv5gwvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.91.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "svelte": "^5.25.0"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -3036,7 +3057,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -3078,7 +3098,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -3101,7 +3120,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
       "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3178,7 +3196,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3264,7 +3281,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3307,7 +3323,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3728,7 +3743,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3981,7 +3995,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -4148,14 +4161,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -4964,7 +4975,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -5470,7 +5480,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -5588,7 +5597,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6707,7 +6715,6 @@
       "version": "5.54.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.54.0.tgz",
       "integrity": "sha512-TTDxwYnHkova6Wsyj1PGt9TByuWqvMoeY1bQiuAf2DM/JeDSMw7FjRKzk8K/5mJ99vGOKhbCqTDpyAKwjp4igg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -7482,7 +7489,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
+    "@tanstack/svelte-query": "^6.1.3",
     "graphql": "^16.9.0",
     "graphql-ws": "^5.16.0",
     "marked": "^17.0.4",

--- a/web/src/lib/components/FileBrowser.svelte
+++ b/web/src/lib/components/FileBrowser.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import { query } from '$lib/graphql/client';
+	import { graphqlQuery } from '$lib/graphql/query';
 	import {
 		DeploymentRootTreeDocument,
-		DeploymentTreeDocument,
-		type DeploymentRootTreeQuery,
-		type DeploymentTreeQuery
+		DeploymentTreeDocument
 	} from '$lib/graphql/generated';
-	import { highlight, type HighlightedLine } from '$lib/highlight';
+	import { highlight } from '$lib/highlight';
 	import { marked } from 'marked';
 	import type { ThemedToken } from 'shiki';
 
@@ -46,16 +44,82 @@
 	};
 
 	let currentPath = $state<string[]>([]);
-	let entries = $state<TreeEntry[]>([]);
-	let blobContent = $state<BlobContent | null>(null);
 	let highlightedLines = $state<ThemedToken[][] | null>(null);
 	let highlightBg = $state<string>('#0d1117');
-	let loading = $state(true);
-	let error = $state<string | null>(null);
-	let readmeContent = $state<string | null>(null);
-	let readmeIsMarkdown = $state(false);
 
 	let pathString = $derived(currentPath.join('/'));
+	let isRoot = $derived(currentPath.length === 0);
+
+	let queryVars = $derived({ org: orgName, repo: repoName, env: envName, commit: commitHash });
+
+	const rootTree = graphqlQuery(() => ({
+		document: DeploymentRootTreeDocument,
+		variables: queryVars,
+		enabled: isRoot
+	}));
+
+	const subTree = graphqlQuery(() => ({
+		document: DeploymentTreeDocument,
+		variables: { ...queryVars, path: pathString },
+		enabled: !isRoot
+	}));
+
+	let loading = $derived(isRoot ? rootTree.isPending : subTree.isPending);
+	let error = $derived.by<string | null>(() => {
+		if (isRoot) return rootTree.error?.message ?? null;
+		if (subTree.error) return subTree.error.message;
+		if (subTree.data && !subTree.data.organization.repository.environment.deployment.commit.treeEntry) {
+			return `Path "${pathString}" not found`;
+		}
+		return null;
+	});
+
+	let entries = $derived.by<TreeEntry[]>(() => {
+		if (isRoot) {
+			if (!rootTree.data) return [];
+			return sortEntries(rootTree.data.organization.repository.environment.deployment.commit.tree.entries);
+		}
+		const entry = subTree.data?.organization.repository.environment.deployment.commit.treeEntry;
+		if (!entry || entry.__typename !== 'Tree') return [];
+		return sortEntries(entry.entries);
+	});
+
+	let blobContent = $derived.by<BlobContent | null>(() => {
+		if (isRoot) return null;
+		const entry = subTree.data?.organization.repository.environment.deployment.commit.treeEntry;
+		if (!entry || entry.__typename !== 'Blob') return null;
+		return entry;
+	});
+
+	// README support: find a README in the current directory entries and fetch it
+	function findReadme(dirEntries: TreeEntry[]): string | null {
+		for (const name of ['README.md', 'readme.md', 'Readme.md', 'README', 'readme']) {
+			if (dirEntries.some((e) => e.__typename === 'Blob' && e.name === name)) return name;
+		}
+		return null;
+	}
+
+	let readmeName = $derived(findReadme(entries));
+	let readmePath = $derived.by(() => {
+		if (!readmeName) return null;
+		return currentPath.length > 0
+			? currentPath.join('/') + '/' + readmeName
+			: readmeName;
+	});
+
+	const readmeQuery = graphqlQuery(() => ({
+		document: DeploymentTreeDocument,
+		variables: { ...queryVars, path: readmePath! },
+		enabled: readmePath != null
+	}));
+
+	let readmeContent = $derived.by<string | null>(() => {
+		const entry = readmeQuery.data?.organization.repository.environment.deployment.commit.treeEntry;
+		if (entry?.__typename === 'Blob' && entry.content != null) return entry.content;
+		return null;
+	});
+
+	let readmeIsMarkdown = $derived(readmeName?.toLowerCase().endsWith('.md') ?? false);
 
 	let renderedReadme = $derived.by(() => {
 		if (!readmeContent) return null;
@@ -65,57 +129,14 @@
 		return null;
 	});
 
-	let queryVars = $derived({ org: orgName, repo: repoName, env: envName, commit: commitHash });
-
-	async function loadRoot() {
-		loading = true;
-		error = null;
-		blobContent = null;
+	// Trigger syntax highlighting when blob content changes
+	$effect(() => {
 		highlightedLines = null;
-		readmeContent = null;
-		try {
-			const data = await query(DeploymentRootTreeDocument, queryVars);
-			const dep = data.organization.repository.environment.deployment;
-			const rawEntries = dep.commit.tree.entries;
-			entries = sortEntries(rawEntries);
-			loadReadme(rawEntries);
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load tree';
-		} finally {
-			loading = false;
+		highlightBg = '#0d1117';
+		if (blobContent?.content != null && blobContent.name) {
+			highlightCode(blobContent.content, blobContent.name);
 		}
-	}
-
-	async function loadPath(path: string) {
-		loading = true;
-		error = null;
-		blobContent = null;
-		highlightedLines = null;
-		try {
-			const data = await query(DeploymentTreeDocument, { ...queryVars, path });
-			const dep = data.organization.repository.environment.deployment;
-			const entry = dep.commit.treeEntry;
-			if (!entry) {
-				error = `Path "${path}" not found`;
-				return;
-			}
-			if (entry.__typename === 'Tree') {
-				entries = sortEntries(entry.entries);
-				blobContent = null;
-				loadReadme(entry.entries);
-			} else {
-				blobContent = entry;
-				entries = [];
-				if (entry.content != null && entry.name) {
-					highlightCode(entry.content, entry.name);
-				}
-			}
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load path';
-		} finally {
-			loading = false;
-		}
-	}
+	});
 
 	async function highlightCode(code: string, filename: string) {
 		try {
@@ -124,33 +145,6 @@
 			highlightBg = result.bg;
 		} catch {
 			// Highlighting failed — fall back to plain text (highlightedLines stays null)
-		}
-	}
-
-	function findReadme(dirEntries: TreeEntry[]): string | null {
-		for (const name of ['README.md', 'readme.md', 'Readme.md', 'README', 'readme']) {
-			if (dirEntries.some((e) => e.__typename === 'Blob' && e.name === name)) return name;
-		}
-		return null;
-	}
-
-	async function loadReadme(dirEntries: TreeEntry[]) {
-		readmeContent = null;
-		readmeIsMarkdown = false;
-		const readmeName = findReadme(dirEntries);
-		if (!readmeName) return;
-		try {
-			const readmePath = currentPath.length > 0
-				? currentPath.join('/') + '/' + readmeName
-				: readmeName;
-			const data = await query(DeploymentTreeDocument, { ...queryVars, path: readmePath });
-			const entry = data.organization.repository.environment.deployment.commit.treeEntry;
-			if (entry?.__typename === 'Blob' && entry.content != null) {
-				readmeContent = entry.content;
-				readmeIsMarkdown = readmeName.toLowerCase().endsWith('.md');
-			}
-		} catch {
-			// README fetch failed — not critical, just skip
 		}
 	}
 
@@ -250,13 +244,6 @@
 		}
 	});
 
-	$effect(() => {
-		if (currentPath.length === 0) {
-			loadRoot();
-		} else {
-			loadPath(currentPath.join('/'));
-		}
-	});
 </script>
 
 <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">

--- a/web/src/lib/graphql/client.ts
+++ b/web/src/lib/graphql/client.ts
@@ -3,12 +3,10 @@ import { print } from 'graphql';
 import { getToken } from '$lib/stores/auth';
 
 function getApiUrl(): string {
-	// In dev, Vite proxy handles /graphql.
-	// In production, configure via env or use relative URL.
 	return '/graphql';
 }
 
-async function execute<TData>(
+export async function execute<TData>(
 	document: TypedDocumentNode<TData, any>,
 	variables: Record<string, unknown>
 ): Promise<TData> {
@@ -51,11 +49,4 @@ export async function query<TData, TVars extends Record<string, unknown>>(
 	...args: TVars extends Record<string, never> ? [variables?: TVars] : [variables: TVars]
 ): Promise<TData> {
 	return execute(document, args[0] ?? {});
-}
-
-export async function mutate<TData, TVars extends Record<string, unknown>>(
-	document: TypedDocumentNode<TData, TVars>,
-	variables: TVars
-): Promise<TData> {
-	return execute(document, variables);
 }

--- a/web/src/lib/graphql/query.ts
+++ b/web/src/lib/graphql/query.ts
@@ -1,0 +1,33 @@
+import { createQuery, createMutation, type CreateMutationOptions } from '@tanstack/svelte-query';
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { print } from 'graphql';
+import { execute } from './client';
+
+export function graphqlQuery<TData, TVars extends Record<string, unknown>>(
+	options: () => {
+		document: TypedDocumentNode<TData, TVars>;
+		variables?: TVars;
+		enabled?: boolean;
+		refetchInterval?: number | false;
+	}
+) {
+	return createQuery(() => {
+		const { document, variables, enabled, refetchInterval } = options();
+		return {
+			queryKey: [print(document), variables ?? {}],
+			queryFn: () => execute(document, variables ?? {}),
+			enabled: enabled ?? true,
+			refetchInterval: refetchInterval ?? false
+		};
+	});
+}
+
+export function graphqlMutation<TData, TVars extends Record<string, unknown>>(
+	document: TypedDocumentNode<TData, TVars>,
+	options?: Omit<CreateMutationOptions<TData, Error, TVars>, 'mutationFn'>
+) {
+	return createMutation(() => ({
+		mutationFn: (variables: TVars) => execute(document, variables),
+		...options
+	}));
+}

--- a/web/src/routes/(app)/+page.svelte
+++ b/web/src/routes/(app)/+page.svelte
@@ -1,40 +1,28 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { query } from '$lib/graphql/client';
-	import { OrganizationsDocument, type OrganizationsQuery } from '$lib/graphql/generated';
+	import { graphqlQuery } from '$lib/graphql/query';
+	import { OrganizationsDocument } from '$lib/graphql/generated';
 	import { orgHref } from '$lib/paths';
 
-	let organizations = $state<OrganizationsQuery['organizations']>([]);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
-
-	onMount(async () => {
-		try {
-			const data = await query(OrganizationsDocument);
-			organizations = data.organizations;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load organizations';
-		} finally {
-			loading = false;
-		}
-	});
+	const organizations = graphqlQuery(() => ({
+		document: OrganizationsDocument
+	}));
 </script>
 
 <div class="p-6">
 	<h1 class="text-2xl font-bold text-white mb-6">Organizations</h1>
 
-	{#if loading}
+	{#if organizations.isPending}
 		<p class="text-gray-400">Loading organizations...</p>
-	{:else if error}
-		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{error}</div>
-	{:else if organizations.length === 0}
+	{:else if organizations.error}
+		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{organizations.error.message}</div>
+	{:else if organizations.data.organizations.length === 0}
 		<div class="text-center py-16">
 			<p class="text-gray-400 mb-2">No organizations found.</p>
 			<p class="text-gray-500 text-sm">Create an organization to get started.</p>
 		</div>
 	{:else}
 		<div class="grid gap-4">
-			{#each organizations as org}
+			{#each organizations.data.organizations as org}
 				<a
 					href={orgHref(org.name)}
 					class="block bg-gray-900 border border-gray-800 rounded-lg p-5 hover:border-gray-700 transition-colors"

--- a/web/src/routes/(app)/[org]/+page.svelte
+++ b/web/src/routes/(app)/[org]/+page.svelte
@@ -1,28 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
-	import { query } from '$lib/graphql/client';
-	import { OrganizationDetailDocument, type OrganizationDetailQuery } from '$lib/graphql/generated';
-	import { DeploymentState } from '$lib/graphql/generated';
+	import { graphqlQuery } from '$lib/graphql/query';
+	import { OrganizationDetailDocument } from '$lib/graphql/generated';
 	import { repoHref } from '$lib/paths';
 
 	let orgName = $derived($page.params.org ?? '');
 
-	type OrgData = OrganizationDetailQuery['organization'];
-	let org = $state<OrgData | null>(null);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
-
-	onMount(async () => {
-		try {
-			const data = await query(OrganizationDetailDocument, { org: orgName });
-			org = data.organization;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load organization';
-		} finally {
-			loading = false;
-		}
-	});
+	const orgDetail = graphqlQuery(() => ({
+		document: OrganizationDetailDocument,
+		variables: { org: orgName }
+	}));
 </script>
 
 <div class="p-6">
@@ -34,11 +21,12 @@
 
 	<h1 class="text-2xl font-bold text-white mb-6">{orgName}</h1>
 
-	{#if loading}
+	{#if orgDetail.isPending}
 		<p class="text-gray-400">Loading repositories...</p>
-	{:else if error}
-		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{error}</div>
-	{:else if org}
+	{:else if orgDetail.error}
+		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{orgDetail.error.message}</div>
+	{:else}
+		{@const org = orgDetail.data.organization}
 		{#if org.repositories.length === 0}
 			<div class="text-center py-16">
 				<p class="text-gray-400 mb-2">No repositories found.</p>

--- a/web/src/routes/(app)/[org]/[repo]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/+page.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
-	import { query } from '$lib/graphql/client';
-	import { DeploymentState, RepositoryDetailDocument, type RepositoryDetailQuery } from '$lib/graphql/generated';
+	import { graphqlQuery } from '$lib/graphql/query';
+	import { DeploymentState, RepositoryDetailDocument } from '$lib/graphql/generated';
 	import DeploymentStateBadge from '$lib/components/DeploymentState.svelte';
 	import FileBrowser from '$lib/components/FileBrowser.svelte';
 	import { orgHref, envHref } from '$lib/paths';
@@ -10,10 +9,13 @@
 	let orgName = $derived($page.params.org ?? '');
 	let repoName = $derived($page.params.repo ?? '');
 
-	type RepoData = RepositoryDetailQuery['organization']['repository'];
-	let repo = $state<RepoData | null>(null);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
+	const repoDetail = graphqlQuery(() => ({
+		document: RepositoryDetailDocument,
+		variables: { org: orgName, repo: repoName },
+		refetchInterval: 10_000
+	}));
+
+	let repo = $derived(repoDetail.data?.organization.repository ?? null);
 
 	// Find the "main" environment (named "main" or the first one) and its desired deployment
 	let mainEnv = $derived(
@@ -25,17 +27,6 @@
 			(d) => d.state === DeploymentState.Desired || d.state === DeploymentState.Up
 		) ?? null
 	);
-
-	onMount(async () => {
-		try {
-			const data = await query(RepositoryDetailDocument, { org: orgName, repo: repoName });
-			repo = data.organization.repository;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load repository';
-		} finally {
-			loading = false;
-		}
-	});
 </script>
 
 <div class="p-6">
@@ -49,10 +40,10 @@
 
 	<h1 class="text-2xl font-bold text-white mb-6">{orgName}/{repoName}</h1>
 
-	{#if loading}
+	{#if repoDetail.isPending}
 		<p class="text-gray-400">Loading repository...</p>
-	{:else if error}
-		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{error}</div>
+	{:else if repoDetail.error}
+		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{repoDetail.error.message}</div>
 	{:else if repo}
 		<!-- File Browser for main environment's desired deployment -->
 		{#if mainEnv && mainDesiredDeployment}

--- a/web/src/routes/(app)/[org]/[repo]/[env]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/+page.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
-	import { query } from '$lib/graphql/client';
+	import { graphqlQuery } from '$lib/graphql/query';
 	import {
 		DeploymentState,
 		EnvironmentDetailDocument,
-		EnvironmentLogsDocument,
-		type EnvironmentDetailQuery
+		EnvironmentLogsDocument
 	} from '$lib/graphql/generated';
 	import DeploymentStateBadge from '$lib/components/DeploymentState.svelte';
 	import ResourceCard from '$lib/components/ResourceCard.svelte';
@@ -18,10 +16,13 @@
 	let repoName = $derived($page.params.repo ?? '');
 	let envName = $derived(decodeSegment($page.params.env ?? ''));
 
-	type EnvData = EnvironmentDetailQuery['organization']['repository']['environment'];
-	let env = $state<EnvData | null>(null);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
+	const envDetail = graphqlQuery(() => ({
+		document: EnvironmentDetailDocument,
+		variables: { org: orgName, repo: repoName, env: envName },
+		refetchInterval: 10_000
+	}));
+
+	let env = $derived(envDetail.data?.organization.repository.environment ?? null);
 	let showLogs = $state(false);
 
 	let desiredDeployment = $derived(
@@ -32,20 +33,8 @@
 
 	function handleNavigateToSource(moduleId: string, line: number) {
 		navigateToFile = { moduleId, line };
-		// Scroll to the file browser section
 		document.querySelector('[data-file-browser]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 	}
-
-	onMount(async () => {
-		try {
-			const data = await query(EnvironmentDetailDocument, { org: orgName, repo: repoName, env: envName });
-			env = data.organization.repository.environment;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load environment';
-		} finally {
-			loading = false;
-		}
-	});
 </script>
 
 <div class="p-6">
@@ -71,10 +60,10 @@
 		{/if}
 	</div>
 
-	{#if loading}
+	{#if envDetail.isPending}
 		<p class="text-gray-400">Loading environment...</p>
-	{:else if error}
-		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{error}</div>
+	{:else if envDetail.error}
+		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{envDetail.error.message}</div>
 	{:else if env}
 		{#if showLogs}
 			<div class="mb-6 h-80 bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">

--- a/web/src/routes/(app)/[org]/[repo]/[env]/[deployment]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/[deployment]/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
-	import { query } from '$lib/graphql/client';
+	import { graphqlQuery } from '$lib/graphql/query';
 	import {
 		DeploymentDetailDocument,
-		DeploymentLogsDocument,
-		type DeploymentDetailQuery
+		DeploymentLogsDocument
 	} from '$lib/graphql/generated';
 	import DeploymentStateBadge from '$lib/components/DeploymentState.svelte';
 	import ResourceCard from '$lib/components/ResourceCard.svelte';
@@ -18,10 +16,13 @@
 	let envName = $derived(decodeSegment($page.params.env ?? ''));
 	let commitHash = $derived($page.params.deployment ?? '');
 
-	type DeploymentData = DeploymentDetailQuery['organization']['repository']['environment']['deployment'];
-	let deployment = $state<DeploymentData | null>(null);
-	let loading = $state(true);
-	let error = $state<string | null>(null);
+	const deploymentDetail = graphqlQuery(() => ({
+		document: DeploymentDetailDocument,
+		variables: { org: orgName, repo: repoName, env: envName, commit: commitHash },
+		refetchInterval: 10_000
+	}));
+
+	let deployment = $derived(deploymentDetail.data?.organization.repository.environment.deployment ?? null);
 	let showFiles = $state(true);
 
 	let navigateToFile = $state<{ moduleId: string; line: number } | null>(null);
@@ -29,22 +30,10 @@
 	function handleNavigateToSource(moduleId: string, line: number) {
 		showFiles = true;
 		navigateToFile = { moduleId, line };
-		// Small delay to let the FileBrowser mount if it was hidden
 		requestAnimationFrame(() => {
 			document.querySelector('[data-file-browser]')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 		});
 	}
-
-	onMount(async () => {
-		try {
-			const data = await query(DeploymentDetailDocument, { org: orgName, repo: repoName, env: envName, commit: commitHash });
-			deployment = data.organization.repository.environment.deployment;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load deployment';
-		} finally {
-			loading = false;
-		}
-	});
 </script>
 
 <div class="p-6">
@@ -60,10 +49,10 @@
 		<span class="text-gray-300 font-mono text-xs">{commitHash.substring(0, 8)}</span>
 	</nav>
 
-	{#if loading}
+	{#if deploymentDetail.isPending}
 		<p class="text-gray-400">Loading deployment...</p>
-	{:else if error}
-		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{error}</div>
+	{:else if deploymentDetail.error}
+		<div class="p-4 bg-red-900/20 border border-red-800 rounded text-red-300">{deploymentDetail.error.message}</div>
 	{:else if deployment}
 		<!-- Header -->
 		<div class="flex items-center gap-4 mb-6">

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
 	import '../app.css';
+	import { QueryClientProvider, QueryClient } from '@tanstack/svelte-query';
 	import { startExpiryWatch, stopExpiryWatch } from '$lib/stores/auth';
 	import { onMount, onDestroy } from 'svelte';
 
 	let { children } = $props();
+
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				staleTime: 30_000,
+				refetchOnWindowFocus: false
+			}
+		}
+	});
 
 	onMount(() => {
 		startExpiryWatch();
@@ -14,4 +24,6 @@
 	});
 </script>
 
-{@render children()}
+<QueryClientProvider client={queryClient}>
+	{@render children()}
+</QueryClientProvider>

--- a/web/src/routes/~signin/+page.svelte
+++ b/web/src/routes/~signin/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { query, mutate } from '$lib/graphql/client';
+	import { graphqlMutation } from '$lib/graphql/query';
+	import { query } from '$lib/graphql/client';
 	import { AuthChallengeDocument, SignInDocument } from '$lib/graphql/generated';
 	import { setAuth } from '$lib/stores/auth';
 	import { onDestroy } from 'svelte';
@@ -12,6 +13,16 @@
 	let loading = $state(false);
 	let step = $state<'username' | 'sign'>('username');
 	let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+	const signIn = graphqlMutation(SignInDocument, {
+		onSuccess: (data) => {
+			setAuth(data.signin.token, data.signin.user);
+			goto('/');
+		},
+		onError: (e) => {
+			error = e.message;
+		}
+	});
 
 	async function fetchChallenge() {
 		if (!username.trim()) return;
@@ -63,27 +74,18 @@
 		return { pubkey, signature };
 	}
 
-	async function submitSignIn() {
+	function submitSignIn() {
 		const parsed = parseResponse(response);
 		if (!parsed) {
 			error = 'Could not find both a public key and an SSH signature in the output. Make sure you pasted the full output.';
 			return;
 		}
 		error = null;
-		loading = true;
-		try {
-			const data = await mutate(SignInDocument, {
-				username: username.trim(),
-				signature: parsed.signature,
-				pubkey: parsed.pubkey
-			});
-			setAuth(data.signin.token, data.signin.user);
-			goto('/');
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Sign-in failed';
-		} finally {
-			loading = false;
-		}
+		signIn.mutate({
+			username: username.trim(),
+			signature: parsed.signature,
+			pubkey: parsed.pubkey
+		});
 	}
 
 	function copyToClipboard(text: string) {
@@ -176,9 +178,9 @@
 					<button
 						onclick={submitSignIn}
 						class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-						disabled={loading || !response.trim()}
+						disabled={signIn.isPending || !response.trim()}
 					>
-						{loading ? 'Signing in...' : 'Sign In'}
+						{signIn.isPending ? 'Signing in...' : 'Sign In'}
 					</button>
 				</div>
 			{/if}


### PR DESCRIPTION
Use TanStack Query for declarative data fetching with automatic caching, deduplication, and polling. Resource/deployment views auto-refresh every 10 seconds.