### PR TITLE
feat(de): add horizontal scaling via deployment sharding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deps:
 	@while [ "$$(podman inspect -f '{{.State.Health.Status}}' skyr_rabbitmq_1 2>/dev/null)" != "healthy" ]; do sleep 2; done
 
 up: image scoc-image web-image deps
-	podman compose -f dev/podman-compose.yml up -d --force-recreate web api scs de rte-0 rte-1 rte-2 plugin-std-random plugin-std-time plugin-std-artifact plugin-std-crypto plugin-std-dns plugin-std-container scoc-1 scoc-2 scoc-3
+	podman compose -f dev/podman-compose.yml up -d --force-recreate web api scs de-0 de-1 rte-0 rte-1 rte-2 plugin-std-random plugin-std-time plugin-std-artifact plugin-std-crypto plugin-std-dns plugin-std-container scoc-1 scoc-2 scoc-3
 
 down:
 	podman compose -f dev/podman-compose.yml down

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Application services:
 | api | 8080 | GraphQL API |
 | web | 5173 | Web dashboard (dev server) |
 | scs | 2222 | SSH Git server |
-| de | — | Deployment engine |
+| de-{0,1} | — | Deployment engine workers |
 | rte-{0,1,2} | — | Resource transition engine workers |
 | plugin-std-random | 50051 | Random plugin |
 | plugin-std-time | 50056 | Time plugin |

--- a/crates/de/README.md
+++ b/crates/de/README.md
@@ -13,11 +13,24 @@ CDB → DE → SCLC (compile)
            DE → LDB (deployment logs)
 ```
 
+## Horizontal Scaling
+
+DE supports horizontal scaling via deployment sharding. Each replica receives a disjoint subset of active deployments based on the commit hash:
+
+```
+de daemon --worker-index 0 --worker-count 3
+de daemon --worker-index 1 --worker-count 3
+de daemon --worker-index 2 --worker-count 3
+```
+
+The first 16 hex characters of each deployment's commit hash are interpreted as a big-endian `u64`. The deployment is assigned to a worker via `hash_prefix % worker_count`. With the defaults (`--worker-index 0 --worker-count 1`), a single instance handles all deployments.
+
 ## How It Works
 
 1. **Polling**: The daemon polls for active deployments every 20 seconds.
-2. **Workers**: A dedicated worker is spawned for each active deployment, running a loop every 5 seconds.
-3. **State handling**: Each worker handles the deployment based on its current state:
+2. **Sharding**: Each instance filters deployments to only those assigned to its worker index.
+3. **Workers**: A dedicated worker is spawned for each owned deployment, running a loop every 5 seconds.
+4. **State handling**: Each worker handles the deployment based on its current state:
 
 | State | Behavior |
 |-------|----------|

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -90,7 +90,31 @@ enum Program {
 
         #[clap(long = "ldb-hostname", default_value = "localhost")]
         ldb_hostname: String,
+
+        #[clap(long = "worker-index", default_value_t = 0)]
+        worker_index: u16,
+
+        #[clap(long = "worker-count", default_value_t = 1)]
+        worker_count: u16,
     },
+}
+
+/// Determines whether the given deployment is owned by this worker.
+///
+/// Interprets the first 16 hex characters of the deployment (commit hash) ID
+/// as a big-endian u64 and assigns it to a worker via modulo division.
+/// When `worker_count` is 1 every deployment is owned.
+fn deployment_owned_by_worker(
+    deployment_id: &ids::DeploymentId,
+    worker_index: u16,
+    worker_count: u16,
+) -> bool {
+    if worker_count <= 1 {
+        return true;
+    }
+    let hex_prefix = &deployment_id.as_str()[..16];
+    let hash = u64::from_str_radix(hex_prefix, 16).unwrap_or(0);
+    (hash % worker_count as u64) == worker_index as u64
 }
 
 #[tokio::main]
@@ -108,8 +132,21 @@ async fn main() -> anyhow::Result<()> {
             rdb_hostname,
             rtq_hostname,
             ldb_hostname,
+            worker_index,
+            worker_count,
         } => {
-            tracing::info!("starting deployment engine daemon");
+            if worker_count == 0 {
+                anyhow::bail!("--worker-count must be at least 1");
+            }
+            if worker_index >= worker_count {
+                anyhow::bail!("--worker-index must be less than --worker-count");
+            }
+
+            tracing::info!(
+                worker_index,
+                worker_count,
+                "starting deployment engine daemon",
+            );
 
             let cdb_client = cdb::ClientBuilder::new()
                 .known_node(&cdb_hostname)
@@ -141,6 +178,8 @@ async fn main() -> anyhow::Result<()> {
                     rtq_publisher.clone(),
                     ldb_publisher.clone(),
                     &mut workers,
+                    worker_index,
+                    worker_count,
                 )
                 .await
                 {
@@ -163,10 +202,25 @@ async fn process(
     rtq_publisher: rtq::Publisher,
     ldb_publisher: ldb::Publisher,
     workers: &mut BTreeMap<String, oneshot::Sender<()>>,
+    worker_index: u16,
+    worker_count: u16,
 ) -> anyhow::Result<()> {
-    let deployments = client.active_deployments().await?.collect::<Vec<_>>().await;
+    let all_deployments = client.active_deployments().await?.collect::<Vec<_>>().await;
 
-    tracing::debug!("found {} deployments", deployments.len());
+    let deployments: Vec<_> = all_deployments
+        .into_iter()
+        .filter(|d| match d {
+            Ok(d) => deployment_owned_by_worker(&d.deployment, worker_index, worker_count),
+            Err(_) => true, // propagate errors
+        })
+        .collect();
+
+    tracing::debug!(
+        "found {} deployments for this worker (index={}, count={})",
+        deployments.len(),
+        worker_index,
+        worker_count,
+    );
 
     let mut untouched = workers.keys().cloned().collect::<BTreeSet<_>>();
     for deployment in deployments {

--- a/dev/podman-compose.yml
+++ b/dev/podman-compose.yml
@@ -153,7 +153,7 @@ services:
     volumes:
       - ./host.pem:/host.pem:ro
 
-  de:
+  de-0:
     image: skyr:latest
     entrypoint: ["/de"]
     command:
@@ -167,6 +167,31 @@ services:
         "rabbitmq",
         "--ldb-hostname",
         "redpanda",
+        "--worker-index",
+        "0",
+        "--worker-count",
+        "2",
+      ]
+    restart: always
+
+  de-1:
+    image: skyr:latest
+    entrypoint: ["/de"]
+    command:
+      [
+        "daemon",
+        "--cdb-hostname",
+        "scylla",
+        "--rdb-hostname",
+        "scylla",
+        "--rtq-hostname",
+        "rabbitmq",
+        "--ldb-hostname",
+        "redpanda",
+        "--worker-index",
+        "1",
+        "--worker-count",
+        "2",
       ]
     restart: always
 

--- a/infra/skyr-k8s/services.tf
+++ b/infra/skyr-k8s/services.tf
@@ -268,22 +268,24 @@ resource "kubernetes_service" "scs" {
 # =============================================================================
 
 resource "kubernetes_deployment" "de" {
+  count = var.de_worker_count
+
   metadata {
-    name      = "de"
+    name      = "de-${count.index}"
     namespace = local.namespace
-    labels    = merge(local.labels, { "app.kubernetes.io/name" = "de" })
+    labels    = merge(local.labels, { "app.kubernetes.io/name" = "de", "skyr/worker-index" = tostring(count.index) })
   }
 
   spec {
     replicas = 1
 
     selector {
-      match_labels = { "app.kubernetes.io/name" = "de" }
+      match_labels = { "app.kubernetes.io/name" = "de", "skyr/worker-index" = tostring(count.index) }
     }
 
     template {
       metadata {
-        labels = merge(local.labels, { "app.kubernetes.io/name" = "de" })
+        labels = merge(local.labels, { "app.kubernetes.io/name" = "de", "skyr/worker-index" = tostring(count.index) })
       }
 
       spec {
@@ -299,6 +301,8 @@ resource "kubernetes_deployment" "de" {
             "--rdb-hostname", local.scylladb_hostname,
             "--rtq-hostname", local.rabbitmq_hostname,
             "--ldb-hostname", local.redpanda_hostname,
+            "--worker-index", tostring(count.index),
+            "--worker-count", tostring(var.de_worker_count),
           ]
         }
       }

--- a/infra/skyr-k8s/variables.tf
+++ b/infra/skyr-k8s/variables.tf
@@ -118,6 +118,14 @@ variable "dns_zone" {
   default     = "skyr.local"
 }
 
+# --- DE Scaling ---
+
+variable "de_worker_count" {
+  type        = number
+  description = "Number of DE worker pods. Each gets a distinct worker index for deployment shard assignment."
+  default     = 2
+}
+
 # --- RTE Scaling ---
 
 variable "rte_worker_count" {


### PR DESCRIPTION
## Summary

Closes #231

- Add `--worker-index` and `--worker-count` CLI args to the DE daemon, following the same pattern as the RTE
- Each deployment is assigned to a worker by interpreting the first 16 hex characters of its commit hash as a big-endian `u64` and applying `hash % worker_count`
- With defaults (`--worker-index 0 --worker-count 1`), a single instance handles all deployments (backwards compatible)

## Changes

- **`crates/de/src/main.rs`** — CLI args, validation, `deployment_owned_by_worker()` sharding function, deployment filtering in `process()`
- **`dev/podman-compose.yml`** — Split single `de` service into `de-0` and `de-1` replicas
- **`Makefile`** — Update `up` target to reference `de-0 de-1` instead of `de`
- **`README.md`** — Update Running Locally service table
- **`crates/de/README.md`** — Document horizontal scaling usage
- **`infra/skyr-k8s/services.tf`** — Use `count = var.de_worker_count` with per-replica worker args
- **`infra/skyr-k8s/variables.tf`** — Add `de_worker_count` variable (default 2)

## Test plan

- [ ] Verify that a single-replica DE (default args) still processes all deployments
- [ ] Verify that with `--worker-count 2`, each replica only picks up its assigned subset
- [ ] Verify that `--worker-index >= --worker-count` is rejected at startup
- [ ] Verify `make up` starts both `de-0` and `de-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)