### PR TITLE
fix(de): allow supersession when deployment has only volatile checks

### DIFF
--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -793,7 +793,10 @@ impl Worker {
                                         "effect touch resource adopt",
                                     );
                                 } else if volatile_resource_ids.contains(&id) {
-                                    had_effect = true;
+                                    // Volatile checks verify resource health but do not
+                                    // count as effects that block completeness. This
+                                    // allows supersession of prior deployments even when
+                                    // volatile resources are present.
                                     let message = rtq::Message::Check(rtq::CheckMessage {
                                         resource: resource_ref(&namespace_id, &id),
                                         deployment_id: deployment_id.clone(),


### PR DESCRIPTION
Previously, volatile resource Check messages set `had_effect = true`,
causing the evaluation to always be `Partial` when volatile resources
were present. This meant superseded (Lingering) deployments were never
transitioned to Undesired, because supersession only fires on
`EvalCompleteness::Complete`.

Checks merely verify resource health and should not block completeness.
With this fix, a Desired deployment with volatile resources that
evaluates without any Create/Update/Adopt effects will correctly:
1. Mark superseded deployments as Undesired (triggering teardown)
2. Stay in Desired state for continued reconciliation (since it has
   volatile resources and cannot transition to Up)

https://claude.ai/code/session_019DsFXBBWRxXqdXSHrEh1xP