### PR TITLE
fix(de): address quality audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,6 +4278,7 @@ dependencies = [
  "rtp",
  "sclc",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -38,35 +38,41 @@ fn serialize_inputs(
     id: &ids::ResourceId,
     inputs: &sclc::Record,
     context: &str,
-) -> Option<serde_json::Value> {
-    match serde_json::to_value(inputs) {
-        Ok(value) => Some(value),
-        Err(error) => {
-            tracing::error!(
-                resource_type = %id.typ,
-                resource_name = %id.name,
-                error = %error,
-                "failed to encode {context} inputs",
-            );
-            None
-        }
-    }
+) -> anyhow::Result<serde_json::Value> {
+    serde_json::to_value(inputs).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to encode {context} inputs for {}:{}: {error}",
+            id.typ,
+            id.name,
+        )
+    })
 }
 
-fn extract_deployment_id(owner_qid: String) -> ids::DeploymentId {
-    let id_str = owner_qid
-        .rsplit_once('@')
-        .map(|(_, id)| id)
-        .unwrap_or(&owner_qid);
-    id_str
+/// Returns the deployment ID portion of an owner QID string, validating
+/// that it parses as a well-formed `DeploymentQid`.
+fn extract_deployment_id(owner_qid: &str) -> anyhow::Result<ids::DeploymentId> {
+    let qid: ids::DeploymentQid = owner_qid
         .parse()
-        .unwrap_or_else(|_| ids::DeploymentId::new_unchecked(id_str))
+        .map_err(|_| anyhow::anyhow!("invalid owner QID: {owner_qid}"))?;
+    Ok(qid.deployment)
+}
+
+/// Returns a short (up to 8 char) prefix of the deployment ID for log messages.
+fn short_id(deployment_id: &str) -> &str {
+    deployment_id.get(..8).unwrap_or(deployment_id)
 }
 
 fn diag_severity(level: sclc::DiagLevel) -> ldb::Severity {
     match level {
         sclc::DiagLevel::Error => ldb::Severity::Error,
         sclc::DiagLevel::Warning => ldb::Severity::Warning,
+    }
+}
+
+fn resource_id_from(resource: &rdb::Resource) -> ids::ResourceId {
+    ids::ResourceId {
+        typ: resource.resource_type.clone(),
+        name: resource.name.clone(),
     }
 }
 
@@ -237,6 +243,30 @@ struct EvalOutcome {
     fully_explored: bool,
 }
 
+/// Enqueue an RTQ message, logging errors to both tracing and the deployment
+/// log publisher. Returns `true` if the message was enqueued successfully.
+async fn enqueue_message(
+    rtq_publisher: &rtq::Publisher,
+    log_publisher: &ldb::NamespacePublisher,
+    message: &rtq::Message,
+    context: &str,
+    id: &ids::ResourceId,
+) -> bool {
+    if let Err(error) = rtq_publisher.enqueue(message).await {
+        tracing::error!(
+            resource_type = %id.typ,
+            resource_name = %id.name,
+            error = %error,
+            "failed to publish {context} message",
+        );
+        log_publisher
+            .error(format!("Failed to enqueue {context} {id}: {error}",))
+            .await;
+        return false;
+    }
+    true
+}
+
 impl Worker {
     async fn run_loop(mut self, mut rx: oneshot::Receiver<()>) {
         loop {
@@ -262,16 +292,16 @@ impl Worker {
     async fn work(&mut self) -> anyhow::Result<()> {
         let deployment = self.client.get().await?;
         let deployment_id = deployment.deployment.clone();
-        let short_id = &deployment_id.as_str()[..8];
+        let sid = short_id(deployment_id.as_str());
 
         match deployment.state {
             DeploymentState::Down => {
-                tracing::info!("{short_id} down, waiting to be decommissioned...");
+                tracing::info!("{sid} down, waiting to be decommissioned...");
                 Ok(())
             }
 
             DeploymentState::Desired => {
-                tracing::info!("{short_id} reconciling");
+                tracing::info!("{sid} reconciling");
                 let outcome = self.compile_and_evaluate().await?;
                 let owner_deployment_qid = deployment.deployment_qid().to_string();
 
@@ -313,12 +343,10 @@ impl Worker {
                         drop(resources);
 
                         if !has_volatile {
-                            tracing::info!(
-                                "{short_id} all resources non-volatile; transitioning to UP"
-                            );
+                            tracing::info!("{sid} all resources non-volatile; transitioning to UP");
                             self.client.set(DeploymentState::Up).await?;
                             self.log_publisher
-                                .info(format!("{short_id} is up (all resources non-volatile)"))
+                                .info(format!("{sid} is up (all resources non-volatile)"))
                                 .await;
                         }
                     }
@@ -333,12 +361,12 @@ impl Worker {
             }
 
             DeploymentState::Up => {
-                tracing::debug!("{short_id} up; no reconciliation needed");
+                tracing::debug!("{sid} up; no reconciliation needed");
                 Ok(())
             }
 
             DeploymentState::Undesired => {
-                tracing::info!("{short_id} tearing down");
+                tracing::info!("{sid} tearing down");
 
                 let owner_deployment_qid = deployment.deployment_qid().to_string();
                 let mut all_resources = Vec::new();
@@ -367,10 +395,7 @@ impl Worker {
                     .collect::<HashSet<_>>();
 
                 for resource in &owned_resources {
-                    let resource_id = ids::ResourceId {
-                        typ: resource.resource_type.clone(),
-                        name: resource.name.clone(),
-                    };
+                    let resource_id = resource_id_from(resource);
 
                     if resource.markers.contains(&sclc::Marker::Sticky) {
                         tracing::info!(
@@ -425,12 +450,10 @@ impl Worker {
                             ))
                             .await;
                     }
-                    tracing::info!(
-                        "{short_id} no more non-sticky resources, setting state to DOWN"
-                    );
+                    tracing::info!("{sid} no more non-sticky resources, setting state to DOWN");
                     self.client.set(DeploymentState::Down).await?;
                     self.log_publisher
-                        .info(format!("Undesired {short_id} is fully torn down"))
+                        .info(format!("Undesired {sid} is fully torn down"))
                         .await;
                     return Ok(());
                 }
@@ -438,11 +461,11 @@ impl Worker {
                 if blocked > 0 {
                     tracing::info!(
                         blocked_resources = blocked,
-                        "{short_id} teardown waiting on living dependents",
+                        "{sid} teardown waiting on living dependents",
                     );
                     self.log_publisher
                         .info(format!(
-                            "Undesired {short_id} still has {blocked} resources with living dependents"
+                            "Undesired {sid} still has {blocked} resources with living dependents"
                         ))
                         .await;
                 }
@@ -450,7 +473,7 @@ impl Worker {
             }
 
             DeploymentState::Lingering => {
-                tracing::info!("{short_id} lingering...");
+                tracing::info!("{sid} lingering...");
                 let mut cursor = self.client.clone();
                 let mut seen = HashSet::new();
 
@@ -502,10 +525,7 @@ impl Worker {
             .iter()
             .filter(|resource| {
                 resource.owner.as_deref() == Some(owner_deployment_qid)
-                    && !touched_resource_ids.contains(&ids::ResourceId {
-                        typ: resource.resource_type.clone(),
-                        name: resource.name.clone(),
-                    })
+                    && !touched_resource_ids.contains(&resource_id_from(resource))
             })
             .collect();
 
@@ -519,10 +539,7 @@ impl Worker {
         let living_dependency_targets: HashSet<ids::ResourceId> = all_resources
             .iter()
             .filter(|resource| {
-                let id = ids::ResourceId {
-                    typ: resource.resource_type.clone(),
-                    name: resource.name.clone(),
-                };
+                let id = resource_id_from(resource);
                 // Don't let untouched owned resources block each other.
                 resource.owner.as_deref() != Some(owner_deployment_qid)
                     || touched_resource_ids.contains(&id)
@@ -531,10 +548,7 @@ impl Worker {
             .collect();
 
         for resource in &untouched_owned {
-            let resource_id = ids::ResourceId {
-                typ: resource.resource_type.clone(),
-                name: resource.name.clone(),
-            };
+            let resource_id = resource_id_from(resource);
 
             if resource.markers.contains(&sclc::Marker::Sticky) {
                 tracing::info!(
@@ -583,13 +597,19 @@ impl Worker {
                 diag = %diag,
                 "compile diagnostic",
             );
-            self.log_publisher
+            if let Err(error) = self
+                .log_publisher
                 .log(
                     diag_severity(diag.level()),
                     format!("{module_id}:{span}: {diag}"),
                 )
                 .await
-                .unwrap_or_default();
+            {
+                tracing::warn!(
+                    error = %error,
+                    "failed to publish diagnostic to log",
+                );
+            }
         }
     }
 
@@ -617,6 +637,14 @@ impl Worker {
         let owner_deployment_qid = full_deployment_qid.to_string();
         let deployment_id = full_deployment_qid.deployment.clone();
 
+        // Collect the set of superseded deployment QIDs so we can validate
+        // that adoption only happens from deployments we legitimately supersede.
+        let mut superseded_deployment_qids = HashSet::new();
+        for superseded in self.client.superseded().await? {
+            let dep = superseded.get().await?;
+            superseded_deployment_qids.insert(dep.deployment_qid().to_string());
+        }
+
         let (effects_tx, mut effects_rx) = mpsc::unbounded_channel();
         let mut eval =
             sclc::Eval::new::<DeploymentClient>(effects_tx, owner_deployment_qid.clone());
@@ -624,10 +652,7 @@ impl Worker {
         let mut volatile_resource_ids = HashSet::new();
         let mut resources = self.namespace.list_resources().await?;
         while let Some(resource) = resources.try_next().await? {
-            let resource_id = ids::ResourceId {
-                typ: resource.resource_type.clone(),
-                name: resource.name.clone(),
-            };
+            let resource_id = resource_id_from(&resource);
             if resource.owner.as_deref() != Some(owner_deployment_qid.as_str())
                 && let Some(owner) = resource.owner.clone()
             {
@@ -669,9 +694,15 @@ impl Worker {
                                 had_effect = true;
                                 had_mutation = true;
                                 touched_resource_ids.insert(id.clone());
-                                let Some(inputs_value) = serialize_inputs(&id, &inputs, "create")
-                                else {
-                                    continue;
+                                let inputs_value = match serialize_inputs(&id, &inputs, "create") {
+                                    Ok(v) => v,
+                                    Err(error) => {
+                                        tracing::error!("{error:#}");
+                                        log_publisher
+                                            .error(format!("Skipping CREATE {id}: {error}"))
+                                            .await;
+                                        continue;
+                                    }
                                 };
                                 let message = rtq::Message::Create(rtq::CreateMessage {
                                     resource: resource_ref(&env_qid, &id),
@@ -680,16 +711,15 @@ impl Worker {
                                     dependencies: map_dependencies(&env_qid, dependencies),
                                     source_trace,
                                 });
-                                if let Err(error) = rtq_publisher.enqueue(&message).await {
-                                    tracing::error!(
-                                        error = %error,
-                                        "failed to publish create message",
-                                    );
-
-                                    log_publisher
-                                        .error(format!("Failed to enqueue CREATE {id}: {error}",))
-                                        .await;
-
+                                if !enqueue_message(
+                                    &rtq_publisher,
+                                    &log_publisher,
+                                    &message,
+                                    "CREATE",
+                                    &id,
+                                )
+                                .await
+                                {
                                     continue;
                                 }
 
@@ -709,17 +739,51 @@ impl Worker {
                                 had_effect = true;
                                 had_mutation = true;
                                 touched_resource_ids.insert(id.clone());
-                                let Some(desired_inputs) = serialize_inputs(&id, &inputs, "update")
-                                else {
-                                    continue;
-                                };
+                                let desired_inputs =
+                                    match serialize_inputs(&id, &inputs, "update") {
+                                        Ok(v) => v,
+                                        Err(error) => {
+                                            tracing::error!("{error:#}");
+                                            log_publisher
+                                                .error(format!("Skipping UPDATE {id}: {error}"))
+                                                .await;
+                                            continue;
+                                        }
+                                    };
                                 let dependencies = map_dependencies(&env_qid, dependencies);
                                 let message = if let Some(from_owner_qid) =
                                     unowned_resource_owner_by_id.get(&id).cloned()
                                 {
+                                    // Validate that we are only adopting from a
+                                    // superseded deployment.
+                                    if !superseded_deployment_qids.contains(&from_owner_qid) {
+                                        tracing::warn!(
+                                            resource_type = %id.typ,
+                                            resource_name = %id.name,
+                                            from_owner = %from_owner_qid,
+                                            "refusing to adopt resource from non-superseded deployment",
+                                        );
+                                        log_publisher
+                                            .error(format!(
+                                                "Cannot adopt {id}: owner {from_owner_qid} is not a superseded deployment",
+                                            ))
+                                            .await;
+                                        continue;
+                                    }
+                                    let from_deployment_id =
+                                        match extract_deployment_id(&from_owner_qid) {
+                                            Ok(id) => id,
+                                            Err(error) => {
+                                                tracing::error!(
+                                                    from_owner = %from_owner_qid,
+                                                    "{error:#}",
+                                                );
+                                                continue;
+                                            }
+                                        };
                                     rtq::Message::Adopt(rtq::AdoptMessage {
                                         resource: resource_ref(&env_qid, &id),
-                                        from_deployment_id: extract_deployment_id(from_owner_qid),
+                                        from_deployment_id,
                                         to_deployment_id: deployment_id.clone(),
                                         desired_inputs,
                                         dependencies,
@@ -734,15 +798,15 @@ impl Worker {
                                         source_trace,
                                     })
                                 };
-                                if let Err(error) = rtq_publisher.enqueue(&message).await {
-                                    tracing::error!(
-                                        error = %error,
-                                        "failed to publish update message",
-                                    );
-
-                                    log_publisher
-                                        .error(format!("Failed to enqueue UPDATE {id}: {error}",))
-                                        .await;
+                                if !enqueue_message(
+                                    &rtq_publisher,
+                                    &log_publisher,
+                                    &message,
+                                    "UPDATE",
+                                    &id,
+                                )
+                                .await
+                                {
                                     continue;
                                 }
 
@@ -763,33 +827,67 @@ impl Worker {
                                 if let Some(from_owner_deployment_qid) =
                                     unowned_resource_owner_by_id.get(&id).cloned()
                                 {
-                                    had_effect = true;
-                                    let Some(desired_inputs) =
-                                        serialize_inputs(&id, &inputs, "touch")
-                                    else {
+                                    // Validate that we are only adopting from a
+                                    // superseded deployment.
+                                    if !superseded_deployment_qids
+                                        .contains(&from_owner_deployment_qid)
+                                    {
+                                        tracing::warn!(
+                                            resource_type = %id.typ,
+                                            resource_name = %id.name,
+                                            from_owner = %from_owner_deployment_qid,
+                                            "refusing to adopt-touch resource from non-superseded deployment",
+                                        );
+                                        log_publisher
+                                            .error(format!(
+                                                "Cannot adopt {id}: owner {from_owner_deployment_qid} is not a superseded deployment",
+                                            ))
+                                            .await;
                                         continue;
+                                    }
+                                    had_effect = true;
+                                    let desired_inputs =
+                                        match serialize_inputs(&id, &inputs, "touch") {
+                                            Ok(v) => v,
+                                            Err(error) => {
+                                                tracing::error!("{error:#}");
+                                                log_publisher
+                                                    .error(format!(
+                                                        "Skipping ADOPT {id}: {error}"
+                                                    ))
+                                                    .await;
+                                                continue;
+                                            }
+                                        };
+                                    let from_deployment_id = match extract_deployment_id(
+                                        &from_owner_deployment_qid,
+                                    ) {
+                                        Ok(id) => id,
+                                        Err(error) => {
+                                            tracing::error!(
+                                                from_owner = %from_owner_deployment_qid,
+                                                "{error:#}",
+                                            );
+                                            continue;
+                                        }
                                     };
                                     let message = rtq::Message::Adopt(rtq::AdoptMessage {
                                         resource: resource_ref(&env_qid, &id),
-                                        from_deployment_id: extract_deployment_id(
-                                            from_owner_deployment_qid,
-                                        ),
+                                        from_deployment_id,
                                         to_deployment_id: deployment_id.clone(),
                                         desired_inputs,
                                         dependencies: map_dependencies(&env_qid, dependencies),
                                         source_trace,
                                     });
-                                    if let Err(error) = rtq_publisher.enqueue(&message).await {
-                                        tracing::error!(
-                                            error = %error,
-                                            "failed to publish touch adopt message",
-                                        );
-
-                                        log_publisher
-                                            .error(
-                                                format!("Failed to enqueue ADOPT {id}: {error}",),
-                                            )
-                                            .await;
+                                    if !enqueue_message(
+                                        &rtq_publisher,
+                                        &log_publisher,
+                                        &message,
+                                        "ADOPT",
+                                        &id,
+                                    )
+                                    .await
+                                    {
                                         continue;
                                     }
 
@@ -808,17 +906,15 @@ impl Worker {
                                         resource: resource_ref(&env_qid, &id),
                                         deployment_id: deployment_id.clone(),
                                     });
-                                    if let Err(error) = rtq_publisher.enqueue(&message).await {
-                                        tracing::error!(
-                                            error = %error,
-                                            "failed to publish touch check message",
-                                        );
-
-                                        log_publisher
-                                            .error(
-                                                format!("Failed to enqueue CHECK {id}: {error}",),
-                                            )
-                                            .await;
+                                    if !enqueue_message(
+                                        &rtq_publisher,
+                                        &log_publisher,
+                                        &message,
+                                        "CHECK",
+                                        &id,
+                                    )
+                                    .await
+                                    {
                                         continue;
                                     }
 
@@ -850,13 +946,19 @@ impl Worker {
             Ok(eval_diagnosed) => {
                 for diag in eval_diagnosed.diags().iter() {
                     let (module_id, span) = diag.locate();
-                    self.log_publisher
+                    if let Err(error) = self
+                        .log_publisher
                         .log(
                             diag_severity(diag.level()),
                             format!("{module_id}:{span}: {diag}"),
                         )
                         .await
-                        .unwrap_or_default();
+                    {
+                        tracing::warn!(
+                            error = %error,
+                            "failed to publish eval diagnostic to log",
+                        );
+                    }
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary
- Fix deployment ID string slicing panic by using safe `get(..8)` (finding 2.1/3.1)
- Make `serialize_inputs` return `Result` and log errors instead of silently dropping effects (finding 3.2)
- Validate resource adoption only happens from superseded deployments (finding 3.6)
- Replace silent `unwrap_or_default()` on log publisher errors with `tracing::warn` (finding 3.7)
- Validate owner QID parsing in `extract_deployment_id` via `DeploymentQid::from_str` (finding 2.2/3.3)
- Extract `enqueue_message` and `resource_id_from` helpers to reduce code duplication (finding 1.1)

Closes #156

## Test plan
- [ ] Verify `cargo clippy -p de --all-targets` passes with no warnings
- [ ] Verify `cargo test -p de` passes
- [ ] Verify `cargo fmt` produces no changes
- [ ] Manual testing with local deployment to confirm reconciliation still works


🤖 Generated with [Claude Code](https://claude.com/claude-code)