### PR TITLE
fix(plugin_std_time): address quality audit findings

### DIFF
--- a/crates/plugin_std_time/src/main.rs
+++ b/crates/plugin_std_time/src/main.rs
@@ -23,6 +23,19 @@ impl TimePlugin {
         let months = *inputs.get("months").assert_int_ref()?;
         let milliseconds = *inputs.get("milliseconds").assert_int_ref()?;
 
+        if months <= 0 && milliseconds <= 0 {
+            anyhow::bail!(
+                "Clock duration must be positive: \
+                 at least one of months or milliseconds must be greater than zero"
+            );
+        }
+        if months < 0 {
+            anyhow::bail!("Clock months must be non-negative, got {months}");
+        }
+        if milliseconds < 0 {
+            anyhow::bail!("Clock milliseconds must be non-negative, got {milliseconds}");
+        }
+
         let now = Utc::now();
         let boundary = truncate_to_boundary(now, months, milliseconds)?;
 
@@ -41,6 +54,11 @@ impl TimePlugin {
     }
 }
 
+/// Compute months since the Unix epoch for a given datetime.
+fn months_since_epoch(dt: &DateTime<Utc>) -> i64 {
+    (dt.year() - 1970) as i64 * 12 + (dt.month() as i64 - 1)
+}
+
 /// Truncate `now` to the closest past boundary of a duration defined by
 /// `months` and `milliseconds`, aligned with the Unix epoch.
 ///
@@ -52,16 +70,19 @@ fn truncate_to_boundary(
     milliseconds: i64,
 ) -> anyhow::Result<DateTime<Utc>> {
     // Start from the epoch
-    let epoch = DateTime::from_timestamp_millis(0).unwrap();
+    let epoch =
+        DateTime::from_timestamp_millis(0).expect("Unix epoch (0ms) is always a valid timestamp");
 
     // Step 1: Find the month boundary
     let month_boundary = if months > 0 {
-        // Months since epoch for `now`
-        let now_months_since_epoch = (now.year() - 1970) as i64 * 12 + (now.month() as i64 - 1);
+        let now_months_since_epoch = months_since_epoch(&now);
         // How many complete month-intervals have passed
         let intervals = now_months_since_epoch / months;
         // The month boundary is intervals * months from epoch
-        let boundary_months = (intervals * months) as u32;
+        let boundary_months = intervals
+            .checked_mul(months)
+            .and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| anyhow::anyhow!("month overflow computing clock boundary"))?;
         epoch
             .checked_add_months(Months::new(boundary_months))
             .ok_or_else(|| anyhow::anyhow!("month overflow computing clock boundary"))?
@@ -76,10 +97,12 @@ fn truncate_to_boundary(
             // now is before the computed month boundary — can happen with
             // day-of-month truncation; fall back to the previous month interval
             let prev_months = if months > 0 {
-                let now_months_since_epoch =
-                    (now.year() - 1970) as i64 * 12 + (now.month() as i64 - 1);
+                let now_months_since_epoch = months_since_epoch(&now);
                 let intervals = now_months_since_epoch / months;
-                let prev_boundary_months = ((intervals - 1) * months) as u32;
+                let prev_boundary_months = (intervals - 1)
+                    .checked_mul(months)
+                    .and_then(|v| u32::try_from(v).ok())
+                    .ok_or_else(|| anyhow::anyhow!("month overflow computing clock boundary"))?;
                 epoch
                     .checked_add_months(Months::new(prev_boundary_months))
                     .ok_or_else(|| anyhow::anyhow!("month overflow computing clock boundary"))?
@@ -88,11 +111,15 @@ fn truncate_to_boundary(
             };
             let ms_since = now.signed_duration_since(prev_months).num_milliseconds();
             let ms_intervals = ms_since / milliseconds;
-            let offset_ms = ms_intervals * milliseconds;
+            let offset_ms = ms_intervals
+                .checked_mul(milliseconds)
+                .ok_or_else(|| anyhow::anyhow!("millisecond overflow computing clock boundary"))?;
             Ok(prev_months + chrono::Duration::milliseconds(offset_ms))
         } else {
             let ms_intervals = ms_since_month_boundary / milliseconds;
-            let offset_ms = ms_intervals * milliseconds;
+            let offset_ms = ms_intervals
+                .checked_mul(milliseconds)
+                .ok_or_else(|| anyhow::anyhow!("millisecond overflow computing clock boundary"))?;
             Ok(month_boundary + chrono::Duration::milliseconds(offset_ms))
         }
     } else {
@@ -224,5 +251,72 @@ mod tests {
         let now = DateTime::from_timestamp_millis(0).unwrap();
         let boundary = truncate_to_boundary(now, 1, 1000).unwrap();
         assert_eq!(boundary.timestamp_millis(), 0);
+    }
+
+    // Edge case tests for negative/zero durations
+
+    #[test]
+    fn reject_zero_duration() {
+        let plugin = TimePlugin::new();
+        let mut inputs = sclc::Record::default();
+        inputs.insert(String::from("months"), sclc::Value::Int(0));
+        inputs.insert(String::from("milliseconds"), sclc::Value::Int(0));
+        let result = plugin.clock_resource(inputs);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must be positive"));
+    }
+
+    #[test]
+    fn reject_negative_months() {
+        let plugin = TimePlugin::new();
+        let mut inputs = sclc::Record::default();
+        inputs.insert(String::from("months"), sclc::Value::Int(-1));
+        inputs.insert(String::from("milliseconds"), sclc::Value::Int(1000));
+        let result = plugin.clock_resource(inputs);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must be non-negative")
+        );
+    }
+
+    #[test]
+    fn reject_negative_milliseconds() {
+        let plugin = TimePlugin::new();
+        let mut inputs = sclc::Record::default();
+        inputs.insert(String::from("months"), sclc::Value::Int(1));
+        inputs.insert(String::from("milliseconds"), sclc::Value::Int(-500));
+        let result = plugin.clock_resource(inputs);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must be non-negative")
+        );
+    }
+
+    #[test]
+    fn reject_both_negative() {
+        let plugin = TimePlugin::new();
+        let mut inputs = sclc::Record::default();
+        inputs.insert(String::from("months"), sclc::Value::Int(-1));
+        inputs.insert(String::from("milliseconds"), sclc::Value::Int(-1));
+        let result = plugin.clock_resource(inputs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn months_since_epoch_helper() {
+        let dt = DateTime::parse_from_rfc3339("2024-03-15T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // (2024-1970)*12 + (3-1) = 54*12 + 2 = 650
+        assert_eq!(months_since_epoch(&dt), 650);
+
+        let epoch = DateTime::from_timestamp_millis(0).unwrap();
+        assert_eq!(months_since_epoch(&epoch), 0);
     }
 }


### PR DESCRIPTION
## Summary
- **Input validation**: Reject zero/negative `months` and `milliseconds` values with clear error messages (findings 3.3, 2.2)
- **Safer arithmetic**: Replace `as u32` casts with `checked_mul` + `try_from` to prevent silent truncation on overflow (findings 3.1, 3.4)
- **Better error context**: Replace bare `.unwrap()` on epoch creation with `.expect()` (finding 3.2)
- **Deduplicate logic**: Extract `months_since_epoch()` helper to remove duplicated month calculation (finding 1.3)
- **Edge case tests**: Add tests for zero duration, negative months, negative milliseconds, both negative, and the helper function (findings 1.2, 2.2)

Closes #151

## Test plan
- [x] All 10 unit tests pass (`cargo test -p plugin_std_time`)
- [x] No clippy warnings
- [x] Formatted with `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)