### PR TITLE
fix(cli): address quality audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ graphql_client = "0.14.0"
 futures-util = "0.3.31"
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 russh = "0.57.0"
+zeroize = "1.8.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tabular = "0.2.0"

--- a/crates/cli/src/auth.rs
+++ b/crates/cli/src/auth.rs
@@ -3,11 +3,19 @@ use graphql_client::GraphQLQuery;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use zeroize::Zeroizing;
+
+/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
+#[allow(clippy::upper_case_acronyms)]
+type JSON = serde_json::Value;
 
 const SIGNATURE_NAMESPACE: &str = "skyr-auth-challenge";
 
-#[allow(clippy::upper_case_acronyms)]
-type JSON = serde_json::Value;
+/// Expected minimum length for a valid token (8 hex chars + separator + payload).
+const MIN_TOKEN_LENGTH: usize = 10;
+
+/// Maximum token length to prevent abuse when constructing HTTP headers.
+const MAX_TOKEN_LENGTH: usize = 4096;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -80,10 +88,12 @@ pub(crate) async fn build_auth_proof(
     username: &str,
     key_path: &Path,
 ) -> anyhow::Result<String> {
-    let key = tokio::fs::read_to_string(key_path)
-        .await
-        .with_context(|| format!("failed to read private key at {}", key_path.display()))?;
-    let private_key = russh::keys::ssh_key::PrivateKey::from_openssh(&key)
+    let key = Zeroizing::new(
+        tokio::fs::read_to_string(key_path)
+            .await
+            .with_context(|| format!("failed to read private key at {}", key_path.display()))?,
+    );
+    let private_key = russh::keys::ssh_key::PrivateKey::from_openssh(key.as_str())
         .context("failed to parse private key")?;
 
     let challenge = query_auth_challenge(client, endpoint, username).await?;
@@ -142,18 +152,31 @@ pub(crate) async fn persist_auth_state(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    tokio::fs::write(&token_path, token)
-        .await
-        .with_context(|| format!("failed to write {}", token_path.display()))?;
+    write_file_restricted(&token_path, token.as_bytes()).await?;
 
     let user_config = UserConfig {
         username: username.to_owned(),
         key: key_path.display().to_string(),
     };
     let user_config_json = serde_json::to_string_pretty(&user_config)?;
-    tokio::fs::write(&user_config_path, user_config_json)
+    write_file_restricted(&user_config_path, user_config_json.as_bytes()).await?;
+
+    Ok(())
+}
+
+/// Write `data` to `path` with mode 0o600 (owner read/write only).
+async fn write_file_restricted(path: &Path, data: &[u8]) -> anyhow::Result<()> {
+    tokio::fs::write(path, data)
         .await
-        .with_context(|| format!("failed to write {}", user_config_path.display()))?;
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .await
+            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    }
 
     Ok(())
 }
@@ -163,18 +186,51 @@ pub(crate) fn graphql_response_data<T>(
     operation: &str,
 ) -> anyhow::Result<T> {
     if let Some(errors) = response.errors {
+        let messages: Vec<String> = errors
+            .iter()
+            .enumerate()
+            .map(|(i, e)| {
+                let mut msg = format!("  {}. {}", i + 1, e.message);
+                if let Some(ref locations) = e.locations
+                    && !locations.is_empty()
+                {
+                    let locs: Vec<String> = locations
+                        .iter()
+                        .map(|loc| format!("line {}:{}", loc.line, loc.column))
+                        .collect();
+                    msg.push_str(&format!(" (at {})", locs.join(", ")));
+                }
+                if let Some(ref path) = e.path
+                    && !path.is_empty()
+                {
+                    let path_strs: Vec<String> = path.iter().map(|p| format!("{p}")).collect();
+                    msg.push_str(&format!(" [path: {}]", path_strs.join(".")));
+                }
+                msg
+            })
+            .collect();
         return Err(anyhow!(
-            "{operation} failed: {}",
-            errors
-                .iter()
-                .map(|e| e.message.as_str())
-                .collect::<Vec<_>>()
-                .join("; ")
+            "{operation} failed with {} error(s):\n{}",
+            messages.len(),
+            messages.join("\n")
         ));
     }
     response
         .data
         .ok_or_else(|| anyhow!("{operation} response did not include data"))
+}
+
+/// Construct an `Authorization: Bearer {token}` header value, validating the
+/// token length to prevent header injection or unreasonably large values.
+pub(crate) fn bearer_header_value(token: &str) -> anyhow::Result<reqwest::header::HeaderValue> {
+    if token.len() < MIN_TOKEN_LENGTH {
+        return Err(anyhow!("token is too short to be valid"));
+    }
+    if token.len() > MAX_TOKEN_LENGTH {
+        return Err(anyhow!("token exceeds maximum allowed length"));
+    }
+    reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+        .context("token contains invalid header characters")
 }
 
 pub(crate) fn graphql_endpoint(api_url: &str) -> String {
@@ -219,10 +275,7 @@ async fn write_token(token: &str) -> anyhow::Result<()> {
             .await
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    tokio::fs::write(&token_path, token)
-        .await
-        .with_context(|| format!("failed to write {}", token_path.display()))?;
-    Ok(())
+    write_file_restricted(&token_path, token.as_bytes()).await
 }
 
 async fn read_user_config() -> anyhow::Result<UserConfig> {
@@ -234,25 +287,40 @@ async fn read_user_config() -> anyhow::Result<UserConfig> {
         .with_context(|| format!("failed to parse {}", user_config_path.display()))
 }
 
-fn is_expired_token(token: &str) -> anyhow::Result<bool> {
-    let expiry_hex = token
-        .get(0..8)
-        .ok_or_else(|| anyhow!("token is missing expiry prefix"))?;
-    let separator = token
-        .as_bytes()
-        .get(8)
-        .copied()
-        .ok_or_else(|| anyhow!("token is missing separator"))?;
-    if separator != b'.' {
-        return Err(anyhow!("token has invalid separator"));
+/// Parse the expiry prefix from a token.
+///
+/// Token format: `<8 hex digits for expiry>.<payload>`
+struct TokenExpiry {
+    expiry_epoch: u32,
+}
+
+impl TokenExpiry {
+    fn parse(token: &str) -> anyhow::Result<Self> {
+        if token.len() < MIN_TOKEN_LENGTH {
+            return Err(anyhow!("token is too short to contain expiry prefix"));
+        }
+        let (expiry_hex, rest) = token.split_at(8);
+        if !rest.starts_with('.') {
+            return Err(anyhow!(
+                "token has invalid separator (expected '.' at position 8)"
+            ));
+        }
+        let expiry_epoch =
+            u32::from_str_radix(expiry_hex, 16).context("token expiry is not valid hex")?;
+        Ok(Self { expiry_epoch })
     }
 
-    let expiry = u32::from_str_radix(expiry_hex, 16).context("token expiry is not valid hex")?;
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("system clock before unix epoch")?
-        .as_secs();
-    Ok(now >= u64::from(expiry))
+    fn is_expired(&self) -> anyhow::Result<bool> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock before unix epoch")?
+            .as_secs();
+        Ok(now >= u64::from(self.expiry_epoch))
+    }
+}
+
+fn is_expired_token(token: &str) -> anyhow::Result<bool> {
+    TokenExpiry::parse(token)?.is_expired()
 }
 
 fn token_cache_path() -> anyhow::Result<PathBuf> {

--- a/crates/cli/src/deployment.rs
+++ b/crates/cli/src/deployment.rs
@@ -1,14 +1,13 @@
 use anyhow::{Context, anyhow};
 use clap::{Args, Subcommand};
-use futures_util::{SinkExt, StreamExt};
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
 use serde_json::json;
 use std::{collections::BTreeSet, time::Duration};
-use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-use crate::{auth, output::OutputFormat, repo};
+use crate::{auth, output::OutputFormat, repo, ws};
 
+/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
 #[allow(clippy::upper_case_acronyms)]
 type JSON = serde_json::Value;
 
@@ -101,13 +100,6 @@ struct ResourceOutput {
 struct ResourceDependencyOutput {
     r#type: String,
     name: String,
-}
-
-#[derive(Debug)]
-pub(crate) struct SubscriptionLog {
-    pub(crate) severity: String,
-    pub(crate) timestamp: String,
-    pub(crate) message: String,
 }
 
 async fn list_deployments(
@@ -209,7 +201,10 @@ async fn print_deployment_last_logs(
     });
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -283,7 +278,7 @@ async fn stream_deployment_logs(
     initial_amount: i64,
 ) -> anyhow::Result<()> {
     let (_, repository_name) = repo::parse_repository_path(repository)?;
-    let ws_endpoint = graphql_ws_endpoint(endpoint)?;
+    let ws_endpoint = ws::graphql_ws_endpoint(endpoint)?;
     let mut subscribed = BTreeSet::new();
     let mut saw_any = false;
     let (task_events_tx, mut task_events_rx) =
@@ -316,15 +311,30 @@ async fn stream_deployment_logs(
                 let ws_endpoint = ws_endpoint.clone();
                 let token = token.to_owned();
                 let task_events_tx = task_events_tx.clone();
+                let env_qid = environment_qid.clone();
                 tokio::spawn(async move {
-                    let result = stream_single_environment(
+                    let result = ws::stream_subscription(
                         &ws_endpoint,
                         &token,
-                        environment_qid.clone(),
-                        initial_amount,
+                        ws::SubscriptionParams {
+                            subscription_id: &env_qid,
+                            query: include_str!("graphql/deployment_logs_subscription.graphql"),
+                            operation_name: "EnvironmentLogs",
+                            variables: json!({
+                                "environmentQid": env_qid,
+                                "initialAmount": initial_amount
+                            }),
+                            log_field_name: "environmentLogs",
+                        },
+                        |log| {
+                            println!(
+                                "[{}] [{}] [{}] {}",
+                                env_qid, log.timestamp, log.severity, log.message
+                            );
+                        },
                     )
                     .await;
-                    let _ = task_events_tx.send((environment_qid, result));
+                    let _ = task_events_tx.send((env_qid, result));
                 });
             }
         }
@@ -349,212 +359,6 @@ async fn stream_deployment_logs(
     }
 }
 
-async fn stream_single_environment(
-    ws_endpoint: &str,
-    token: &str,
-    environment_qid: String,
-    initial_amount: i64,
-) -> anyhow::Result<()> {
-    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-
-    let mut request = ws_endpoint
-        .into_client_request()
-        .context("failed to build websocket request")?;
-    request.headers_mut().insert(
-        reqwest::header::AUTHORIZATION,
-        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
-            .context("failed to format authorization header")?,
-    );
-    request.headers_mut().insert(
-        reqwest::header::SEC_WEBSOCKET_PROTOCOL,
-        reqwest::header::HeaderValue::from_static("graphql-transport-ws"),
-    );
-
-    let (ws_stream, _) = connect_async(request)
-        .await
-        .with_context(|| format!("failed to connect websocket at {ws_endpoint}"))?;
-    let (mut write, mut read) = ws_stream.split();
-
-    write
-        .send(Message::Text(
-            json!({
-                "type": "connection_init"
-            })
-            .to_string(),
-        ))
-        .await
-        .with_context(|| {
-            format!(
-                "failed to send graphql websocket connection init for environment {}",
-                environment_qid
-            )
-        })?;
-
-    wait_for_connection_ack(&mut read, &mut write).await?;
-
-    write
-        .send(Message::Text(
-            json!({
-                "id": environment_qid,
-                "type": "subscribe",
-                "payload": {
-                    "query": include_str!("graphql/deployment_logs_subscription.graphql"),
-                    "variables": {
-                        "environmentQid": environment_qid,
-                        "initialAmount": initial_amount
-                    },
-                    "operationName": "EnvironmentLogs"
-                }
-            })
-            .to_string(),
-        ))
-        .await
-        .context("failed to send environment logs subscription")?;
-
-    while let Some(message) = read.next().await {
-        let message = message.context("failed to read websocket message")?;
-        match message {
-            Message::Text(text) => {
-                if let Some(log) = decode_log_message(&text)? {
-                    println!(
-                        "[{}] [{}] [{}] {}",
-                        environment_qid, log.timestamp, log.severity, log.message
-                    );
-                }
-            }
-            Message::Binary(_) => {}
-            Message::Ping(payload) => {
-                write
-                    .send(Message::Pong(payload))
-                    .await
-                    .context("failed to send websocket pong")?;
-            }
-            Message::Pong(_) => {}
-            Message::Close(_) => {
-                break;
-            }
-            Message::Frame(_) => {}
-        }
-    }
-
-    Ok(())
-}
-
-pub(crate) async fn wait_for_connection_ack<Read, Write>(
-    read: &mut Read,
-    write: &mut Write,
-) -> anyhow::Result<()>
-where
-    Read:
-        futures_util::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
-    Write: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
-{
-    while let Some(message) = read.next().await {
-        let message = message.context("failed to read connection ack message")?;
-        match message {
-            Message::Text(text) => {
-                let value: serde_json::Value = serde_json::from_str(&text)
-                    .with_context(|| format!("failed to decode websocket message: {text}"))?;
-                match value
-                    .get("type")
-                    .and_then(|message_type| message_type.as_str())
-                {
-                    Some("connection_ack") => return Ok(()),
-                    Some("ping") => {
-                        write
-                            .send(Message::Text(json!({ "type": "pong" }).to_string()))
-                            .await
-                            .context("failed to send graphql ping response")?;
-                    }
-                    Some("connection_error") => {
-                        return Err(anyhow!(
-                            "graphql websocket connection rejected: {}",
-                            value
-                                .get("payload")
-                                .map(|payload| payload.to_string())
-                                .unwrap_or_else(|| String::from("<empty payload>"))
-                        ));
-                    }
-                    _ => {}
-                }
-            }
-            Message::Ping(payload) => {
-                write
-                    .send(Message::Pong(payload))
-                    .await
-                    .context("failed to send websocket pong")?;
-            }
-            Message::Close(_) => return Err(anyhow!("websocket closed before connection ack")),
-            Message::Binary(_) | Message::Pong(_) | Message::Frame(_) => {}
-        }
-    }
-
-    Err(anyhow!("websocket closed before connection ack"))
-}
-
-fn decode_log_message(text: &str) -> anyhow::Result<Option<SubscriptionLog>> {
-    decode_subscription_log(text, "environmentLogs")
-}
-
-pub(crate) fn decode_subscription_log(
-    text: &str,
-    field_name: &str,
-) -> anyhow::Result<Option<SubscriptionLog>> {
-    let value: serde_json::Value =
-        serde_json::from_str(text).with_context(|| format!("failed to decode message: {text}"))?;
-
-    let Some(message_type) = value
-        .get("type")
-        .and_then(|message_type| message_type.as_str())
-    else {
-        return Ok(None);
-    };
-
-    match message_type {
-        "next" => {
-            let payload = value
-                .get("payload")
-                .ok_or_else(|| anyhow!("subscription message missing payload"))?;
-            if let Some(errors) = payload.get("errors") {
-                return Err(anyhow!("subscription returned errors: {errors}"));
-            }
-
-            let log = payload
-                .get("data")
-                .and_then(|data| data.get(field_name))
-                .ok_or_else(|| anyhow!("subscription message missing {field_name}"))?;
-
-            let severity = log
-                .get("severity")
-                .and_then(|severity| severity.as_str())
-                .ok_or_else(|| anyhow!("log entry missing severity"))?;
-            let timestamp = log
-                .get("timestamp")
-                .and_then(|timestamp| timestamp.as_str())
-                .ok_or_else(|| anyhow!("log entry missing timestamp"))?;
-            let message = log
-                .get("message")
-                .and_then(|message| message.as_str())
-                .ok_or_else(|| anyhow!("log entry missing message"))?;
-
-            Ok(Some(SubscriptionLog {
-                severity: severity.to_string(),
-                timestamp: timestamp.to_string(),
-                message: message.to_string(),
-            }))
-        }
-        "error" => {
-            let payload = value
-                .get("payload")
-                .map(|payload| payload.to_string())
-                .unwrap_or_else(|| String::from("<empty payload>"));
-            Err(anyhow!("subscription returned error: {payload}"))
-        }
-        "complete" | "ka" | "connection_ack" | "pong" | "ping" => Ok(None),
-        other => Err(anyhow!("unsupported subscription message type: {other}")),
-    }
-}
-
 async fn query_repository_environments(
     client: &reqwest::Client,
     endpoint: &str,
@@ -566,7 +370,10 @@ async fn query_repository_environments(
     let body = ListRepositoryDeployments::build_query(list_repository_deployments::Variables {});
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -583,20 +390,4 @@ async fn query_repository_environments(
         .ok_or_else(|| anyhow!("repository '{repository_name}' not found"))?;
 
     Ok(repository.environments)
-}
-
-pub(crate) fn graphql_ws_endpoint(graphql_endpoint: &str) -> anyhow::Result<String> {
-    let ws_endpoint = if let Some(rest) = graphql_endpoint.strip_prefix("https://") {
-        format!("wss://{rest}")
-    } else if let Some(rest) = graphql_endpoint.strip_prefix("http://") {
-        format!("ws://{rest}")
-    } else if graphql_endpoint.starts_with("ws://") || graphql_endpoint.starts_with("wss://") {
-        graphql_endpoint.to_string()
-    } else {
-        return Err(anyhow!(
-            "unsupported graphql endpoint scheme for websocket: {graphql_endpoint}"
-        ));
-    };
-
-    Ok(ws_endpoint)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,6 +14,7 @@ mod run;
 mod signin;
 mod signup;
 mod whoami;
+mod ws;
 
 #[derive(Parser)]
 struct Program {

--- a/crates/cli/src/repo.rs
+++ b/crates/cli/src/repo.rs
@@ -64,7 +64,10 @@ async fn create_repository(
     });
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -101,7 +104,10 @@ async fn list_repositories(
     let body = ListRepositories::build_query(list_repositories::Variables {});
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -137,13 +143,22 @@ async fn list_repositories(
     Ok(())
 }
 
+/// Validate that a segment (organization or repository name) contains only
+/// allowed characters: alphanumeric, hyphens, and underscores.
+fn is_valid_path_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 pub(crate) fn parse_repository_path(repository: &str) -> anyhow::Result<(&str, &str)> {
     let (organization, repository_name) = repository
         .split_once('/')
         .ok_or_else(|| anyhow!("repository must be in <organization>/<repository> format"))?;
-    if organization.is_empty() || repository_name.is_empty() || repository_name.contains('/') {
+    if !is_valid_path_segment(organization) || !is_valid_path_segment(repository_name) {
         return Err(anyhow!(
-            "repository must be in <organization>/<repository> format"
+            "repository path segments must be non-empty and contain only \
+             alphanumeric characters, hyphens, or underscores"
         ));
     }
     Ok((organization, repository_name))

--- a/crates/cli/src/resource.rs
+++ b/crates/cli/src/resource.rs
@@ -1,13 +1,12 @@
 use anyhow::{Context, anyhow};
 use clap::{Args, Subcommand};
-use futures_util::{SinkExt, StreamExt};
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
 use serde_json::json;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-use crate::{auth, deployment, output::OutputFormat, repo};
+use crate::{auth, output::OutputFormat, repo, ws};
 
+/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
 #[allow(clippy::upper_case_acronyms)]
 type JSON = serde_json::Value;
 
@@ -125,7 +124,10 @@ async fn list_resources(
     let body = ListRepositoryResources::build_query(list_repository_resources::Variables {});
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -242,7 +244,10 @@ async fn print_resource_last_logs(
     });
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(token)?,
+        )
         .json(&body)
         .send()
         .await
@@ -313,7 +318,7 @@ async fn stream_resource_logs(
     resource_qids: &[String],
     initial_amount: i64,
 ) -> anyhow::Result<()> {
-    let ws_endpoint = deployment::graphql_ws_endpoint(endpoint)?;
+    let ws_endpoint = ws::graphql_ws_endpoint(endpoint)?;
     let (task_events_tx, mut task_events_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, anyhow::Result<()>)>();
 
@@ -323,9 +328,28 @@ async fn stream_resource_logs(
         let resource_qid = resource_qid.clone();
         let task_events_tx = task_events_tx.clone();
         tokio::spawn(async move {
-            let result =
-                stream_single_resource(&ws_endpoint, &token, resource_qid.clone(), initial_amount)
-                    .await;
+            let qid = resource_qid.clone();
+            let result = ws::stream_subscription(
+                &ws_endpoint,
+                &token,
+                ws::SubscriptionParams {
+                    subscription_id: &resource_qid,
+                    query: include_str!("graphql/resource_logs_subscription.graphql"),
+                    operation_name: "ResourceLogs",
+                    variables: json!({
+                        "resourceQid": resource_qid,
+                        "initialAmount": initial_amount
+                    }),
+                    log_field_name: "resourceLogs",
+                },
+                |log| {
+                    println!(
+                        "[{}] [{}] [{}] {}",
+                        qid, log.timestamp, log.severity, log.message
+                    );
+                },
+            )
+            .await;
             let _ = task_events_tx.send((resource_qid, result));
         });
     }
@@ -344,95 +368,4 @@ async fn stream_resource_logs(
             }
         }
     }
-}
-
-async fn stream_single_resource(
-    ws_endpoint: &str,
-    token: &str,
-    resource_qid: String,
-    initial_amount: i64,
-) -> anyhow::Result<()> {
-    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-
-    let mut request = ws_endpoint
-        .into_client_request()
-        .context("failed to build websocket request")?;
-    request.headers_mut().insert(
-        reqwest::header::AUTHORIZATION,
-        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
-            .context("failed to format authorization header")?,
-    );
-    request.headers_mut().insert(
-        reqwest::header::SEC_WEBSOCKET_PROTOCOL,
-        reqwest::header::HeaderValue::from_static("graphql-transport-ws"),
-    );
-
-    let (ws_stream, _) = connect_async(request)
-        .await
-        .with_context(|| format!("failed to connect websocket at {ws_endpoint}"))?;
-    let (mut write, mut read) = ws_stream.split();
-
-    write
-        .send(Message::Text(
-            json!({
-                "type": "connection_init"
-            })
-            .to_string(),
-        ))
-        .await
-        .with_context(|| {
-            format!(
-                "failed to send graphql websocket connection init for resource {}",
-                resource_qid
-            )
-        })?;
-
-    deployment::wait_for_connection_ack(&mut read, &mut write).await?;
-
-    write
-        .send(Message::Text(
-            json!({
-                "id": resource_qid,
-                "type": "subscribe",
-                "payload": {
-                    "query": include_str!("graphql/resource_logs_subscription.graphql"),
-                    "variables": {
-                        "resourceQid": resource_qid,
-                        "initialAmount": initial_amount
-                    },
-                    "operationName": "ResourceLogs"
-                }
-            })
-            .to_string(),
-        ))
-        .await
-        .context("failed to send resource logs subscription")?;
-
-    while let Some(message) = read.next().await {
-        let message = message.context("failed to read websocket message")?;
-        match message {
-            Message::Text(text) => {
-                if let Some(log) = deployment::decode_subscription_log(&text, "resourceLogs")? {
-                    println!(
-                        "[{}] [{}] [{}] {}",
-                        resource_qid, log.timestamp, log.severity, log.message
-                    );
-                }
-            }
-            Message::Binary(_) => {}
-            Message::Ping(payload) => {
-                write
-                    .send(Message::Pong(payload))
-                    .await
-                    .context("failed to send websocket pong")?;
-            }
-            Message::Pong(_) => {}
-            Message::Close(_) => {
-                break;
-            }
-            Message::Frame(_) => {}
-        }
-    }
-
-    Ok(())
 }

--- a/crates/cli/src/signin.rs
+++ b/crates/cli/src/signin.rs
@@ -24,12 +24,10 @@ pub async fn run_signin(args: SigninArgs, format: OutputFormat) -> anyhow::Resul
     #[derive(Serialize)]
     struct SigninOutput {
         username: String,
-        token: String,
     }
 
     let output = SigninOutput {
         username: args.username,
-        token,
     };
 
     match format {
@@ -44,10 +42,7 @@ pub async fn run_signin(args: SigninArgs, format: OutputFormat) -> anyhow::Resul
                 String::from("username"),
                 output.username,
             ]));
-            table.add_row(crate::output::row(vec![
-                String::from("token"),
-                output.token,
-            ]));
+            println!("Token saved to credentials file.");
             print!("{table}");
         }
     }

--- a/crates/cli/src/signup.rs
+++ b/crates/cli/src/signup.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 use crate::{auth, output::OutputFormat};
 
+/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
 #[allow(clippy::upper_case_acronyms)]
 type JSON = serde_json::Value;
 
@@ -68,7 +69,6 @@ pub async fn run_signup(args: SignupArgs, format: OutputFormat) -> anyhow::Resul
     #[derive(Serialize)]
     struct SignupOutput {
         user: SignupUserOutput,
-        token: String,
     }
 
     let output = SignupOutput {
@@ -77,7 +77,6 @@ pub async fn run_signup(args: SignupArgs, format: OutputFormat) -> anyhow::Resul
             email: data.signup.user.email,
             fullname: data.signup.user.fullname,
         },
-        token: data.signup.token,
     };
 
     match format {
@@ -100,10 +99,7 @@ pub async fn run_signup(args: SignupArgs, format: OutputFormat) -> anyhow::Resul
                 String::from("fullname"),
                 output.user.fullname.unwrap_or_default(),
             ]));
-            table.add_row(crate::output::row(vec![
-                String::from("token"),
-                output.token,
-            ]));
+            println!("Token saved to credentials file.");
             print!("{table}");
         }
     }

--- a/crates/cli/src/whoami.rs
+++ b/crates/cli/src/whoami.rs
@@ -27,7 +27,10 @@ pub async fn run_whoami(args: WhoamiArgs, format: OutputFormat) -> anyhow::Resul
     let body = Me::build_query(me::Variables {});
     let response = client
         .post(endpoint)
-        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            auth::bearer_header_value(&token)?,
+        )
         .json(&body)
         .send()
         .await

--- a/crates/cli/src/ws.rs
+++ b/crates/cli/src/ws.rs
@@ -1,0 +1,237 @@
+//! Shared WebSocket streaming logic for GraphQL subscriptions.
+
+use anyhow::{Context, anyhow};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+use crate::auth;
+
+/// A decoded log entry from a GraphQL subscription.
+#[derive(Debug)]
+pub(crate) struct SubscriptionLog {
+    pub(crate) severity: String,
+    pub(crate) timestamp: String,
+    pub(crate) message: String,
+}
+
+/// Parameters describing a GraphQL subscription to stream.
+pub(crate) struct SubscriptionParams<'a> {
+    pub(crate) subscription_id: &'a str,
+    pub(crate) query: &'a str,
+    pub(crate) operation_name: &'a str,
+    pub(crate) variables: serde_json::Value,
+    pub(crate) log_field_name: &'a str,
+}
+
+/// Open a WebSocket connection to the given endpoint with authentication,
+/// perform the graphql-transport-ws handshake (connection_init + ack),
+/// send a subscription message, and invoke `on_log` for each log entry received.
+pub(crate) async fn stream_subscription(
+    ws_endpoint: &str,
+    token: &str,
+    params: SubscriptionParams<'_>,
+    mut on_log: impl FnMut(&SubscriptionLog),
+) -> anyhow::Result<()> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let mut request = ws_endpoint
+        .into_client_request()
+        .context("failed to build websocket request")?;
+    let header_value = auth::bearer_header_value(token)?;
+    request
+        .headers_mut()
+        .insert(reqwest::header::AUTHORIZATION, header_value);
+    request.headers_mut().insert(
+        reqwest::header::SEC_WEBSOCKET_PROTOCOL,
+        reqwest::header::HeaderValue::from_static("graphql-transport-ws"),
+    );
+
+    let (ws_stream, _) = connect_async(request)
+        .await
+        .with_context(|| format!("failed to connect websocket at {ws_endpoint}"))?;
+    let (mut write, mut read) = ws_stream.split();
+
+    write
+        .send(Message::Text(
+            json!({ "type": "connection_init" }).to_string(),
+        ))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to send graphql websocket connection init for {}",
+                params.subscription_id
+            )
+        })?;
+
+    wait_for_connection_ack(&mut read, &mut write).await?;
+
+    write
+        .send(Message::Text(
+            json!({
+                "id": params.subscription_id,
+                "type": "subscribe",
+                "payload": {
+                    "query": params.query,
+                    "variables": params.variables,
+                    "operationName": params.operation_name
+                }
+            })
+            .to_string(),
+        ))
+        .await
+        .with_context(|| format!("failed to send {} subscription", params.operation_name))?;
+
+    while let Some(message) = read.next().await {
+        let message = message.context("failed to read websocket message")?;
+        match message {
+            Message::Text(text) => {
+                if let Some(log) = decode_subscription_log(&text, params.log_field_name)? {
+                    on_log(&log);
+                }
+            }
+            Message::Binary(_) => {}
+            Message::Ping(payload) => {
+                write
+                    .send(Message::Pong(payload))
+                    .await
+                    .context("failed to send websocket pong")?;
+            }
+            Message::Pong(_) => {}
+            Message::Close(_) => {
+                break;
+            }
+            Message::Frame(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
+async fn wait_for_connection_ack<Read, Write>(
+    read: &mut Read,
+    write: &mut Write,
+) -> anyhow::Result<()>
+where
+    Read:
+        futures_util::Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+    Write: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    while let Some(message) = read.next().await {
+        let message = message.context("failed to read connection ack message")?;
+        match message {
+            Message::Text(text) => {
+                let value: serde_json::Value = serde_json::from_str(&text)
+                    .with_context(|| format!("failed to decode websocket message: {text}"))?;
+                match value
+                    .get("type")
+                    .and_then(|message_type| message_type.as_str())
+                {
+                    Some("connection_ack") => return Ok(()),
+                    Some("ping") => {
+                        write
+                            .send(Message::Text(json!({ "type": "pong" }).to_string()))
+                            .await
+                            .context("failed to send graphql ping response")?;
+                    }
+                    Some("connection_error") => {
+                        return Err(anyhow!(
+                            "graphql websocket connection rejected: {}",
+                            value
+                                .get("payload")
+                                .map(|payload| payload.to_string())
+                                .unwrap_or_else(|| String::from("<empty payload>"))
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            Message::Ping(payload) => {
+                write
+                    .send(Message::Pong(payload))
+                    .await
+                    .context("failed to send websocket pong")?;
+            }
+            Message::Close(_) => return Err(anyhow!("websocket closed before connection ack")),
+            Message::Binary(_) | Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+
+    Err(anyhow!("websocket closed before connection ack"))
+}
+
+fn decode_subscription_log(
+    text: &str,
+    field_name: &str,
+) -> anyhow::Result<Option<SubscriptionLog>> {
+    let value: serde_json::Value =
+        serde_json::from_str(text).with_context(|| format!("failed to decode message: {text}"))?;
+
+    let Some(message_type) = value
+        .get("type")
+        .and_then(|message_type| message_type.as_str())
+    else {
+        return Ok(None);
+    };
+
+    match message_type {
+        "next" => {
+            let payload = value
+                .get("payload")
+                .ok_or_else(|| anyhow!("subscription message missing payload"))?;
+            if let Some(errors) = payload.get("errors") {
+                return Err(anyhow!("subscription returned errors: {errors}"));
+            }
+
+            let log = payload
+                .get("data")
+                .and_then(|data| data.get(field_name))
+                .ok_or_else(|| anyhow!("subscription message missing {field_name}"))?;
+
+            let severity = log
+                .get("severity")
+                .and_then(|severity| severity.as_str())
+                .ok_or_else(|| anyhow!("log entry missing severity"))?;
+            let timestamp = log
+                .get("timestamp")
+                .and_then(|timestamp| timestamp.as_str())
+                .ok_or_else(|| anyhow!("log entry missing timestamp"))?;
+            let message = log
+                .get("message")
+                .and_then(|message| message.as_str())
+                .ok_or_else(|| anyhow!("log entry missing message"))?;
+
+            Ok(Some(SubscriptionLog {
+                severity: severity.to_string(),
+                timestamp: timestamp.to_string(),
+                message: message.to_string(),
+            }))
+        }
+        "error" => {
+            let payload = value
+                .get("payload")
+                .map(|payload| payload.to_string())
+                .unwrap_or_else(|| String::from("<empty payload>"));
+            Err(anyhow!("subscription returned error: {payload}"))
+        }
+        "complete" | "ka" | "connection_ack" | "pong" | "ping" => Ok(None),
+        other => Err(anyhow!("unsupported subscription message type: {other}")),
+    }
+}
+
+/// Convert an HTTP(S) GraphQL endpoint to its WebSocket equivalent.
+pub(crate) fn graphql_ws_endpoint(graphql_endpoint: &str) -> anyhow::Result<String> {
+    let ws_endpoint = if let Some(rest) = graphql_endpoint.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = graphql_endpoint.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else if graphql_endpoint.starts_with("ws://") || graphql_endpoint.starts_with("wss://") {
+        graphql_endpoint.to_string()
+    } else {
+        return Err(anyhow!(
+            "unsupported graphql endpoint scheme for websocket: {graphql_endpoint}"
+        ));
+    };
+
+    Ok(ws_endpoint)
+}


### PR DESCRIPTION
## Summary

Addresses the critical, high, and medium severity findings from the CLI quality audit.

Closes #155

### Security (High)
- **Token exposure**: Tokens are no longer printed to stdout in `signin`/`signup` text output; they are only persisted to the credentials file
- **File permissions**: Token cache and user config files are now written with `0o600` (owner read/write only) on Unix systems

### Security (Medium)
- **SSH key zeroing**: Private key material is wrapped in `Zeroizing<String>` so it is cleared from memory when dropped
- **Header validation**: New `bearer_header_value()` validates token length (min 10, max 4096) before constructing HTTP Authorization headers
- **WebSocket auth**: WS connections now use the validated `bearer_header_value()` helper

### Factoring (Medium)
- **WebSocket deduplication**: Extracted ~200 lines of shared WebSocket streaming logic (connection setup, handshake, subscription message loop, log decoding) into a new `ws.rs` module with a `stream_subscription()` function and `SubscriptionParams` struct, used by both `deployment.rs` and `resource.rs`

### Data Model (Medium)
- **GraphQL error handling**: `graphql_response_data()` now preserves structured error info (locations, paths) with numbered error messages instead of concatenating with `.join("; ")`
- **Token format decoupling**: Extracted token expiry parsing into a `TokenExpiry` struct, removing magic numbers and hard-coded byte positions

### Validation (Low)
- **Repository path validation**: `parse_repository_path()` now rejects segments containing special characters, allowing only alphanumeric, hyphens, and underscores

## Test plan
- [x] `cargo clippy -p cli --all-targets` passes with no warnings
- [x] `cargo test -p cli` passes
- [x] `cargo fmt -p cli` produces no changes
- [ ] Manual test: `skyr signin` no longer prints token to terminal
- [ ] Manual test: token file has 0o600 permissions after signin

🤖 Generated with [Claude Code](https://claude.com/claude-code)