### PR TITLE
fix(sclc): disallow extra fields in record literals

### DIFF
--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -700,6 +700,20 @@ impl crate::Diag for UnknownType {
 }
 
 #[derive(Error, Debug)]
+#[error("unknown field \"{name}\" in record literal")]
+pub struct UnknownField {
+    pub module_id: crate::ModuleId,
+    pub name: String,
+    pub span: crate::Span,
+}
+
+impl crate::Diag for UnknownField {
+    fn locate(&self) -> (crate::ModuleId, crate::Span) {
+        (self.module_id.clone(), self.span)
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum TypeCheckError {
     #[error("module id missing during type checking")]
     ModuleIdMissing,
@@ -1909,6 +1923,15 @@ impl<'p, S: crate::SourceRepo> TypeChecker<'p, S> {
                             )),
                             span: expr.span(),
                         });
+                    }
+                    for field in &record_expr.fields {
+                        if expected_record.get(field.var.name.as_str()).is_none() {
+                            diags.push(UnknownField {
+                                module_id: env.module_id()?,
+                                name: field.var.name.clone(),
+                                span: field.var.span(),
+                            });
+                        }
                     }
                     return Ok(Diagnosed::new(ty, diags));
                 }

--- a/crates/sclc/src/tests/DiagRecordExtraField/Main.scl
+++ b/crates/sclc/src/tests/DiagRecordExtraField/Main.scl
@@ -1,0 +1,2 @@
+let f = fn(x: {name: Str, age: Int?}) x
+let y = f({ name: "Alice", agee: 30 })

--- a/crates/sclc/src/tests/DiagRecordExtraField/diag.log
+++ b/crates/sclc/src/tests/DiagRecordExtraField/diag.log
@@ -1,0 +1,1 @@
+DiagRecordExtraField/Main 2:28,2:32: unknown field "agee" in record literal

--- a/crates/sclc/src/tests/mod.rs
+++ b/crates/sclc/src/tests/mod.rs
@@ -511,6 +511,7 @@ test_case!(RecursiveGlobalFn);
 // Diagnostic tests
 test_case!(DiagNumToHexWrongType);
 test_case!(DiagListMapWrongType);
+test_case!(DiagRecordExtraField);
 
 // Let type annotation tests
 test_case!(LetTypeAnnotation);


### PR DESCRIPTION
## Summary

- Adds an `UnknownField` diagnostic to the type checker that fires when a record literal contains fields not present in the expected record type (bidirectional "check" mode)
- This catches typos in optional field names (e.g. `agee` instead of `age`) that were previously silently accepted
- Only applies when an expected type is propagated down; record literals in "synthesize" mode (no expected type) continue to accept any fields

Closes #193

## Test plan

- [x] New `DiagRecordExtraField` fixture test verifies the diagnostic is produced
- [x] All 262 existing `sclc` tests pass (no regressions)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)