### PR TITLE
fix(udb): address quality audit findings (#166)

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -329,6 +329,9 @@ impl Mutation {
             Err(udb::RegisterUserError::UsernameTaken) => {
                 return Err(field_error("Username already taken"));
             }
+            Err(udb::RegisterUserError::InvalidUsername(msg)) => {
+                return Err(field_error(&format!("Invalid username: {msg}")));
+            }
             Err(e) => {
                 tracing::error!("Failed to register user: {}", e);
                 return Err(internal_error());
@@ -2264,7 +2267,7 @@ async fn graphql_handler(
 
     if let Some(token) = auth_header {
         match udb_client.lookup_token(token).await {
-            Err(udb::LookupTokenError::InvalidToken) => {
+            Err(udb::LookupTokenError::InvalidToken | udb::LookupTokenError::Expired) => {
                 return AxumJson(juniper::http::GraphQLResponse::error(
                     juniper::FieldError::new(
                         "Invalid token",
@@ -2335,7 +2338,7 @@ async fn graphql_ws_handler(
 
     let user = if let Some(token) = auth_header {
         match udb_client.lookup_token(token).await {
-            Err(udb::LookupTokenError::InvalidToken) => {
+            Err(udb::LookupTokenError::InvalidToken | udb::LookupTokenError::Expired) => {
                 return (StatusCode::UNAUTHORIZED, "Invalid token").into_response();
             }
             Err(e) => {
@@ -2441,7 +2444,10 @@ async fn graphql_ws_connection(
                                 Ok(user) => {
                                     context.user = Some(user);
                                 }
-                                Err(udb::LookupTokenError::InvalidToken) => {
+                                Err(
+                                    udb::LookupTokenError::InvalidToken
+                                    | udb::LookupTokenError::Expired,
+                                ) => {
                                     tracing::debug!("Invalid token in connection_init payload");
                                 }
                                 Err(e) => {

--- a/crates/udb/src/lib.rs
+++ b/crates/udb/src/lib.rs
@@ -58,6 +58,9 @@ pub enum RegisterUserError {
 
     #[error("username already taken")]
     UsernameTaken,
+
+    #[error("invalid username: {0}")]
+    InvalidUsername(String),
 }
 
 #[derive(Error, Debug)]
@@ -73,6 +76,15 @@ pub enum UserQueryError {
 
     #[error("token expiry cannot be represented as u32 epoch seconds")]
     InvalidTokenExpiry,
+
+    #[error("invalid SSH public key: {0}")]
+    InvalidPublicKey(#[from] ssh_key::Error),
+
+    #[error("invalid username: {0}")]
+    InvalidUsername(String),
+
+    #[error("corrupted data: {0}")]
+    DataCorruption(String),
 }
 
 #[derive(Error, Debug)]
@@ -82,6 +94,12 @@ pub enum LookupTokenError {
 
     #[error("invalid token")]
     InvalidToken,
+
+    #[error("token has expired")]
+    Expired,
+
+    #[error("system clock error: {0}")]
+    Clock(#[from] std::time::SystemTimeError),
 }
 
 #[derive(Error, Debug)]
@@ -135,6 +153,18 @@ fn credential_key(username: &str, fingerprint: &str) -> String {
     format!("c:{username}:{fingerprint}")
 }
 
+/// Validates that a username is safe for use in Redis key construction.
+/// Returns the validation error message if invalid, or Ok(()) if valid.
+fn validate_username(username: &str) -> Result<(), String> {
+    if username.is_empty() {
+        return Err("username must not be empty".into());
+    }
+    if username.contains(':') {
+        return Err("username must not contain ':'".into());
+    }
+    Ok(())
+}
+
 impl Client {
     pub fn user(&self, username: impl Into<String>) -> UserClient {
         UserClient {
@@ -148,6 +178,29 @@ impl Client {
         token: impl Into<String>,
     ) -> Result<UserClient, LookupTokenError> {
         let token = token.into();
+
+        // Validate embedded expiry before hitting Redis (defense-in-depth
+        // beyond Redis TTL). Token format: "{expiry_hex}.{raw_token}".
+        if let Some(dot_pos) = token.find('.') {
+            let expiry_hex = &token[..dot_pos];
+            if let Ok(expiry_bytes) = hex::decode(expiry_hex)
+                && expiry_bytes.len() == 4
+            {
+                let expiry = u32::from_be_bytes([
+                    expiry_bytes[0],
+                    expiry_bytes[1],
+                    expiry_bytes[2],
+                    expiry_bytes[3],
+                ]);
+                let now = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)?
+                    .as_secs();
+                if u64::from(expiry) < now {
+                    return Err(LookupTokenError::Expired);
+                }
+            }
+        }
+
         let username: Option<String> = self.conn.get(token_key(&token)).await?;
 
         match username {
@@ -177,6 +230,7 @@ impl UserClient {
         email: impl Into<String>,
         fullname: Option<String>,
     ) -> Result<User, RegisterUserError> {
+        validate_username(&self.username).map_err(RegisterUserError::InvalidUsername)?;
         let email = email.into();
 
         let result: i32 = self
@@ -272,14 +326,25 @@ impl TokensClient {
     pub async fn revoke(&mut self, token: impl Into<String>) -> Result<(), LookupTokenError> {
         let token = token.into();
 
-        let deleted: bool = redis::cmd("DELEX")
-            .arg(token_key(&token))
-            .arg("IFEQ")
+        // Atomically delete the key only if its value matches the expected
+        // username. This replaces the non-standard DELEX command with a
+        // standard Lua script that works on all Redis versions.
+        let script = redis::Script::new(
+            r#"
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                return redis.call('DEL', KEYS[1])
+            else
+                return 0
+            end
+            "#,
+        );
+        let deleted: i32 = script
+            .key(token_key(&token))
             .arg(&self.user.username)
-            .query_async(&mut self.user.client.conn)
+            .invoke_async(&mut self.user.client.conn)
             .await?;
 
-        if !deleted {
+        if deleted == 0 {
             return Err(LookupTokenError::InvalidToken);
         }
 
@@ -356,9 +421,7 @@ impl PubkeysClient {
         credential_id: Option<&str>,
         sign_count: u32,
     ) -> Result<Credential, UserQueryError> {
-        let parsed = PublicKey::from_openssh(public_key).map_err(|e| {
-            UserQueryError::Redis(redis::RedisError::from(std::io::Error::other(e)))
-        })?;
+        let parsed = PublicKey::from_openssh(public_key)?;
         let fingerprint = parsed.fingerprint(ssh_key::HashAlg::Sha256).to_string();
 
         let _: () = self
@@ -407,11 +470,12 @@ impl PubkeysClient {
         };
 
         let credential_id = credential_id.filter(|s| !s.is_empty());
-        let sign_count = sign_count_str
-            .as_deref()
-            .unwrap_or("0")
-            .parse::<u32>()
-            .unwrap_or(0);
+        let sign_count_raw = sign_count_str.as_deref().unwrap_or("0");
+        let sign_count = sign_count_raw.parse::<u32>().map_err(|_| {
+            UserQueryError::DataCorruption(format!(
+                "sign_count is not a valid u32: {sign_count_raw:?}"
+            ))
+        })?;
 
         Ok(Credential {
             fingerprint: fingerprint.to_owned(),


### PR DESCRIPTION
## Summary

Addresses the critical and medium-severity findings from the quality audit in #166:

- **[CRITICAL] Token expiry validation (2.1):** `lookup_token` now parses and validates the embedded expiry timestamp before querying Redis, providing defense-in-depth beyond Redis TTL
- **[MEDIUM] Non-standard DELEX command (2.2):** Replaced with a portable Lua script (`GET` + conditional `DEL`) that works on all standard Redis versions
- **[MEDIUM] Error type mapping (1.3):** Added `InvalidPublicKey` error variant to `UserQueryError` instead of incorrectly wrapping SSH key parse errors as `Redis` errors
- **[MEDIUM] Silent parse failures (2.4):** `sign_count` parse errors now surface as `DataCorruption` instead of silently defaulting to 0
- **[MEDIUM] Username validation (3.3):** Added validation at registration time to reject empty usernames and usernames containing `:` (which would interfere with Redis credential key format)
- Updated all API call sites to handle the new `Expired` token variant alongside `InvalidToken`

**Not addressed** (would require larger refactoring):
- 1.1 (`&mut self` on reads) — Redis-rs `AsyncCommands` trait requires `&mut self`; changing this needs a wrapper with interior mutability
- 3.1 (COSE curve point validation) — requires a crypto library for on-curve checks
- 3.2 (rate limiting) — infrastructure-level concern, better handled at the API/middleware layer

## Test plan

- [x] `cargo clippy -p udb -p api` — no warnings
- [x] `cargo clippy --all-targets` — no new warnings (pre-existing `scs` warning only)
- [x] `cargo test -p udb -p api` — all tests pass
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)