### PR TITLE
fix(web): use trailingSlash page option and replaceState for URL norm…

### DIFF
--- a/web/src/routes/(app)/[org]/[repo]/~/[commit]/[...path]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/~/[commit]/[...path]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+	import { replaceState } from '$app/navigation';
 	import { query } from '$lib/graphql/client';
 	import {
 		CommitRootTreeDocument,
@@ -60,14 +60,15 @@
 		}
 	}
 
-	// Trailing slash normalization: directories get trailing slash, files lose it
+	// Trailing slash normalization: directories get trailing slash, files lose it.
+	// Uses replaceState to update the URL without triggering a navigation cycle.
 	$effect(() => {
 		const currentUrl = $page.url.pathname;
 		const hasTrailingSlash = currentUrl.endsWith('/');
 		if (view.kind === 'directory' && !hasTrailingSlash) {
-			goto(currentUrl + '/', { replaceState: true });
+			replaceState(currentUrl + '/', {});
 		} else if (view.kind === 'file' && hasTrailingSlash) {
-			goto(currentUrl.replace(/\/+$/, ''), { replaceState: true });
+			replaceState(currentUrl.replace(/\/+$/, ''), {});
 		}
 	});
 

--- a/web/src/routes/(app)/[org]/[repo]/~/[commit]/[...path]/+page.ts
+++ b/web/src/routes/(app)/[org]/[repo]/~/[commit]/[...path]/+page.ts
@@ -1,0 +1,3 @@
+// This route serves both directories (trailing slash) and files (no trailing slash),
+// so we must opt out of SvelteKit's automatic trailing-slash redirects.
+export const trailingSlash = 'ignore';


### PR DESCRIPTION
…alization

Set trailingSlash = 'ignore' to prevent SvelteKit from fighting the manual trailing-slash logic, and replace goto with replaceState to update the URL without triggering a navigation cycle.