### PR TITLE
refactor(lsp): extract shared handler helpers to reduce boilerplate

### DIFF
--- a/crates/lsp/src/handlers/completion.rs
+++ b/crates/lsp/src/handlers/completion.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use lsp_types as lsp;
 
-use crate::analysis::{self, module_id_from_path, uri_to_path};
+use super::{lock_cursor_info, resolve_document};
+use crate::analysis;
 use crate::convert;
 use crate::document::DocumentCache;
 use crate::server::{LspProgram, OutgoingMessage, RequestId};
@@ -21,24 +22,23 @@ pub fn completion(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let path = match uri_to_path(&params.text_document_position.text_document.uri) {
-        Some(p) => p,
+    let ctx = match resolve_document(
+        &params.text_document_position.text_document.uri,
+        documents,
+        root,
+        package_id,
+    ) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let module_id = module_id_from_path(&path, root, package_id);
     let position = convert::to_sclc_position(params.text_document_position.position);
     let cursor_info = match program {
-        Some(program) => analysis::query_cursor(program, &source, &module_id, position),
+        Some(program) => analysis::query_cursor(program, &ctx.source, &ctx.module_id, position),
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let info = cursor_info.lock().unwrap();
+    let info = lock_cursor_info(&cursor_info);
 
     if info.completion_candidates.is_empty() {
         return vec![OutgoingMessage::response(id, serde_json::Value::Null)];

--- a/crates/lsp/src/handlers/formatting.rs
+++ b/crates/lsp/src/handlers/formatting.rs
@@ -1,6 +1,6 @@
 use lsp_types as lsp;
 
-use crate::analysis::{is_scle_path, module_id_from_path, uri_to_path};
+use crate::analysis::is_scle_path;
 use crate::document::DocumentCache;
 use crate::server::{OutgoingMessage, RequestId};
 
@@ -14,23 +14,22 @@ pub fn formatting(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let path = match uri_to_path(&params.text_document.uri) {
-        Some(p) => p,
+    // Formatting only needs path + source, not a full module ID for the
+    // workspace package, so we use a lightweight resolve here.
+    let ctx = match super::resolve_document(
+        &params.text_document.uri,
+        documents,
+        None,
+        &sclc::PackageId::from(["Local"]),
+    ) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let formatted = if is_scle_path(&path) {
-        format_scle(&source)
+    let formatted = if is_scle_path(&ctx.path) {
+        format_scle(&ctx.source)
     } else {
-        // Module ID is only used as a parse-diagnostic label here, so the
-        // package details don't need to match the workspace.
-        let module_id = module_id_from_path(&path, None, &sclc::PackageId::from(["Local"]));
-        format_scl(&source, &module_id)
+        format_scl(&ctx.source, &ctx.module_id)
     };
 
     let formatted = match formatted {
@@ -39,7 +38,7 @@ pub fn formatting(
     };
 
     // If the formatted output is the same, return an empty edit list
-    if formatted == source {
+    if formatted == ctx.source {
         let empty_edits = serde_json::to_value(Vec::<lsp::TextEdit>::new()).unwrap_or_else(|err| {
             eprintln!("lsp: failed to serialize empty edits: {err}");
             serde_json::Value::Null
@@ -48,8 +47,13 @@ pub fn formatting(
     }
 
     // Replace the entire document with the formatted text
-    let line_count = source.lines().count().max(1) as u32;
-    let last_line_len = source.lines().last().map(|l| l.len() as u32).unwrap_or(0);
+    let line_count = ctx.source.lines().count().max(1) as u32;
+    let last_line_len = ctx
+        .source
+        .lines()
+        .last()
+        .map(|l| l.len() as u32)
+        .unwrap_or(0);
 
     let edit = lsp::TextEdit {
         range: lsp::Range {

--- a/crates/lsp/src/handlers/hover.rs
+++ b/crates/lsp/src/handlers/hover.rs
@@ -5,7 +5,8 @@ use lsp_types as lsp;
 // TODO: Add hover support for .scle files. The synthesised __Scle__/Main ASG
 // produced by evaluate_scle could support hover, but cursor positions in the
 // original SCLE source need to map correctly into the synthesised module.
-use crate::analysis::{self, module_id_from_path, uri_to_path};
+use super::{lock_cursor_info, resolve_document};
+use crate::analysis;
 use crate::convert;
 use crate::document::DocumentCache;
 use crate::server::{LspProgram, OutgoingMessage, RequestId};
@@ -23,24 +24,23 @@ pub fn hover(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let path = match uri_to_path(&params.text_document_position_params.text_document.uri) {
-        Some(p) => p,
+    let ctx = match resolve_document(
+        &params.text_document_position_params.text_document.uri,
+        documents,
+        root,
+        package_id,
+    ) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let module_id = module_id_from_path(&path, root, package_id);
     let position = convert::to_sclc_position(params.text_document_position_params.position);
     let cursor_info = match program {
-        Some(program) => analysis::query_cursor(program, &source, &module_id, position),
+        Some(program) => analysis::query_cursor(program, &ctx.source, &ctx.module_id, position),
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let info = cursor_info.lock().unwrap();
+    let info = lock_cursor_info(&cursor_info);
     let mut parts = Vec::new();
     let type_value = match (&info.identifier, &info.ty) {
         (Some(sclc::CursorIdentifier::Let(name)), Some(ty)) => Some(format!("let {name}: {ty}")),

--- a/crates/lsp/src/handlers/mod.rs
+++ b/crates/lsp/src/handlers/mod.rs
@@ -1,5 +1,50 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use crate::analysis::{module_id_from_path, uri_to_path};
+use crate::document::DocumentCache;
+
 pub mod completion;
 pub mod formatting;
 pub mod hover;
 pub mod lifecycle;
 pub mod navigation;
+
+/// Resolved document context from a URI: the file path, source text, and
+/// computed module ID.
+pub struct DocumentContext {
+    pub path: PathBuf,
+    pub source: String,
+    pub module_id: sclc::ModuleId,
+}
+
+/// Resolve a document URI into its path, source content, and module ID.
+///
+/// Returns `None` when the URI cannot be mapped to a path or the document
+/// is not in the cache.
+pub fn resolve_document(
+    uri: &lsp_types::Uri,
+    documents: &DocumentCache,
+    root: Option<&Path>,
+    package_id: &sclc::PackageId,
+) -> Option<DocumentContext> {
+    let path = uri_to_path(uri)?;
+    let source = documents.get(&path)?;
+    let module_id = module_id_from_path(&path, root, package_id);
+    Some(DocumentContext {
+        path,
+        source,
+        module_id,
+    })
+}
+
+/// Lock a `CursorInfo` mutex, recovering gracefully from a poisoned lock
+/// instead of panicking.
+pub fn lock_cursor_info(
+    info: &Arc<Mutex<sclc::CursorInfo>>,
+) -> std::sync::MutexGuard<'_, sclc::CursorInfo> {
+    info.lock().unwrap_or_else(|poisoned| {
+        eprintln!("lsp: cursor info lock was poisoned, recovering");
+        poisoned.into_inner()
+    })
+}

--- a/crates/lsp/src/handlers/navigation.rs
+++ b/crates/lsp/src/handlers/navigation.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 
 use lsp_types as lsp;
 
-use crate::analysis::{self, module_id_from_path, uri_to_path};
+use super::{lock_cursor_info, resolve_document};
+use crate::analysis;
 use crate::convert;
 use crate::document::DocumentCache;
 use crate::server::{LspProgram, OutgoingMessage, RequestId};
@@ -22,29 +23,27 @@ pub fn goto_definition(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let uri = &params.text_document_position_params.text_document.uri;
-    let path = match uri_to_path(uri) {
-        Some(p) => p,
+    let uri = params
+        .text_document_position_params
+        .text_document
+        .uri
+        .clone();
+    let ctx = match resolve_document(&uri, documents, root, package_id) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let module_id = module_id_from_path(&path, root, package_id);
     let position = convert::to_sclc_position(params.text_document_position_params.position);
     let cursor_info = match program {
-        Some(program) => analysis::query_cursor(program, &source, &module_id, position),
+        Some(program) => analysis::query_cursor(program, &ctx.source, &ctx.module_id, position),
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let info = cursor_info.lock().unwrap();
+    let info = lock_cursor_info(&cursor_info);
     let result = match info.declaration {
         Some(decl_span) => {
             let location = lsp::Location {
-                uri: uri.clone(),
+                uri,
                 range: convert::to_lsp_range(decl_span),
             };
             serde_json::to_value(location).unwrap_or_else(|err| {
@@ -71,25 +70,19 @@ pub fn references(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let uri = &params.text_document_position.text_document.uri;
-    let path = match uri_to_path(uri) {
-        Some(p) => p,
+    let uri = params.text_document_position.text_document.uri.clone();
+    let ctx = match resolve_document(&uri, documents, root, package_id) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let module_id = module_id_from_path(&path, root, package_id);
     let position = convert::to_sclc_position(params.text_document_position.position);
     let cursor_info = match program {
-        Some(program) => analysis::query_cursor(program, &source, &module_id, position),
+        Some(program) => analysis::query_cursor(program, &ctx.source, &ctx.module_id, position),
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let info = cursor_info.lock().unwrap();
+    let info = lock_cursor_info(&cursor_info);
 
     let mut locations: Vec<lsp::Location> = info
         .references
@@ -137,18 +130,12 @@ pub fn document_symbol(
         Err(_) => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let path = match uri_to_path(&params.text_document.uri) {
-        Some(p) => p,
+    let ctx = match resolve_document(&params.text_document.uri, documents, root, package_id) {
+        Some(ctx) => ctx,
         None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
     };
 
-    let source = match documents.get(&path) {
-        Some(s) => s,
-        None => return vec![OutgoingMessage::response(id, serde_json::Value::Null)],
-    };
-
-    let module_id = module_id_from_path(&path, root, package_id);
-    let symbols = analysis::document_symbols(&source, &module_id);
+    let symbols = analysis::document_symbols(&ctx.source, &ctx.module_id);
 
     let result = serde_json::to_value(symbols).unwrap_or_else(|err| {
         eprintln!("lsp: failed to serialize document symbols: {err}");


### PR DESCRIPTION
## Summary

- Extracts `resolve_document()` helper in `handlers/mod.rs` that consolidates the repeated URI→path→source→module_id resolution pattern shared across all LSP request handlers (completion, hover, goto-definition, references, document-symbol, formatting).
- Extracts `lock_cursor_info()` helper that recovers from poisoned mutex locks instead of panicking with `.lock().unwrap()`, matching the existing pattern in `DocumentCache`.
- Removes ~30 lines of duplicated boilerplate across 5 handler files.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes cleanly
- [x] `cargo test -p lsp` — all 13 tests pass
- [x] `cargo fmt` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)