### PR TITLE
fix(plugin_std_random): defensive validation and logging

### DIFF
--- a/crates/plugin_std_random/Cargo.toml
+++ b/crates/plugin_std_random/Cargo.toml
@@ -16,6 +16,7 @@ ids = { path = "../ids" }
 rtp = { path = "../rtp" }
 sclc = { path = "../sclc" }
 tokio = { version = "1.49.0", features = ["full"] }
+tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [lints]

--- a/crates/plugin_std_random/src/main.rs
+++ b/crates/plugin_std_random/src/main.rs
@@ -1,6 +1,8 @@
+use anyhow::Context;
 use clap::Parser;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use sclc::ValueAssertions;
+use tracing::debug;
 
 const INT_RESOURCE_TYPE: &str = "Std/Random.Int";
 
@@ -33,9 +35,23 @@ impl RandomPlugin {
     }
 
     fn gen_int_resource(&mut self, inputs: sclc::Record) -> anyhow::Result<sclc::Resource> {
-        let min = *inputs.get("min").assert_int_ref()?;
-        let max = *inputs.get("max").assert_int_ref()?;
+        let min = *inputs
+            .get("min")
+            .assert_int_ref()
+            .context("missing or invalid 'min' input")?;
+        let max = *inputs
+            .get("max")
+            .assert_int_ref()
+            .context("missing or invalid 'max' input")?;
+
+        anyhow::ensure!(
+            min <= max,
+            "min ({min}) must not be greater than max ({max})"
+        );
+
+        debug!(min, max, "generating random integer");
         let result = self.rng.random_range(min..=max);
+        debug!(result, "generated random integer");
 
         let mut outputs = sclc::Record::default();
         outputs.insert(String::from("result"), sclc::Value::Int(result));
@@ -57,6 +73,7 @@ impl rtp::Plugin for RandomPlugin {
         id: ids::ResourceId,
         inputs: sclc::Record,
     ) -> anyhow::Result<sclc::Resource> {
+        debug!(resource_type = %id.typ, "creating random resource");
         self.dispatch(&id, inputs)
     }
 
@@ -69,6 +86,7 @@ impl rtp::Plugin for RandomPlugin {
         _prev_outputs: sclc::Record,
         inputs: sclc::Record,
     ) -> anyhow::Result<sclc::Resource> {
+        debug!(resource_type = %id.typ, "updating random resource");
         self.dispatch(&id, inputs)
     }
 }


### PR DESCRIPTION
## Summary
- Add min/max validation to prevent `random_range` panic when `min > max`
- Add `.context()` on `Record::get` assertions for better error messages
- Add `tracing::debug!` logging for resource create/update operations

Closes #158

## Test plan
- [ ] Verify `cargo clippy -p plugin_std_random` passes
- [ ] Verify `cargo test -p plugin_std_random` passes
- [ ] Manual test: confirm plugin rejects `min > max` with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)