### PR TITLE
fix(scoc): address quality audit findings

### DIFF
--- a/crates/scoc/src/dns.rs
+++ b/crates/scoc/src/dns.rs
@@ -90,9 +90,9 @@ fn handle_query(query: &[u8], records: &DnsRecords, upstream_dns: &[String]) -> 
 
     // Only handle A record queries for *.internal names
     if qtype == DNS_TYPE_A && qclass == DNS_CLASS_IN && name.ends_with(".internal") {
-        let records = records
-            .read()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        // Use unwrap_or_else to recover from a poisoned lock rather than
+        // permanently failing DNS resolution.
+        let records = records.read().unwrap_or_else(|e| e.into_inner());
 
         if let Some(&ip) = records.get(&name) {
             debug!(name = %name, ip = %ip, "DNS: resolved from records");
@@ -216,6 +216,13 @@ fn build_error_response(query: &[u8], rcode: u16) -> Option<Vec<u8>> {
 /// Forward a DNS query to upstream servers and return the response.
 fn forward_query(query: &[u8], upstream_dns: &[String]) -> Result<Vec<u8>> {
     for upstream in upstream_dns {
+        // Validate upstream is a well-formed IP address before using it
+        if upstream.parse::<Ipv4Addr>().is_err() && upstream.parse::<std::net::Ipv6Addr>().is_err()
+        {
+            warn!(upstream = %upstream, "skipping invalid upstream DNS address");
+            continue;
+        }
+
         let upstream_addr: SocketAddr = format!("{upstream}:53")
             .parse()
             .with_context(|| format!("invalid upstream DNS address: {upstream}"))?;

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -157,6 +157,31 @@ impl CriConduit {
         }
     }
 
+    /// Clean up a partially-created pod on failure.
+    ///
+    /// Stops and removes any containers that were already started, tears down
+    /// pod networking, releases the IPAM allocation, and removes the CRI sandbox.
+    /// All errors during cleanup are logged but do not propagate.
+    async fn cleanup_failed_pod(
+        &self,
+        cri: &mut CriClient,
+        cri_pod_id: &str,
+        container_ids: &[String],
+        network_setup: bool,
+    ) {
+        for cid in container_ids {
+            let _ = cri.stop_container(cid, 10).await;
+            let _ = cri.remove_container(cid).await;
+        }
+        if network_setup {
+            let _ = net::teardown_pod_network(cri_pod_id);
+        }
+        let mut ipam = self.ipam.lock().await;
+        ipam.release(cri_pod_id);
+        let _ = cri.stop_pod_sandbox(cri_pod_id).await;
+        let _ = cri.remove_pod_sandbox(cri_pod_id).await;
+    }
+
     /// Convert SCOP PodConfig to CRI PodSandboxConfig.
     fn to_cri_pod_config(&self, config: &scop::PodConfig) -> k8s_cri::v1::PodSandboxConfig {
         cri::pod_sandbox_config(&config.name, &config.environment_qid, &self.dns_servers)
@@ -288,8 +313,8 @@ impl scop::Conduit for CriConduit {
             match ipam.allocate(&cri_pod_id) {
                 Ok(ip) => ip,
                 Err(e) => {
-                    let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-                    let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+                    self.cleanup_failed_pod(&mut cri, &cri_pod_id, &[], false)
+                        .await;
                     return Err(scop::tonic::Status::internal(format!(
                         "IPAM allocation failed: {e}"
                     )));
@@ -301,10 +326,8 @@ impl scop::Conduit for CriConduit {
         let netns_path = match cri.pod_network_namespace(&cri_pod_id).await {
             Ok(path) => path,
             Err(e) => {
-                let mut ipam = self.ipam.lock().await;
-                ipam.release(&cri_pod_id);
-                let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-                let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+                self.cleanup_failed_pod(&mut cri, &cri_pod_id, &[], false)
+                    .await;
                 return Err(scop::tonic::Status::internal(format!(
                     "failed to get network namespace: {e}"
                 )));
@@ -320,10 +343,8 @@ impl scop::Conduit for CriConduit {
             self.cluster_cidr.as_deref(),
             self.service_cidr.as_deref(),
         ) {
-            let mut ipam = self.ipam.lock().await;
-            ipam.release(&cri_pod_id);
-            let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-            let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+            self.cleanup_failed_pod(&mut cri, &cri_pod_id, &[], false)
+                .await;
             return Err(scop::tonic::Status::internal(format!(
                 "pod network setup failed: {e:#}"
             )));
@@ -346,16 +367,8 @@ impl scop::Conduit for CriConduit {
 
             // Pull the image
             if let Err(e) = cri.pull_image(&container_config.image, None).await {
-                // Clean up on failure
-                for cid in &container_ids {
-                    let _ = cri.stop_container(cid, 10).await;
-                    let _ = cri.remove_container(cid).await;
-                }
-                let _ = net::teardown_pod_network(&cri_pod_id);
-                let mut ipam = self.ipam.lock().await;
-                ipam.release(&cri_pod_id);
-                let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-                let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+                self.cleanup_failed_pod(&mut cri, &cri_pod_id, &container_ids, true)
+                    .await;
                 return Err(scop::tonic::Status::internal(format!(
                     "failed to pull image for container {i}: {e}"
                 )));
@@ -368,15 +381,8 @@ impl scop::Conduit for CriConduit {
             {
                 Ok(id) => id,
                 Err(e) => {
-                    for cid in &container_ids {
-                        let _ = cri.stop_container(cid, 10).await;
-                        let _ = cri.remove_container(cid).await;
-                    }
-                    let _ = net::teardown_pod_network(&cri_pod_id);
-                    let mut ipam = self.ipam.lock().await;
-                    ipam.release(&cri_pod_id);
-                    let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-                    let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+                    self.cleanup_failed_pod(&mut cri, &cri_pod_id, &container_ids, true)
+                        .await;
                     return Err(scop::tonic::Status::internal(format!(
                         "failed to create container {i}: {e}"
                     )));
@@ -386,15 +392,8 @@ impl scop::Conduit for CriConduit {
             // Start the container
             if let Err(e) = cri.start_container(&container_id).await {
                 let _ = cri.remove_container(&container_id).await;
-                for cid in &container_ids {
-                    let _ = cri.stop_container(cid, 10).await;
-                    let _ = cri.remove_container(cid).await;
-                }
-                let _ = net::teardown_pod_network(&cri_pod_id);
-                let mut ipam = self.ipam.lock().await;
-                ipam.release(&cri_pod_id);
-                let _ = cri.stop_pod_sandbox(&cri_pod_id).await;
-                let _ = cri.remove_pod_sandbox(&cri_pod_id).await;
+                self.cleanup_failed_pod(&mut cri, &cri_pod_id, &container_ids, true)
+                    .await;
                 return Err(scop::tonic::Status::internal(format!(
                     "failed to start container {i}: {e}"
                 )));
@@ -651,10 +650,8 @@ impl scop::Conduit for CriConduit {
             .parse()
             .map_err(|e| scop::tonic::Status::invalid_argument(format!("invalid IP: {e}")))?;
 
-        let mut records = self
-            .dns_records
-            .write()
-            .map_err(|e| scop::tonic::Status::internal(format!("DNS lock poisoned: {e}")))?;
+        // Recover from a poisoned lock rather than permanently failing.
+        let mut records = self.dns_records.write().unwrap_or_else(|e| e.into_inner());
         records.insert(request.hostname.clone(), ip);
         tracing::info!(
             hostname = %request.hostname,
@@ -668,10 +665,8 @@ impl scop::Conduit for CriConduit {
         &self,
         request: scop::RemoveDnsRecordRequest,
     ) -> Result<scop::RemoveDnsRecordResponse, scop::tonic::Status> {
-        let mut records = self
-            .dns_records
-            .write()
-            .map_err(|e| scop::tonic::Status::internal(format!("DNS lock poisoned: {e}")))?;
+        // Recover from a poisoned lock rather than permanently failing.
+        let mut records = self.dns_records.write().unwrap_or_else(|e| e.into_inner());
         records.remove(&request.hostname);
         tracing::info!(
             hostname = %request.hostname,
@@ -1053,12 +1048,23 @@ fn extract_host_from_address(addr: &str) -> String {
 ///
 /// If the input is already an IP address, it is returned as-is.
 /// Otherwise, DNS resolution is performed to get the IP.
+///
+/// The input is validated to only contain safe characters (alphanumeric, hyphens,
+/// dots, colons for IPv6) to prevent injection attacks.
 fn resolve_hostname_to_ip(hostname: &str) -> Result<String> {
+    anyhow::ensure!(!hostname.is_empty(), "hostname must not be empty");
+    anyhow::ensure!(
+        hostname
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == ':'),
+        "hostname contains invalid characters: {hostname:?}"
+    );
+
     // Add a dummy port for ToSocketAddrs (it requires host:port format)
-    let addr_with_port = format!("{}:0", hostname);
+    let addr_with_port = format!("{hostname}:0");
     let resolved = addr_with_port
         .to_socket_addrs()?
         .next()
-        .ok_or_else(|| anyhow::anyhow!("could not resolve hostname: {}", hostname))?;
+        .ok_or_else(|| anyhow::anyhow!("could not resolve hostname: {hostname}"))?;
     Ok(resolved.ip().to_string())
 }

--- a/crates/scoc/src/net.rs
+++ b/crates/scoc/src/net.rs
@@ -14,6 +14,48 @@ use anyhow::{Context, Result, bail};
 use ipnet::Ipv4Net;
 use tracing::{debug, info, warn};
 
+// ============================================================================
+// Input validation helpers
+// ============================================================================
+
+/// Validate that a string is a valid IPv4 address.
+fn validate_ipv4(s: &str) -> Result<Ipv4Addr> {
+    s.parse::<Ipv4Addr>()
+        .with_context(|| format!("invalid IPv4 address: {s:?}"))
+}
+
+/// Validate that a string is a valid CIDR notation (e.g., "10.0.0.0/24").
+fn validate_cidr(s: &str) -> Result<Ipv4Net> {
+    s.parse::<Ipv4Net>()
+        .with_context(|| format!("invalid CIDR notation: {s:?}"))
+}
+
+/// Validate that a port number is in the valid range (1-65535).
+fn validate_port(port: i32) -> Result<u16> {
+    if !(1..=65535).contains(&port) {
+        bail!("port number out of range (1-65535): {port}");
+    }
+    Ok(port as u16)
+}
+
+/// Validate that a protocol string is one of the allowed values.
+fn validate_protocol(protocol: &str) -> Result<&str> {
+    match protocol {
+        "tcp" | "udp" => Ok(protocol),
+        _ => bail!("invalid protocol (expected \"tcp\" or \"udp\"): {protocol:?}"),
+    }
+}
+
+/// Validate that a network namespace path looks legitimate.
+///
+/// Must be an absolute path under `/proc/` to prevent path traversal.
+fn validate_netns_path(path: &str) -> Result<()> {
+    if !path.starts_with("/proc/") || path.contains("..") {
+        bail!("invalid network namespace path (must be under /proc/ with no ..): {path:?}");
+    }
+    Ok(())
+}
+
 /// Bridge interface name used for pod networking.
 const BRIDGE_NAME: &str = "skyr0";
 
@@ -250,6 +292,13 @@ pub(crate) fn setup_pod_network(
     cluster_cidr: Option<&str>,
     service_cidr: Option<&str>,
 ) -> Result<()> {
+    validate_netns_path(netns_path)?;
+    if let Some(cidr) = cluster_cidr {
+        validate_cidr(cidr)?;
+    }
+    if let Some(cidr) = service_cidr {
+        validate_cidr(cidr)?;
+    }
     let gateway = Ipv4Addr::from(u32::from(subnet.network()) + 1);
     let ip_cidr = format!("{}/{}", ip, subnet.prefix_len());
     let host_veth = veth_host_name(pod_id);
@@ -426,6 +475,10 @@ fn setup_pod_egress_rules(
     cluster_cidr: &str,
     service_cidr: Option<&str>,
 ) -> Result<()> {
+    validate_cidr(cluster_cidr)?;
+    if let Some(cidr) = service_cidr {
+        validate_cidr(cidr)?;
+    }
     debug!(
         netns = %netns_path,
         cluster_cidr = %cluster_cidr,
@@ -498,6 +551,10 @@ pub(crate) fn open_egress_port(
     port: i32,
     protocol: &str,
 ) -> Result<()> {
+    validate_netns_path(netns_path)?;
+    validate_ipv4(dest_address)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
     let port_str = port.to_string();
     info!(
         netns = %netns_path,
@@ -535,6 +592,10 @@ pub(crate) fn close_egress_port(
     port: i32,
     protocol: &str,
 ) -> Result<()> {
+    validate_netns_path(netns_path)?;
+    validate_ipv4(dest_address)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
     let port_str = port.to_string();
     info!(
         netns = %netns_path,
@@ -572,6 +633,7 @@ pub(crate) fn close_egress_port(
 /// L2 learning for MAC-to-VTEP resolution after BUM traffic is flooded
 /// to all peers via FDB entries.
 pub(crate) fn setup_vxlan(local_ip: &str) -> Result<()> {
+    validate_ipv4(local_ip)?;
     let vni = VXLAN_VNI.to_string();
     let port = VXLAN_PORT.to_string();
 
@@ -623,6 +685,7 @@ pub(crate) fn teardown_vxlan() -> Result<()> {
 /// Adds an FDB entry that directs BUM (broadcast, unknown-unicast, multicast)
 /// traffic to the peer's underlay IP. This enables ARP resolution across nodes.
 pub(crate) fn add_overlay_peer(peer_ip: &str) -> Result<()> {
+    validate_ipv4(peer_ip)?;
     info!(peer_ip = %peer_ip, "adding overlay peer");
     run_cmd(
         "bridge",
@@ -641,6 +704,7 @@ pub(crate) fn add_overlay_peer(peer_ip: &str) -> Result<()> {
 
 /// Remove a VXLAN overlay peer.
 pub(crate) fn remove_overlay_peer(peer_ip: &str) -> Result<()> {
+    validate_ipv4(peer_ip)?;
     info!(peer_ip = %peer_ip, "removing overlay peer");
     run_cmd(
         "bridge",
@@ -666,6 +730,9 @@ pub(crate) fn remove_overlay_peer(peer_ip: &str) -> Result<()> {
 /// Appends an iptables INPUT ACCEPT rule for the specified port/protocol
 /// in the pod's network namespace.
 pub(crate) fn open_port(netns_path: &str, port: i32, protocol: &str) -> Result<()> {
+    validate_netns_path(netns_path)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
     let port_str = port.to_string();
     info!(
         netns = %netns_path,
@@ -688,6 +755,9 @@ pub(crate) fn open_port(netns_path: &str, port: i32, protocol: &str) -> Result<(
 /// Deletes the matching iptables INPUT ACCEPT rule from the pod's
 /// network namespace.
 pub(crate) fn close_port(netns_path: &str, port: i32, protocol: &str) -> Result<()> {
+    validate_netns_path(netns_path)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
     let port_str = port.to_string();
     info!(
         netns = %netns_path,
@@ -799,7 +869,7 @@ pub(crate) fn teardown_services_chain() -> Result<()> {
 /// instead of dots/colons to satisfy iptables naming constraints.
 ///
 /// Example: VIP `10.43.0.1`, port 80, protocol `tcp` → `SKYR_SVC_10_43_0_1_80_tcp`
-fn service_chain_name(vip: &str, port: i32, protocol: &str) -> String {
+fn service_chain_name(vip: &str, port: u16, protocol: &str) -> String {
     let vip_clean = vip.replace('.', "_");
     format!("SKYR_SVC_{vip_clean}_{port}_{protocol}")
 }
@@ -825,6 +895,16 @@ pub(crate) fn add_service_route(
     backends: &[scop::ServiceBackend],
     service_cidr: &str,
 ) -> Result<()> {
+    validate_ipv4(vip)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
+    // Validate each backend address
+    for backend in backends {
+        validate_ipv4(&backend.address)?;
+        validate_port(backend.port)?;
+        validate_protocol(&backend.protocol)?;
+    }
+
     if backends.is_empty() {
         warn!(vip = %vip, port = %port, "no backends for service route, skipping");
         return Ok(());
@@ -886,7 +966,8 @@ pub(crate) fn add_service_route(
         let backend_chain;
         let dest;
         if is_vip {
-            backend_chain = service_chain_name(&backend.address, backend.port, &backend.protocol);
+            backend_chain =
+                service_chain_name(&backend.address, backend.port as u16, &backend.protocol);
             args.extend_from_slice(&["-j", &backend_chain]);
         } else {
             dest = format!("{}:{}", backend.address, backend.port);
@@ -929,6 +1010,9 @@ pub(crate) fn add_service_route(
 /// Removes the dispatch rule from SKYR-SERVICES and flushes/deletes the
 /// per-service chain.
 pub(crate) fn remove_service_route(vip: &str, port: i32, protocol: &str) -> Result<()> {
+    validate_ipv4(vip)?;
+    let port = validate_port(port)?;
+    let protocol = validate_protocol(protocol)?;
     let port_str = port.to_string();
     let chain = service_chain_name(vip, port, protocol);
 
@@ -980,6 +1064,7 @@ pub(crate) fn remove_service_route(vip: &str, port: i32, protocol: &str) -> Resu
 /// Allows forwarding of traffic destined to the service CIDR through the bridge,
 /// so DNAT'd packets can reach their backend pods.
 pub(crate) fn configure_service_cidr_forwarding(service_cidr: &str) -> Result<()> {
+    validate_cidr(service_cidr)?;
     info!(
         service_cidr = %service_cidr,
         "configuring service CIDR forwarding"
@@ -1023,7 +1108,14 @@ pub(crate) fn host_nameservers() -> Vec<String> {
         .filter_map(|line| {
             let line = line.trim();
             if line.starts_with("nameserver") {
-                line.split_whitespace().nth(1).map(String::from)
+                let addr = line.split_whitespace().nth(1)?;
+                // Validate that the nameserver is a well-formed IP address
+                if addr.parse::<Ipv4Addr>().is_ok() || addr.parse::<std::net::Ipv6Addr>().is_ok() {
+                    Some(addr.to_string())
+                } else {
+                    warn!(addr = %addr, "skipping invalid nameserver from resolv.conf");
+                    None
+                }
             } else {
                 None
             }


### PR DESCRIPTION
## Summary
- **3.1/3.2 [CRITICAL/HIGH]** Validate all user-controlled inputs (IPs, ports, protocols, CIDR notations, netns paths, hostnames) before passing to system commands (`iptables`, `nsenter`, `ip`, `bridge`), preventing command injection
- **3.3 [HIGH]** Recover from poisoned `std::sync::RwLock` in DNS record access using `unwrap_or_else(|e| e.into_inner())` instead of returning permanent errors
- **1.4 [MEDIUM]** Extract 4 identical pod cleanup blocks into `cleanup_failed_pod()` helper method
- **2.3 [MEDIUM]** Validate port numbers are in range 1-65535 before use in firewall rules
- **3.4 [MEDIUM]** Validate upstream DNS server addresses before forwarding queries
- **3.6 [MEDIUM]** Validate hostname characters in `resolve_hostname_to_ip()` to prevent injection

Closes #163

## Test plan
- [ ] Verify `cargo clippy --all-targets` passes with no warnings
- [ ] Verify `cargo test -p scoc` passes
- [ ] Verify pod creation/removal still works end-to-end on a real node
- [ ] Verify invalid inputs (bad IPs, out-of-range ports, bad protocols) are rejected with clear errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)