### PR TITLE
feat(web): add static docs rendering at /~docs

### DIFF
--- a/dev/Containerfile.web
+++ b/dev/Containerfile.web
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ ./
+COPY docs/ /docs/
 RUN npm run build
 
 # Stage 2: nginx serving static files with API reverse proxy

--- a/web/src/lib/components/ResourceDag.svelte
+++ b/web/src/lib/components/ResourceDag.svelte
@@ -75,7 +75,7 @@ let dag = $derived.by(() => {
                     name: dep.name,
                     markers: [],
                     isShadow: true,
-        
+
                     layer: 0,
                     x: 0,
                     y: 0,
@@ -227,12 +227,12 @@ let dag = $derived.by(() => {
             const layerNodes = layers.get(l) ?? [];
             // Interpolate where the edge naturally wants to be at this layer
             const t = (l - fromNode.layer) / span;
-            const naturalY = fromNode.y + NODE_H / 2 + t * (toNode.y + NODE_H / 2 - (fromNode.y + NODE_H / 2));
+            const naturalY =
+                fromNode.y + NODE_H / 2 + t * (toNode.y + NODE_H / 2 - (fromNode.y + NODE_H / 2));
 
             // Check if any real node at this layer overlaps the natural Y
             let blocked = false;
             for (const n of layerNodes) {
-
                 if (naturalY >= n.y - MARGIN && naturalY <= n.y + NODE_H + MARGIN) {
                     blocked = true;
                     break;
@@ -241,9 +241,7 @@ let dag = $derived.by(() => {
 
             if (blocked) {
                 // Find the nearest gap (above or below the blocking nodes)
-                const sortedNodes = layerNodes
-
-                    .sort((a, b) => a.y - b.y);
+                const sortedNodes = layerNodes.sort((a, b) => a.y - b.y);
 
                 // Candidate positions: above topmost, below bottommost, or
                 // between consecutive nodes
@@ -295,9 +293,7 @@ function edgePath(edge: DagEdge): string {
     const waypoints = dag.waypointMap.get(edgeKey);
 
     // Build the list of points the edge passes through
-    const points: { x: number; y: number }[] = [
-        { x: from.x + NODE_W, y: from.y + NODE_H / 2 },
-    ];
+    const points: { x: number; y: number }[] = [{ x: from.x + NODE_W, y: from.y + NODE_H / 2 }];
     if (waypoints) {
         // Dummy nodes occupy a full node slot; route through the center of that slot
         for (const wp of waypoints) {

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -1,0 +1,205 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { Marked } from "marked";
+import { createHighlighter, type Highlighter } from "shiki";
+import sclGrammar from "$lib/scl.tmLanguage.json";
+
+const SCL_LANG = {
+    ...sclGrammar,
+    id: "scl",
+    scopeName: "source.scl",
+} as const;
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+function getHighlighter(): Promise<Highlighter> {
+    if (!highlighterPromise) {
+        highlighterPromise = createHighlighter({
+            themes: ["github-light"],
+            langs: [
+                "javascript",
+                "typescript",
+                "json",
+                "yaml",
+                "toml",
+                "html",
+                "css",
+                "markdown",
+                "bash",
+                "shell",
+                "python",
+                "rust",
+                "go",
+                "dockerfile",
+                "sql",
+                "graphql",
+                "xml",
+                "ini",
+                "diff",
+                "plaintext",
+                SCL_LANG,
+            ],
+        });
+    }
+    return highlighterPromise;
+}
+
+const LANG_ALIASES: Record<string, string> = {
+    sh: "bash",
+    zsh: "bash",
+    ts: "typescript",
+    js: "javascript",
+};
+
+function resolveDocsDir(): string {
+    // In the web/ directory, docs is at ../docs
+    // In the container, web is at /app and docs is at /docs
+    const fromWeb = join(process.cwd(), "..", "docs");
+    try {
+        statSync(fromWeb);
+        return fromWeb;
+    } catch {
+        return "/docs";
+    }
+}
+
+export interface DocPage {
+    title: string;
+    html: string;
+}
+
+export function findAllDocPaths(): string[] {
+    const docsDir = resolveDocsDir();
+    const paths: string[] = [];
+
+    function walk(dir: string, base: string) {
+        for (const entry of readdirSync(dir)) {
+            const full = join(dir, entry);
+            const rel = base ? `${base}/${entry}` : entry;
+            if (statSync(full).isDirectory()) {
+                walk(full, rel);
+            } else if (entry.endsWith(".md")) {
+                let urlPath = rel.replace(/\.md$/, "");
+                if (urlPath.endsWith("/index")) urlPath = urlPath.slice(0, -"/index".length);
+                if (urlPath === "index") urlPath = "";
+                paths.push(urlPath);
+            }
+        }
+    }
+
+    walk(docsDir, "");
+    return paths;
+}
+
+function resolveFilePath(urlPath: string): string {
+    const docsDir = resolveDocsDir();
+
+    // Try exact file first
+    const exactPath = join(docsDir, `${urlPath || "index"}.md`);
+    try {
+        statSync(exactPath);
+        return exactPath;
+    } catch {
+        // Try index.md in directory
+        const indexPath = join(docsDir, urlPath, "index.md");
+        return indexPath;
+    }
+}
+
+function resolveDocLink(href: string, docFilePath: string): string {
+    // docFilePath is relative to docs/, e.g. "scl/types.md" or "index.md"
+    const docDir = docFilePath.replace(/[^/]*$/, ""); // e.g. "scl/" or ""
+
+    // Split off anchor
+    const hashIdx = href.indexOf("#");
+    const pathPart = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
+    const anchor = hashIdx >= 0 ? href.slice(hashIdx) : "";
+
+    if (!pathPart) {
+        // Pure anchor link
+        return href;
+    }
+
+    // Resolve relative path against the doc's directory
+    const segments = (docDir + pathPart).split("/");
+    const resolved: string[] = [];
+    for (const seg of segments) {
+        if (seg === "..") resolved.pop();
+        else if (seg && seg !== ".") resolved.push(seg);
+    }
+    let result = resolved.join("/");
+
+    // Strip .md extension
+    result = result.replace(/\.md$/, "");
+    // Strip trailing /index
+    result = result.replace(/\/index$/, "");
+    if (result === "index") result = "";
+
+    return `/~docs/${result}${result ? "/" : ""}${anchor}`;
+}
+
+export async function loadDocPage(urlPath: string): Promise<DocPage> {
+    const filePath = resolveFilePath(urlPath);
+    const source = readFileSync(filePath, "utf-8");
+
+    // Determine the doc file's relative path within docs/ for link resolution
+    const docsDir = resolveDocsDir();
+    const docRelPath = filePath.slice(docsDir.length + 1); // e.g. "scl/types.md"
+
+    const hl = await getHighlighter();
+
+    const marked = new Marked();
+    marked.use({
+        async: true,
+        renderer: {
+            heading({ text, depth }) {
+                const slug = text
+                    .toLowerCase()
+                    .replace(/<[^>]*>/g, "")
+                    .replace(/[^\w\s-]/g, "")
+                    .replace(/\s+/g, "-")
+                    .replace(/-+/g, "-")
+                    .replace(/^-|-$/g, "");
+                return `<h${depth} id="${escapeAttr(slug)}">${text}</h${depth}>`;
+            },
+            code({ text, lang }) {
+                const language = LANG_ALIASES[lang ?? ""] ?? lang ?? "plaintext";
+                try {
+                    return hl.codeToHtml(text, {
+                        lang: language as any,
+                        theme: "github-light",
+                    });
+                } catch {
+                    return `<pre><code>${escapeHtml(text)}</code></pre>`;
+                }
+            },
+            link({ href, text }) {
+                if (
+                    href &&
+                    !href.startsWith("http") &&
+                    !href.startsWith("#") &&
+                    !href.startsWith("/")
+                ) {
+                    href = resolveDocLink(href, docRelPath);
+                }
+                return `<a href="${escapeAttr(href ?? "")}">${text}</a>`;
+            },
+        },
+    });
+
+    const html = await marked.parse(source);
+
+    // Extract title from first h1
+    const titleMatch = source.match(/^#\s+(.+)$/m);
+    const title = titleMatch ? titleMatch[1] : "Documentation";
+
+    return { title, html };
+}
+
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}

--- a/web/src/lib/graphql/client.ts
+++ b/web/src/lib/graphql/client.ts
@@ -35,8 +35,7 @@ export async function execute<TData>(
 
     if (json.errors?.length) {
         const hasInvalidToken = json.errors.some(
-            (e: { extensions?: { code?: string } }) =>
-                e.extensions?.code === "INVALID_TOKEN",
+            (e: { extensions?: { code?: string } }) => e.extensions?.code === "INVALID_TOKEN",
         );
         if (hasInvalidToken) {
             clearAuth();

--- a/web/src/routes/~docs/+layout.svelte
+++ b/web/src/routes/~docs/+layout.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+import { page } from "$app/state";
+
+let { children } = $props();
+
+const nav = [
+    { title: "Overview", path: "/~docs/" },
+    { title: "Deployments", path: "/~docs/deployments/" },
+    {
+        title: "SCL",
+        path: "/~docs/scl/",
+        children: [
+            { title: "Syntax", path: "/~docs/scl/syntax/" },
+            { title: "Types", path: "/~docs/scl/types/" },
+            { title: "Standard Library", path: "/~docs/scl/stdlib/" },
+        ],
+    },
+];
+
+function isActive(path: string): boolean {
+    return page.url.pathname === path;
+}
+</script>
+
+<div class="min-h-screen bg-white flex">
+    <nav class="w-56 shrink-0 border-r border-gray-200 p-4 text-sm">
+        <a href="/~docs/" class="font-bold text-gray-900 block mb-4">Skyr Docs</a>
+        <ul class="space-y-1">
+            {#each nav as item}
+                <li>
+                    <a
+                        href={item.path}
+                        class="block px-2 py-1 rounded {isActive(item.path)
+                            ? 'bg-gray-100 text-gray-900 font-medium'
+                            : 'text-gray-600 hover:text-gray-900'}"
+                    >
+                        {item.title}
+                    </a>
+                    {#if item.children}
+                        <ul class="ml-3 mt-1 space-y-1">
+                            {#each item.children as child}
+                                <li>
+                                    <a
+                                        href={child.path}
+                                        class="block px-2 py-1 rounded {isActive(child.path)
+                                            ? 'bg-gray-100 text-gray-900 font-medium'
+                                            : 'text-gray-600 hover:text-gray-900'}"
+                                    >
+                                        {child.title}
+                                    </a>
+                                </li>
+                            {/each}
+                        </ul>
+                    {/if}
+                </li>
+            {/each}
+        </ul>
+    </nav>
+
+    <main class="flex-1 min-w-0 max-w-3xl px-8 py-6">
+        {@render children()}
+    </main>
+</div>

--- a/web/src/routes/~docs/+layout.ts
+++ b/web/src/routes/~docs/+layout.ts
@@ -1,0 +1,3 @@
+export const prerender = true;
+export const ssr = true;
+export const trailingSlash = "always";

--- a/web/src/routes/~docs/[...path]/+page.server.ts
+++ b/web/src/routes/~docs/[...path]/+page.server.ts
@@ -1,0 +1,17 @@
+import { error } from "@sveltejs/kit";
+import { findAllDocPaths, loadDocPage } from "$lib/docs";
+import type { EntryGenerator, PageServerLoad } from "./$types";
+
+export const entries: EntryGenerator = () => {
+    return findAllDocPaths().map((path) => ({ path }));
+};
+
+export const load: PageServerLoad = async ({ params }) => {
+    try {
+        const urlPath = (params.path ?? "").replace(/\/$/, "");
+        const page = await loadDocPage(urlPath);
+        return page;
+    } catch {
+        error(404, "Page not found");
+    }
+};

--- a/web/src/routes/~docs/[...path]/+page.svelte
+++ b/web/src/routes/~docs/[...path]/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+let { data } = $props();
+</script>
+
+<svelte:head>
+    <title>{data.title} - Skyr Docs</title>
+</svelte:head>
+
+<article class="prose max-w-none">
+    {@html data.html}
+</article>


### PR DESCRIPTION
Render the docs/ markdown files as prerendered HTML pages at /~docs.
Uses marked for markdown parsing and shiki for syntax highlighting,
both of which were already project dependencies.

- Vite plugin reads docs/ at build time via +page.server.ts
- SvelteKit prerenders all doc pages with sidebar navigation
- Links between docs are rewritten to absolute /~docs/ URLs
- Containerfile.web updated to include docs/ in the build context

https://claude.ai/code/session_01Fq5hexsQPHMta7buPjeNHU