### PR TITLE
fix(ldb): reduce Kafka connection churn to prevent FD exhaustion

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -26,7 +26,7 @@ struct Context {
     cdb_client: cdb::Client,
     rdb_client: rdb::Client,
     adb_client: adb::Client,
-    ldb_brokers: String,
+    ldb_consumer: ldb::Consumer,
     challenger: Arc<challenge::Challenger>,
     rp_id: Arc<String>,
     rp_name: Arc<String>,
@@ -1714,19 +1714,14 @@ impl Subscription {
 
         let initial_amount = initial_amount.unwrap_or(1000).max(0) as u64;
 
-        let consumer = ldb::ClientBuilder::new()
-            .brokers(context.ldb_brokers.clone())
-            .build_consumer()
+        let namespace = context
+            .ldb_consumer
+            .namespace(deployment_id)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to build ldb consumer for subscription: {}", e);
+                tracing::error!("Failed to prepare deployment logs subscription consumer: {e}");
                 field_error("failed to tail logs")
             })?;
-
-        let namespace = consumer.namespace(deployment_id).await.map_err(|e| {
-            tracing::error!("Failed to prepare deployment logs subscription consumer: {e}");
-            field_error("failed to tail logs")
-        })?;
         let mut inner = namespace
             .tail(ldb::TailConfig {
                 follow: true,
@@ -1780,17 +1775,7 @@ impl Subscription {
 
         let initial_amount = initial_amount.unwrap_or(1000).max(0) as u64;
 
-        let consumer = ldb::ClientBuilder::new()
-            .brokers(context.ldb_brokers.clone())
-            .build_consumer()
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to build ldb consumer for environment logs subscription: {e}"
-                );
-                field_error("failed to tail logs")
-            })?;
-
+        let consumer = context.ldb_consumer.clone();
         let cdb_client = context.cdb_client.clone();
 
         Ok(Box::pin(async_stream::stream! {
@@ -1901,16 +1886,8 @@ impl Subscription {
 
         let initial_amount = initial_amount.unwrap_or(1000).max(0) as u64;
 
-        let consumer = ldb::ClientBuilder::new()
-            .brokers(context.ldb_brokers.clone())
-            .build_consumer()
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to build ldb consumer for resource logs subscription: {e}");
-                field_error("failed to tail logs")
-            })?;
-
-        let namespace = consumer
+        let namespace = context
+            .ldb_consumer
             .namespace(resource_qid.clone())
             .await
             .map_err(|e| {
@@ -1953,11 +1930,7 @@ impl Subscription {
 }
 
 async fn load_logs(context: &Context, namespace: String, amount: u64) -> anyhow::Result<Vec<Log>> {
-    let consumer = ldb::ClientBuilder::new()
-        .brokers(context.ldb_brokers.clone())
-        .build_consumer()
-        .await?;
-    let namespace = consumer.namespace(namespace).await?;
+    let namespace = context.ldb_consumer.namespace(namespace).await?;
     let mut stream = namespace
         .tail(ldb::TailConfig {
             follow: false,
@@ -2228,6 +2201,10 @@ async fn main() -> anyhow::Result<()> {
     }
     let adb_client = adb_builder.build().await?;
     let ldb_brokers = format!("{}:9092", cli.ldb_hostname);
+    let ldb_consumer = ldb::ClientBuilder::new()
+        .brokers(ldb_brokers)
+        .build_consumer()
+        .await?;
     let challenger = Arc::new(challenge::Challenger::new(challenge_salt.into_bytes()));
     let rp_id = Arc::new(cli.rp_id);
     let rp_name = Arc::new(cli.rp_name);
@@ -2250,7 +2227,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(cdb_client))
         .layer(Extension(rdb_client))
         .layer(Extension(adb_client))
-        .layer(Extension(ldb_brokers))
+        .layer(Extension(ldb_consumer))
         .layer(Extension(udb_client));
 
     let bind_target = format!("{}:{}", cli.host, cli.port);
@@ -2275,7 +2252,7 @@ async fn graphql_handler(
     Extension(cdb_client): Extension<cdb::Client>,
     Extension(rdb_client): Extension<rdb::Client>,
     Extension(adb_client): Extension<adb::Client>,
-    Extension(ldb_brokers): Extension<String>,
+    Extension(ldb_consumer): Extension<ldb::Consumer>,
     Extension(mut udb_client): Extension<udb::Client>,
     headers: http::header::HeaderMap,
     AxumJson(request): AxumJson<juniper::http::GraphQLRequest>,
@@ -2304,7 +2281,7 @@ async fn graphql_handler(
                     cdb_client,
                     rdb_client,
                     adb_client,
-                    ldb_brokers,
+                    ldb_consumer,
                     challenger,
                     rp_id,
                     rp_name,
@@ -2320,7 +2297,7 @@ async fn graphql_handler(
         cdb_client,
         rdb_client,
         adb_client,
-        ldb_brokers,
+        ldb_consumer,
         challenger,
         rp_id,
         rp_name,
@@ -2347,7 +2324,7 @@ async fn graphql_ws_handler(
     Extension(cdb_client): Extension<cdb::Client>,
     Extension(rdb_client): Extension<rdb::Client>,
     Extension(adb_client): Extension<adb::Client>,
-    Extension(ldb_brokers): Extension<String>,
+    Extension(ldb_consumer): Extension<ldb::Consumer>,
     Extension(mut udb_client): Extension<udb::Client>,
     headers: http::header::HeaderMap,
 ) -> Response {
@@ -2375,7 +2352,7 @@ async fn graphql_ws_handler(
         cdb_client,
         rdb_client,
         adb_client,
-        ldb_brokers,
+        ldb_consumer,
         challenger,
         rp_id,
         rp_name,

--- a/crates/ldb/Cargo.toml
+++ b/crates/ldb/Cargo.toml
@@ -10,7 +10,7 @@ chrono = { version = "0.4.43", features = ["clock"] }
 futures-util = "0.3.31"
 rskafka = "0.5.0"
 thiserror = "2.0.18"
-tokio = { version = "1.49.0", features = ["time"] }
+tokio = { version = "1.49.0", features = ["sync", "time"] }
 
 [lints]
 workspace = true

--- a/crates/ldb/src/lib.rs
+++ b/crates/ldb/src/lib.rs
@@ -5,6 +5,8 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use tokio::sync::Mutex;
+
 use async_stream::try_stream;
 use base64::Engine as _;
 use chrono::Utc;
@@ -176,6 +178,7 @@ impl Publisher {
         Ok(NamespacePublisher {
             client: self.client.clone(),
             topic,
+            partition_client: Arc::new(Mutex::new(None)),
         })
     }
 }
@@ -184,6 +187,7 @@ impl Publisher {
 pub struct NamespacePublisher {
     client: Arc<rskafka::client::Client>,
     topic: String,
+    partition_client: Arc<Mutex<Option<Arc<rskafka::client::partition::PartitionClient>>>>,
 }
 
 impl NamespacePublisher {
@@ -210,13 +214,7 @@ impl NamespacePublisher {
         payload.push(severity.as_byte());
         payload.extend_from_slice(message.as_bytes());
 
-        let partition_client = tokio::time::timeout(
-            PRODUCE_TIMEOUT,
-            self.client
-                .partition_client(&self.topic, 0, UnknownTopicHandling::Retry),
-        )
-        .await
-        .map_err(|_| PublishError::ProduceTimeout)??;
+        let partition_client = self.get_or_create_partition_client().await?;
 
         tokio::time::timeout(
             PRODUCE_TIMEOUT,
@@ -235,8 +233,28 @@ impl NamespacePublisher {
 
         Ok(())
     }
+
+    async fn get_or_create_partition_client(
+        &self,
+    ) -> Result<Arc<rskafka::client::partition::PartitionClient>, PublishError> {
+        let mut guard = self.partition_client.lock().await;
+        if let Some(client) = guard.as_ref() {
+            return Ok(Arc::clone(client));
+        }
+        let client = tokio::time::timeout(
+            PRODUCE_TIMEOUT,
+            self.client
+                .partition_client(&self.topic, 0, UnknownTopicHandling::Retry),
+        )
+        .await
+        .map_err(|_| PublishError::ProduceTimeout)??;
+        let client = Arc::new(client);
+        *guard = Some(Arc::clone(&client));
+        Ok(client)
+    }
 }
 
+#[derive(Clone)]
 pub struct Consumer {
     client: Arc<rskafka::client::Client>,
 }


### PR DESCRIPTION
## Summary

- **Cache `PartitionClient` in `NamespacePublisher`** — previously, every single log message opened a new TCP connection to the Kafka broker via `client.partition_client()`. Now the connection is created once and reused for all subsequent publishes on the same namespace.
- **Share a single `ldb::Consumer` across all API subscriptions and queries** — previously, each GraphQL subscription (`deployment_logs`, `environment_logs`, `resource_logs`) and each `load_logs` query created a brand new `rskafka::client::Client`, each with its own metadata connection. Now one consumer is built at API startup and shared via the axum `Extension` layer / juniper `Context`.

Together these two changes dramatically reduce the number of open Kafka connections, which was exhausting the Redpanda container's file descriptor limit and causing `InvalidPartitions` / "Can not increase partition count due to FD limit" errors.

## Test plan

- [x] `cargo clippy -p ldb -p api` passes clean
- [x] `cargo test -p ldb -p api` passes
- [x] `cargo fmt` applied
- [ ] Manual test: run `make up` with a low-resource Redpanda container, open multiple log subscriptions in the web UI, and verify FD count stays stable over time

https://claude.ai/code/session_01J2yCGA8BmShtChj1Yf4gXZ