### PR TITLE
fix(sclc): address quality audit findings

### DIFF
--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -370,6 +370,16 @@ pub struct TypeChecker<'p, S> {
     program: &'p Program<S>,
 }
 
+/// Global monotonic counter for unique type variable IDs.
+///
+/// # Thread safety
+///
+/// The counter is process-global and atomic, so IDs are unique across threads.
+/// However, the counter is never reset between compilations, meaning type IDs
+/// will grow monotonically across invocations within the same process. This is
+/// harmless in practice — IDs are only used for identity comparison during a
+/// single type-checking pass — but embedders should be aware that IDs are not
+/// stable or reproducible across runs.
 static NEXT_TYPE_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn next_type_id() -> usize {

--- a/crates/sclc/src/eval.rs
+++ b/crates/sclc/src/eval.rs
@@ -230,6 +230,18 @@ pub struct Eval {
     externs: HashMap<String, Value>,
 }
 
+/// Resource effects emitted during evaluation.
+///
+/// Effects are sent through an unbounded MPSC channel to the caller. Because
+/// evaluation is single-threaded and the channel is unbounded, sends never
+/// block or fail unless the receiver is dropped.
+///
+/// **Atomicity:** effects are emitted one at a time as the evaluator
+/// encounters resources. If evaluation fails partway through (e.g. due to a
+/// runtime error or exception), the caller will have received a partial set
+/// of effects. The caller is responsible for discarding or rolling back
+/// partial effects on failure — the evaluator itself does not provide
+/// transactional guarantees.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Effect {
     CreateResource {
@@ -539,8 +551,19 @@ impl Eval {
         eval
     }
 
+    /// Register an extern value under the given name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty or contains whitespace, which would make it
+    /// unreachable from SCL source code.
     pub fn add_extern(&mut self, name: impl Into<String>, value: Value) {
-        self.externs.insert(name.into(), value);
+        let name = name.into();
+        assert!(
+            !name.is_empty() && !name.contains(char::is_whitespace),
+            "extern name must be non-empty and contain no whitespace, got: {name:?}"
+        );
+        self.externs.insert(name, value);
     }
 
     pub fn add_resource(&mut self, id: ResourceId, resource: crate::Resource) {

--- a/crates/sclc/src/fmt.rs
+++ b/crates/sclc/src/fmt.rs
@@ -20,22 +20,8 @@ fn collect_comments(source: &str) -> Vec<Comment> {
         .collect()
 }
 
-/// Encode a string value back to its source representation (without quotes).
-/// This is the inverse of `decode_string` in the parser.
 fn encode_string(s: &str) -> String {
-    let mut out = String::new();
-    for c in s.chars() {
-        match c {
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\\' => out.push_str("\\\\"),
-            '{' => out.push_str("\\{"),
-            '"' => out.push_str("\\\""),
-            other => out.push(other),
-        }
-    }
-    out
+    crate::string_escape::encode_string(s)
 }
 
 pub struct Formatter {

--- a/crates/sclc/src/lib.rs
+++ b/crates/sclc/src/lib.rs
@@ -14,6 +14,7 @@ mod program;
 mod resource;
 mod source_repo;
 mod std;
+pub mod string_escape;
 mod ty;
 mod value;
 

--- a/crates/sclc/src/module_id.rs
+++ b/crates/sclc/src/module_id.rs
@@ -11,6 +11,16 @@ impl ModuleId {
         Self { segments }
     }
 
+    /// Returns `true` if every segment is a safe identifier (non-empty, no `.`,
+    /// no `/`, no `\`, and not `..`). This prevents path-traversal when the
+    /// module id is converted to a filesystem path via
+    /// [`to_path_buf_with_extension`](Self::to_path_buf_with_extension).
+    pub fn is_safe_path(&self) -> bool {
+        self.segments.iter().all(|s| {
+            !s.is_empty() && s != ".." && s != "." && !s.contains('/') && !s.contains('\\')
+        })
+    }
+
     pub fn len(&self) -> usize {
         self.segments.len()
     }
@@ -88,5 +98,46 @@ impl FromStr for ModuleId {
                 .map(str::to_owned)
                 .collect(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_path_accepts_normal_segments() {
+        let id = ModuleId::from(["Std", "Time"]);
+        assert!(id.is_safe_path());
+    }
+
+    #[test]
+    fn safe_path_rejects_dot_dot() {
+        let id = ModuleId::from(["Std", "..", "etc"]);
+        assert!(!id.is_safe_path());
+    }
+
+    #[test]
+    fn safe_path_rejects_single_dot() {
+        let id = ModuleId::from([".", "Foo"]);
+        assert!(!id.is_safe_path());
+    }
+
+    #[test]
+    fn safe_path_rejects_slash_in_segment() {
+        let id = ModuleId::from(["Std/../../etc"]);
+        assert!(!id.is_safe_path());
+    }
+
+    #[test]
+    fn safe_path_rejects_empty_segment() {
+        let id = ModuleId::from(["Std", "", "Foo"]);
+        assert!(!id.is_safe_path());
+    }
+
+    #[test]
+    fn safe_path_rejects_backslash_in_segment() {
+        let id = ModuleId::from(["Std\\..\\etc"]);
+        assert!(!id.is_safe_path());
     }
 }

--- a/crates/sclc/src/package.rs
+++ b/crates/sclc/src/package.rs
@@ -16,6 +16,9 @@ pub enum OpenError {
     #[error("module not found: {0}")]
     NotFound(PathBuf),
 
+    #[error("path traversal rejected: {0}")]
+    PathTraversal(PathBuf),
+
     #[error("failed to load source file: {0}")]
     Source(Box<dyn std::error::Error + Send + Sync>),
 
@@ -62,6 +65,16 @@ impl<S: SourceRepo> Package<S> {
         path: impl AsRef<Path>,
     ) -> Result<Diagnosed<Option<&FileMod>>, OpenError> {
         let path = path.as_ref().to_path_buf();
+
+        // Reject paths that contain traversal components (e.g. ".." or
+        // absolute prefixes) to prevent escaping the package directory.
+        for component in path.components() {
+            match component {
+                Component::Normal(_) => {}
+                _ => return Err(OpenError::PathTraversal(path)),
+            }
+        }
+
         if self.files.contains_key(&path) {
             return Ok(Diagnosed::new(
                 Some(

--- a/crates/sclc/src/parser.rs
+++ b/crates/sclc/src/parser.rs
@@ -15,6 +15,28 @@ use crate::{
     UnaryExpr, UnaryOp, Var,
 };
 
+/// Maximum allowed source file size in bytes. Files larger than this are
+/// rejected early to prevent excessive memory use and parse time. The limit
+/// is generous enough for any reasonable SCL source file.
+pub const MAX_SOURCE_SIZE: usize = 1_024 * 1_024; // 1 MiB
+
+#[derive(Error, Debug)]
+#[error("source file too large ({size} bytes, limit {limit} bytes)")]
+pub struct SourceTooLarge {
+    pub module_id: ModuleId,
+    pub size: usize,
+    pub limit: usize,
+}
+
+impl Diag for SourceTooLarge {
+    fn locate(&self) -> (ModuleId, Span) {
+        (
+            self.module_id.clone(),
+            Span::new(Position::default(), Position::default()),
+        )
+    }
+}
+
 #[derive(Error, Debug)]
 #[error("duplicate record field: {name}")]
 pub struct DuplicateRecordField {
@@ -78,30 +100,7 @@ enum TypeExprSuffix {
 }
 
 fn decode_string(raw: &str) -> String {
-    let mut out = String::new();
-    let mut chars = raw.chars();
-
-    while let Some(c) = chars.next() {
-        if c != '\\' {
-            out.push(c);
-            continue;
-        }
-
-        match chars.next() {
-            Some('n') => out.push('\n'),
-            Some('r') => out.push('\r'),
-            Some('t') => out.push('\t'),
-            Some('\\') => out.push('\\'),
-            Some('{') => out.push('{'),
-            Some(other) => {
-                out.push('\\');
-                out.push(other);
-            }
-            None => out.push('\\'),
-        }
-    }
-
-    out
+    crate::string_escape::decode_string(raw)
 }
 
 pub struct TokenStream<'a> {
@@ -1206,6 +1205,16 @@ pub fn parse_file_mod_with_cursor(
     cursor: Option<crate::Cursor>,
 ) -> Diagnosed<FileMod> {
     let mut diags = DiagList::new();
+
+    if source.len() > MAX_SOURCE_SIZE {
+        diags.push(SourceTooLarge {
+            module_id: module_id.clone(),
+            size: source.len(),
+            limit: MAX_SOURCE_SIZE,
+        });
+        return Diagnosed::new(FileMod::default(), diags);
+    }
+
     let mut exception_id = 0u64;
     let mut skip_span = None;
     let token_stream = match &cursor {
@@ -1243,6 +1252,16 @@ pub fn parse_repl_line_with_cursor(
     cursor: Option<crate::Cursor>,
 ) -> Diagnosed<Option<ReplLine>> {
     let mut diags = DiagList::new();
+
+    if source.len() > MAX_SOURCE_SIZE {
+        diags.push(SourceTooLarge {
+            module_id: module_id.clone(),
+            size: source.len(),
+            limit: MAX_SOURCE_SIZE,
+        });
+        return Diagnosed::new(None, diags);
+    }
+
     let mut exception_id = 0u64;
     let mut skip_span = None;
     let token_stream = match &cursor {

--- a/crates/sclc/src/program.rs
+++ b/crates/sclc/src/program.rs
@@ -146,11 +146,15 @@ impl<S: SourceRepo> Program<S> {
             return Ok(Diagnosed::new(None, DiagList::new()));
         }
 
-        let module_path = module_segments
-            .iter()
-            .cloned()
-            .collect::<ModuleId>()
-            .to_path_buf_with_extension("scl");
+        let module_id_from_segments = module_segments.iter().cloned().collect::<ModuleId>();
+
+        // Reject module paths containing traversal components (e.g. "..")
+        // to prevent escaping the package directory.
+        if !module_id_from_segments.is_safe_path() {
+            return Ok(Diagnosed::new(None, DiagList::new()));
+        }
+
+        let module_path = module_id_from_segments.to_path_buf_with_extension("scl");
 
         let Some(package) = self.packages.get_mut(&package_name) else {
             return Ok(Diagnosed::new(None, DiagList::new()));
@@ -194,11 +198,13 @@ impl<S: SourceRepo> Program<S> {
             return Err(EvaluateError::MissingModulePath(module_id.clone()));
         }
 
-        let module_path = module_segments
-            .iter()
-            .cloned()
-            .collect::<ModuleId>()
-            .to_path_buf_with_extension("scl");
+        let module_id_from_segments = module_segments.iter().cloned().collect::<ModuleId>();
+
+        if !module_id_from_segments.is_safe_path() {
+            return Err(EvaluateError::ModuleNotLoaded(module_id.clone()));
+        }
+
+        let module_path = module_id_from_segments.to_path_buf_with_extension("scl");
 
         let file_mod = {
             let Some(package) = self.packages.get_mut(&package_name) else {
@@ -262,11 +268,11 @@ impl<S: SourceRepo> Program<S> {
         if module_segments.is_empty() {
             return None;
         }
-        let module_path = module_segments
-            .iter()
-            .cloned()
-            .collect::<ModuleId>()
-            .to_path_buf_with_extension("scl");
+        let module_id_from_segments = module_segments.iter().cloned().collect::<ModuleId>();
+        if !module_id_from_segments.is_safe_path() {
+            return None;
+        }
+        let module_path = module_id_from_segments.to_path_buf_with_extension("scl");
         package
             .modules()
             .find_map(|(path, file_mod)| (path == &module_path).then_some(file_mod))

--- a/crates/sclc/src/string_escape.rs
+++ b/crates/sclc/src/string_escape.rs
@@ -1,0 +1,110 @@
+//! SCL string escape handling.
+//!
+//! SCL strings support the following escape sequences:
+//!
+//! | Escape   | Character       |
+//! |----------|-----------------|
+//! | `\n`     | Line feed       |
+//! | `\r`     | Carriage return |
+//! | `\t`     | Tab             |
+//! | `\\`     | Backslash       |
+//! | `\{`     | Literal `{`     |
+//! | `\"`     | Double quote    |
+//!
+//! Inside string literals, an unescaped `{` begins an interpolation
+//! expression (handled by the lexer/parser, not here).
+//!
+//! Unrecognised escape sequences are kept verbatim (the backslash and
+//! the following character are both emitted).
+
+/// Decode a raw string literal body (the text between quotes, with
+/// interpolation segments already split out) into its runtime value.
+pub fn decode_string(raw: &str) -> String {
+    let mut out = String::new();
+    let mut chars = raw.chars();
+
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            Some('\\') => out.push('\\'),
+            Some('{') => out.push('{'),
+            Some('"') => out.push('"'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+
+    out
+}
+
+/// Encode a runtime string value back to its source representation
+/// (without surrounding quotes). This is the inverse of [`decode_string`].
+pub fn encode_string(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\\' => out.push_str("\\\\"),
+            '{' => out.push_str("\\{"),
+            '"' => out.push_str("\\\""),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_basic() {
+        let original = "hello\nworld\t{foo}\\bar\"baz";
+        let encoded = encode_string(original);
+        let decoded = decode_string(&encoded);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn decode_unrecognised_escape() {
+        // Unrecognised escapes are kept verbatim.
+        assert_eq!(decode_string(r"\z"), "\\z");
+    }
+
+    #[test]
+    fn decode_trailing_backslash() {
+        assert_eq!(decode_string("abc\\"), "abc\\");
+    }
+
+    #[test]
+    fn encode_special_chars() {
+        assert_eq!(encode_string("\n"), "\\n");
+        assert_eq!(encode_string("\r"), "\\r");
+        assert_eq!(encode_string("\t"), "\\t");
+        assert_eq!(encode_string("\\"), "\\\\");
+        assert_eq!(encode_string("{"), "\\{");
+        assert_eq!(encode_string("\""), "\\\"");
+    }
+
+    #[test]
+    fn decode_all_escapes() {
+        assert_eq!(decode_string(r"\n"), "\n");
+        assert_eq!(decode_string(r"\r"), "\r");
+        assert_eq!(decode_string(r"\t"), "\t");
+        assert_eq!(decode_string(r"\\"), "\\");
+        assert_eq!(decode_string(r"\{"), "{");
+        assert_eq!(decode_string(r#"\""#), "\"");
+    }
+}

--- a/crates/sclc/src/ty.rs
+++ b/crates/sclc/src/ty.rs
@@ -6,6 +6,15 @@ thread_local! {
     /// function type is formatted, its type-parameter IDs are pushed here so
     /// that nested `Type::Var` nodes can look up their index and print a
     /// friendly name (`A`, `B`, …) instead of a raw numeric ID.
+    ///
+    /// # Note for embedders
+    ///
+    /// This state is thread-local and only accessed during `Display::fmt`
+    /// calls on [`Type`] / [`FnType`]. It is cleaned up after each
+    /// formatting call completes, so it is safe to format types from any
+    /// thread. However, formatting a `Type` inside a `Display` impl for
+    /// another `Type` on the same thread is intentional — it is how nested
+    /// generic types resolve their parameter names.
     static DISPLAY_TYPE_PARAMS: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
 }
 


### PR DESCRIPTION
## Summary

Addresses the medium and low severity findings from the `sclc` quality audit in #150.

Closes #150

### Security fixes
- **Path traversal in module loading (3.4):** Added `ModuleId::is_safe_path()` validation to reject segments containing `..`, `.`, `/`, or `\`. Applied in `Package::open` (rejects non-`Normal` path components) and all three module-path resolution sites in `Program`.
- **Input size validation (3.2):** Added a 1 MiB source file size limit enforced in `parse_file_mod` and `parse_repl_line` entry points, producing a diagnostic instead of attempting to parse.
- **Extern registration validation (3.5):** `Eval::add_extern` now panics on empty or whitespace-containing names that would be unreachable from SCL source.

### Code quality fixes
- **String escape consolidation (3.6):** Moved `decode_string` (parser) and `encode_string` (formatter) into a shared `string_escape` module with a documented escape table and round-trip tests. Also fixed `decode_string` to handle `\"` escapes (matching `encode_string`).
- **Non-atomic resource effects (3.3):** Documented partial-failure semantics on the `Effect` enum -- callers are responsible for rollback.
- **Global type ID counter (2.5):** Documented thread-safety characteristics and non-reproducibility across runs.
- **Thread-local type display state (2.4):** Expanded documentation with embedder guidance.

### Not addressed in this PR
- **Oversized modules (1.2-1.4):** Splitting `checker.rs`, `parser.rs`, and `eval.rs` is a large refactoring effort better done incrementally.
- **40+ error structs (2.3):** Consolidating diagnostics into enum-based types would touch many call sites and is better done as a dedicated refactor.

## Test plan
- [x] All 259 existing `sclc` tests pass
- [x] New unit tests for `ModuleId::is_safe_path` (6 tests)
- [x] New unit tests for string escape round-tripping (5 tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)