### PR TITLE
fix(sclc): handle nested pending values in extern function arguments

### DIFF
--- a/crates/sclc/src/eval.rs
+++ b/crates/sclc/src/eval.rs
@@ -695,15 +695,6 @@ impl Eval {
                         }
                         *self.ctx.source_trace.lock().unwrap() = trace;
 
-                        if args
-                            .iter()
-                            .any(|arg| matches!(arg.value, Value::Pending(_)))
-                        {
-                            self.ctx.source_trace.lock().unwrap().clear();
-                            return Ok(
-                                TrackedValue::pending().with_dependencies(callee_dependencies)
-                            );
-                        }
                         let result = function
                             .call(args, &self.ctx)
                             .map(|value| value.with_dependencies(callee_dependencies));

--- a/crates/sclc/src/std/artifact.rs
+++ b/crates/sclc/src/std/artifact.rs
@@ -10,6 +10,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
 
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let config = config_arg.value.assert_record()?;
 
         let name = config.get("name").assert_str_ref()?;

--- a/crates/sclc/src/std/container.rs
+++ b/crates/sclc/src/std/container.rs
@@ -44,6 +44,10 @@ fn image_extern_fn(
         .unwrap_or_else(|| TrackedValue::new(Value::Nil));
     let mut argument_dependencies = config_arg.dependencies.clone();
 
+    if config_arg.value.has_pending() {
+        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+    }
+
     let config = config_arg.value.assert_record()?;
 
     // Extract inputs
@@ -130,6 +134,10 @@ fn pod_extern_fn(
         .next()
         .unwrap_or_else(|| TrackedValue::new(Value::Nil));
     let mut argument_dependencies = config_arg.dependencies.clone();
+
+    if config_arg.value.has_pending() {
+        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+    }
 
     let config = config_arg.value.assert_record()?;
 
@@ -250,6 +258,10 @@ fn create_port_fn(
         // The port depends on the pod
         argument_dependencies.insert(pod_resource_id.clone());
 
+        if config_arg.value.has_pending() {
+            return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let config = config_arg.value.assert_record()?;
 
         // Extract port-specific inputs
@@ -318,6 +330,10 @@ fn create_attachment_fn(
         // The attachment depends on the pod
         argument_dependencies.insert(pod_resource_id.clone());
 
+        if port_arg.value.has_pending() {
+            return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let port_record = port_arg.value.assert_record()?;
 
         // Extract destination port details
@@ -381,6 +397,10 @@ fn host_extern_fn(
         .next()
         .unwrap_or_else(|| TrackedValue::new(Value::Nil));
     let mut argument_dependencies = config_arg.dependencies.clone();
+
+    if config_arg.value.has_pending() {
+        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+    }
 
     let config = config_arg.value.assert_record()?;
 
@@ -450,6 +470,10 @@ fn create_host_port_fn(
 
         // The host port depends on the host
         argument_dependencies.insert(host_resource_id.clone());
+
+        if config_arg.value.has_pending() {
+            return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
 
         let config = config_arg.value.assert_record()?;
 

--- a/crates/sclc/src/std/crypto.rs
+++ b/crates/sclc/src/std/crypto.rs
@@ -31,6 +31,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
 
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let config = config_arg.value.assert_record()?;
         let name = config.get("name").assert_str_ref()?;
 
@@ -66,6 +70,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
+
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
 
         let config = config_arg.value.assert_record()?;
         let name = config.get("name").assert_str_ref()?;
@@ -107,6 +115,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
+
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
 
         let config = config_arg.value.assert_record()?;
         let private_key_pem = config.get("privateKeyPem").assert_str_ref()?;
@@ -189,6 +201,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
 
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let config = config_arg.value.assert_record()?;
         let name = config.get("name").assert_str_ref()?;
 
@@ -229,6 +245,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
+
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
 
         let config = config_arg.value.assert_record()?;
 

--- a/crates/sclc/src/std/encoding.rs
+++ b/crates/sclc/src/std/encoding.rs
@@ -10,6 +10,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
 
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
+
         first.try_map(|value| {
             let json = to_json_value(&value)?;
             let encoded = serde_json::to_string(&json)
@@ -25,6 +29,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
         let first = args
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
 
         first.try_map(|value| {
             let input = value.assert_str()?;

--- a/crates/sclc/src/std/list.rs
+++ b/crates/sclc/src/std/list.rs
@@ -7,6 +7,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
 
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
+
         first.try_map(|value| {
             let n = value.assert_int()?;
             if n < 0 {

--- a/crates/sclc/src/std/num.rs
+++ b/crates/sclc/src/std/num.rs
@@ -7,6 +7,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
 
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
+
         first.try_map(|value| {
             value
                 .assert_int()

--- a/crates/sclc/src/std/random.rs
+++ b/crates/sclc/src/std/random.rs
@@ -10,6 +10,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
         let mut argument_dependencies = config_arg.dependencies.clone();
 
+        if config_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
+
         let config = config_arg.value.assert_record()?;
 
         let name = config.get("name").assert_str_ref()?;

--- a/crates/sclc/src/std/time.rs
+++ b/crates/sclc/src/std/time.rs
@@ -11,6 +11,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
 
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
+
         first.try_map(|value| {
             let record = value.assert_record()?;
             let epoch_millis = *record.get("epochMillis").assert_int_ref()?;
@@ -24,6 +28,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
         let first = args
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+        if first.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(first.dependencies));
+        }
 
         first.try_map(|value| {
             let record = value.assert_record()?;
@@ -63,6 +71,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .cloned()
             .collect();
 
+        if instant_arg.value.has_pending() || duration_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(deps));
+        }
+
         let instant = instant_arg.value.assert_record()?;
         let duration = duration_arg.value.assert_record()?;
         let epoch_millis = *instant.get("epochMillis").assert_int_ref()?;
@@ -81,6 +93,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .next()
             .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
         let mut argument_dependencies = duration_arg.dependencies.clone();
+
+        if duration_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
+        }
 
         let duration = duration_arg.value.assert_record()?;
 
@@ -136,6 +152,10 @@ pub fn register_extern(eval: &mut crate::Eval) {
             .union(&duration_arg.dependencies)
             .cloned()
             .collect();
+
+        if instant_arg.value.has_pending() || duration_arg.value.has_pending() {
+            return Ok(crate::TrackedValue::pending().with_dependencies(deps));
+        }
 
         let instant = instant_arg.value.assert_record()?;
         let duration = duration_arg.value.assert_record()?;

--- a/crates/sclc/src/value.rs
+++ b/crates/sclc/src/value.rs
@@ -278,6 +278,19 @@ impl Dict {
     }
 }
 
+impl Value {
+    /// Recursively checks whether this value or any nested value is pending.
+    pub fn has_pending(&self) -> bool {
+        match self {
+            Value::Pending(_) => true,
+            Value::List(values) => values.iter().any(Value::has_pending),
+            Value::Record(record) => record.iter().any(|(_, v)| v.has_pending()),
+            Value::Dict(dict) => dict.iter().any(|(k, v)| k.has_pending() || v.has_pending()),
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Add Value::has_pending() for recursive pending detection in nested structures (records, lists, dicts). Move pending-argument handling from the evaluator's blanket pre-call check into each extern fn, allowing them to correctly detect pending values nested inside record arguments.

Previously, passing a record with a pending field (e.g. {contents: key.pem} where key.pem is pending) to an extern fn would bypass the top-level pending check and cause an "unexpected value: <pending>" error inside the fn.