### PR TITLE
fix(rdb): address quality audit findings

### DIFF
--- a/crates/rdb/src/lib.rs
+++ b/crates/rdb/src/lib.rs
@@ -13,6 +13,12 @@ use scylla::{
 };
 use thiserror::Error;
 
+/// Maximum size in bytes for JSON payloads deserialized from the database.
+///
+/// This prevents malicious or corrupted database content from causing
+/// unbounded memory allocation during deserialization.
+const MAX_JSON_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+
 #[derive(Error, Debug)]
 pub enum ConnectError {
     #[error("failed to create session: {0}")]
@@ -48,14 +54,15 @@ macro_rules! prepared_statements {
     }
 }
 
-prepared_statements! {
-    KeyspaceStatements {
-        create_keyspace = r#"
-            CREATE KEYSPACE IF NOT EXISTS rdb
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}
-        "#,
-    }
+// Schema version: 1
+//
+// Migration strategy: this crate uses CREATE ... IF NOT EXISTS for all DDL.
+// When the schema needs to change, add new CREATE statements (for additive
+// changes like new columns or indexes) or implement an explicit migration
+// step that checks the current schema version and applies ALTER statements.
+// Bump the version comment above when the schema changes.
 
+prepared_statements! {
     TableStatements {
         create_resources_table = r#"
             CREATE TABLE IF NOT EXISTS rdb.resources (
@@ -70,6 +77,10 @@ prepared_statements! {
                 source_trace_json TEXT,
                 PRIMARY KEY ((namespace), resource_type, name)
             )
+        "#,
+        create_owner_index = r#"
+            CREATE INDEX IF NOT EXISTS resources_owner_idx
+            ON rdb.resources (owner)
         "#,
     }
 
@@ -91,7 +102,6 @@ prepared_statements! {
             FROM rdb.resources
             WHERE namespace = ?
             AND owner = ?
-            ALLOW FILTERING
         "#,
         set_resource_input = r#"
             UPDATE rdb.resources
@@ -176,6 +186,7 @@ fn map_resource_row(namespace: &str, row: ResourceRow) -> Result<Resource, Resou
 #[derive(Default)]
 pub struct ClientBuilder {
     inner: SessionBuilder,
+    replication_factor: Option<u32>,
 }
 
 impl ClientBuilder {
@@ -188,19 +199,33 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets the replication factor for the `rdb` keyspace.
+    ///
+    /// Defaults to 1 if not specified. Production deployments should use a
+    /// higher value (e.g. 3) for redundancy.
+    pub fn replication_factor(mut self, factor: u32) -> Self {
+        self.replication_factor = Some(factor);
+        self
+    }
+
     pub async fn build(&self) -> Result<Client, ConnectError> {
         let session = Arc::new(self.inner.build().await?);
 
-        let statements = KeyspaceStatements::new(&session).await?;
-
-        session
-            .execute_unpaged(&statements.create_keyspace, ())
-            .await?;
+        let replication_factor = self.replication_factor.unwrap_or(1);
+        let create_keyspace = format!(
+            "CREATE KEYSPACE IF NOT EXISTS rdb \
+             WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': {replication_factor}}}"
+        );
+        session.query_unpaged(create_keyspace, ()).await?;
 
         let statements = TableStatements::new(&session).await?;
 
         session
             .execute_unpaged(&statements.create_resources_table, ())
+            .await?;
+
+        session
+            .execute_unpaged(&statements.create_owner_index, ())
             .await?;
 
         let statements = PreparedStatements::new(&session).await?;
@@ -466,54 +491,264 @@ pub enum ResourceError {
     #[error("failed to load row: {0}")]
     ScyllaNextRow(#[from] NextRowError),
 
-    #[error("failed to encode json: {0}")]
-    EncodeJson(#[from] serde_json::Error),
+    #[error("failed to encode/decode json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("JSON payload too large ({size} bytes, limit is {MAX_JSON_SIZE})")]
+    JsonTooLarge { size: usize },
 }
 
+/// Checks that a JSON string does not exceed [`MAX_JSON_SIZE`] before
+/// deserializing it. Returns [`ResourceError::JsonTooLarge`] if the payload
+/// is too large.
+fn check_json_size(text: &str) -> Result<(), ResourceError> {
+    if text.len() > MAX_JSON_SIZE {
+        return Err(ResourceError::JsonTooLarge { size: text.len() });
+    }
+    Ok(())
+}
+
+/// Decodes a JSON-encoded [`Record`] from an optional database column.
+///
+/// Both SQL `NULL` and empty strings are treated as `None`, since ScyllaDB
+/// may store either representation for absent values.
 fn decode_record(value: Option<String>) -> Result<Option<Record>, ResourceError> {
     match value {
         None => Ok(None),
         Some(text) if text.is_empty() => Ok(None),
-        Some(text) => Ok(Some(serde_json::from_str(&text)?)),
+        Some(text) => {
+            check_json_size(&text)?;
+            Ok(Some(serde_json::from_str(&text)?))
+        }
     }
 }
 
+/// Decodes a JSON-encoded list of [`ids::ResourceId`] from an optional
+/// database column.
+///
+/// Both SQL `NULL` and empty strings are treated as an empty `Vec`, since
+/// ScyllaDB may store either representation for absent values.
 fn decode_dependencies(value: Option<String>) -> Result<Vec<ids::ResourceId>, ResourceError> {
     match value {
         None => Ok(Vec::new()),
         Some(text) if text.is_empty() => Ok(Vec::new()),
-        Some(text) => Ok(serde_json::from_str(&text)?),
+        Some(text) => {
+            check_json_size(&text)?;
+            Ok(serde_json::from_str(&text)?)
+        }
     }
 }
 
+/// Decodes a JSON-encoded set of [`sclc::Marker`] from an optional database
+/// column.
+///
+/// Both SQL `NULL` and empty strings are treated as an empty set, since
+/// ScyllaDB may store either representation for absent values.
 fn decode_markers(value: Option<String>) -> Result<BTreeSet<sclc::Marker>, ResourceError> {
     match value {
         None => Ok(BTreeSet::new()),
         Some(text) if text.is_empty() => Ok(BTreeSet::new()),
-        Some(text) => Ok(serde_json::from_str(&text)?),
+        Some(text) => {
+            check_json_size(&text)?;
+            Ok(serde_json::from_str(&text)?)
+        }
     }
 }
 
+/// Serializes a [`Record`] to a JSON string for database storage.
 fn encode_record(value: &Record) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
 }
 
+/// Serializes a slice of [`ids::ResourceId`] to a JSON string for database storage.
 fn encode_dependencies(value: &[ids::ResourceId]) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
 }
 
+/// Serializes a set of [`sclc::Marker`] to a JSON string for database storage.
 fn encode_markers(value: &BTreeSet<sclc::Marker>) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
 }
 
+/// Decodes a JSON-encoded [`ids::SourceTrace`] from an optional database
+/// column.
+///
+/// Both SQL `NULL` and empty strings are treated as an empty trace, since
+/// ScyllaDB may store either representation for absent values.
 fn decode_source_trace(value: Option<String>) -> Result<ids::SourceTrace, ResourceError> {
     match value {
         None => Ok(Vec::new()),
         Some(text) if text.is_empty() => Ok(Vec::new()),
-        Some(text) => Ok(serde_json::from_str(&text)?),
+        Some(text) => {
+            check_json_size(&text)?;
+            Ok(serde_json::from_str(&text)?)
+        }
     }
 }
 
+/// Serializes a [`ids::SourceTrace`] to a JSON string for database storage.
 fn encode_source_trace(value: &ids::SourceTrace) -> Result<String, ResourceError> {
     Ok(serde_json::to_string(value)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── decode_record ──────────────────────────────────────────────
+
+    #[test]
+    fn decode_record_none_returns_none() {
+        assert!(decode_record(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_record_empty_string_returns_none() {
+        assert!(decode_record(Some(String::new())).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_record_valid_json_round_trips() {
+        let mut record = Record::default();
+        record.insert("key".into(), sclc::Value::Str("value".into()));
+        let json = serde_json::to_string(&record).unwrap();
+        let decoded = decode_record(Some(json)).unwrap().unwrap();
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn decode_record_invalid_json_returns_error() {
+        assert!(decode_record(Some("not json".into())).is_err());
+    }
+
+    // ── decode_dependencies ────────────────────────────────────────
+
+    #[test]
+    fn decode_dependencies_none_returns_empty() {
+        assert!(decode_dependencies(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_dependencies_empty_string_returns_empty() {
+        assert!(decode_dependencies(Some(String::new())).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_dependencies_valid_json_round_trips() {
+        let deps = vec![ids::ResourceId::new("Std/Random.Int", "my-int")];
+        let json = serde_json::to_string(&deps).unwrap();
+        let decoded = decode_dependencies(Some(json)).unwrap();
+        assert_eq!(decoded, deps);
+    }
+
+    // ── decode_markers ─────────────────────────────────────────────
+
+    #[test]
+    fn decode_markers_none_returns_empty() {
+        assert!(decode_markers(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_markers_empty_string_returns_empty() {
+        assert!(decode_markers(Some(String::new())).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_markers_valid_json_round_trips() {
+        let mut markers = BTreeSet::new();
+        markers.insert(sclc::Marker::Volatile);
+        let json = serde_json::to_string(&markers).unwrap();
+        let decoded = decode_markers(Some(json)).unwrap();
+        assert_eq!(decoded, markers);
+    }
+
+    // ── decode_source_trace ────────────────────────────────────────
+
+    #[test]
+    fn decode_source_trace_none_returns_empty() {
+        assert!(decode_source_trace(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_source_trace_empty_string_returns_empty() {
+        assert!(decode_source_trace(Some(String::new())).unwrap().is_empty());
+    }
+
+    // ── encode round-trips ─────────────────────────────────────────
+
+    #[test]
+    fn encode_decode_record_round_trip() {
+        let mut record = Record::default();
+        record.insert("a".into(), sclc::Value::Int(42));
+        let json = encode_record(&record).unwrap();
+        let decoded = decode_record(Some(json)).unwrap().unwrap();
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn encode_decode_dependencies_round_trip() {
+        let deps = vec![
+            ids::ResourceId::new("Std/Random.Int", "a"),
+            ids::ResourceId::new("Std/Time.Clock", "b"),
+        ];
+        let json = encode_dependencies(&deps).unwrap();
+        let decoded = decode_dependencies(Some(json)).unwrap();
+        assert_eq!(decoded, deps);
+    }
+
+    #[test]
+    fn encode_decode_markers_round_trip() {
+        let mut markers = BTreeSet::new();
+        markers.insert(sclc::Marker::Volatile);
+        markers.insert(sclc::Marker::Sticky);
+        let json = encode_markers(&markers).unwrap();
+        let decoded = decode_markers(Some(json)).unwrap();
+        assert_eq!(decoded, markers);
+    }
+
+    #[test]
+    fn encode_decode_source_trace_round_trip() {
+        let trace: ids::SourceTrace = vec![];
+        let json = encode_source_trace(&trace).unwrap();
+        let decoded = decode_source_trace(Some(json)).unwrap();
+        assert_eq!(decoded, trace);
+    }
+
+    // ── size limit ─────────────────────────────────────────────────
+
+    #[test]
+    fn decode_record_rejects_oversized_payload() {
+        let huge = "x".repeat(MAX_JSON_SIZE + 1);
+        match decode_record(Some(huge)) {
+            Err(ResourceError::JsonTooLarge { .. }) => {}
+            other => panic!("expected JsonTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_dependencies_rejects_oversized_payload() {
+        let huge = "x".repeat(MAX_JSON_SIZE + 1);
+        match decode_dependencies(Some(huge)) {
+            Err(ResourceError::JsonTooLarge { .. }) => {}
+            other => panic!("expected JsonTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_markers_rejects_oversized_payload() {
+        let huge = "x".repeat(MAX_JSON_SIZE + 1);
+        match decode_markers(Some(huge)) {
+            Err(ResourceError::JsonTooLarge { .. }) => {}
+            other => panic!("expected JsonTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_source_trace_rejects_oversized_payload() {
+        let huge = "x".repeat(MAX_JSON_SIZE + 1);
+        match decode_source_trace(Some(huge)) {
+            Err(ResourceError::JsonTooLarge { .. }) => {}
+            other => panic!("expected JsonTooLarge, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #159

- **[HIGH] Replication factor configurable** — `ClientBuilder::replication_factor()` method added; defaults to 1 but production deployments can set a higher value (e.g. 3)
- **[MEDIUM] ALLOW FILTERING removed** — replaced with a secondary index (`resources_owner_idx`) on the `owner` column so `list_resources_by_owner` no longer requires a full partition scan
- **[MEDIUM] JSON size limits** — all `decode_*` helpers now reject payloads exceeding 16 MiB before deserialization, preventing memory exhaustion from malicious DB content
- **[MEDIUM] Schema versioning** — added version comment and migration strategy documentation in the schema section
- **[MEDIUM] NULL/empty semantics documented** — all decode helpers now have doc comments explaining that both SQL NULL and empty strings are treated as absent values
- **[MEDIUM] Unit tests added** — 20 tests covering encode/decode round-trips, NULL/empty handling, invalid JSON, and size limit enforcement
- **[LOW] Helper functions documented** — all encode/decode helpers have doc comments

### Not addressed (intentional)

- **[LOW] Public Resource struct fields** — making fields private would require adding accessor methods and updating all downstream consumers (`de`, `api`, `rte`). The struct is effectively a data transfer object, so public fields are appropriate.
- **[LOW] Input validation on namespace/type/name** — callers already use typed IDs from the `ids` crate; adding redundant validation in rdb would duplicate logic.
- **[LOW] Rate limiting** — this is an infrastructure concern better handled at the service/network level, not in the database client library.

## Test plan

- [x] `cargo clippy --all-targets` passes clean
- [x] `cargo test` — all 20 new rdb unit tests pass
- [x] Full test suite passes
- [x] Downstream crates (`de`, `rte`, `api`) compile without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)