### PR TITLE
refactor(lsp): consolidate duplicated helpers across handlers and analysis

### DIFF
--- a/crates/lsp/src/analysis.rs
+++ b/crates/lsp/src/analysis.rs
@@ -91,37 +91,13 @@ impl sclc::Package for OverlayPackage {
         // For directories, merge open documents from the editor.
         let result = self.inner.lookup(path).await?;
         if let Some(Cow::Owned(sclc::PackageEntity::Dir { hash, mut children })) = result {
-            // Merge entries from open documents in the editor
             let prefix = self.root.join(path);
-            let prefix_str = prefix.to_string_lossy().to_string();
             let existing_names: HashSet<String> = children.iter().map(|c| c.name.clone()).collect();
-            let null_hash_child = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);
-
-            for doc_path in self.documents.paths() {
-                let doc_str = doc_path.to_string_lossy().to_string();
-                let relative = if prefix_str.ends_with('/') || prefix_str.is_empty() {
-                    doc_str.strip_prefix(&prefix_str).map(|s| s.to_string())
-                } else {
-                    doc_str
-                        .strip_prefix(&prefix_str)
-                        .and_then(|r| r.strip_prefix('/'))
-                        .map(|s| s.to_string())
-                };
-                if let Some(relative) = relative {
-                    let (name, kind) = if let Some(slash_pos) = relative.find('/') {
-                        (relative[..slash_pos].to_owned(), sclc::DirChildKind::Dir)
-                    } else {
-                        (relative, sclc::DirChildKind::File)
-                    };
-                    if !existing_names.contains(&name) {
-                        children.push(sclc::DirChild {
-                            name,
-                            kind,
-                            hash: null_hash_child,
-                        });
-                    }
-                }
-            }
+            children.extend(dir_children_from_documents(
+                &self.documents,
+                &prefix,
+                &existing_names,
+            ));
 
             return Ok(Some(Cow::Owned(sclc::PackageEntity::Dir {
                 hash,
@@ -132,33 +108,8 @@ impl sclc::Package for OverlayPackage {
         // Check if an open document would make a missing directory appear
         if result.is_none() {
             let prefix = self.root.join(path);
-            let prefix_str = prefix.to_string_lossy().to_string();
             let null_hash = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);
-            let mut children = Vec::new();
-
-            for doc_path in self.documents.paths() {
-                let doc_str = doc_path.to_string_lossy().to_string();
-                let relative = if prefix_str.ends_with('/') || prefix_str.is_empty() {
-                    doc_str.strip_prefix(&prefix_str).map(|s| s.to_string())
-                } else {
-                    doc_str
-                        .strip_prefix(&prefix_str)
-                        .and_then(|r| r.strip_prefix('/'))
-                        .map(|s| s.to_string())
-                };
-                if let Some(relative) = relative {
-                    let (name, kind) = if let Some(slash_pos) = relative.find('/') {
-                        (relative[..slash_pos].to_owned(), sclc::DirChildKind::Dir)
-                    } else {
-                        (relative, sclc::DirChildKind::File)
-                    };
-                    children.push(sclc::DirChild {
-                        name,
-                        kind,
-                        hash: null_hash,
-                    });
-                }
-            }
+            let children = dir_children_from_documents(&self.documents, &prefix, &HashSet::new());
 
             if !children.is_empty() {
                 return Ok(Some(Cow::Owned(sclc::PackageEntity::Dir {
@@ -277,13 +228,7 @@ pub async fn analyze_scle(
     package_id: &sclc::PackageId,
 ) -> Vec<lsp::Diagnostic> {
     let module_id = module_id_from_path(path, Some(root), package_id);
-    let entry: Vec<String> = module_id
-        .package
-        .as_slice()
-        .iter()
-        .cloned()
-        .chain(module_id.path.iter().cloned())
-        .collect();
+    let entry = module_id_to_raw_segments(&module_id);
     let entry_refs: Vec<&str> = entry.iter().map(String::as_str).collect();
 
     let mut diagnostics = Vec::new();
@@ -324,13 +269,7 @@ async fn build_workspace_asg(
     let mut load_errors: HashMap<PathBuf, sclc::LoadError> = HashMap::new();
     for path in &paths {
         let module_id = module_id_from_path(path, Some(root), package_id);
-        let segments: Vec<String> = module_id
-            .package
-            .as_slice()
-            .iter()
-            .cloned()
-            .chain(module_id.path.iter().cloned())
-            .collect();
+        let segments = module_id_to_raw_segments(&module_id);
         let refs: Vec<&str> = segments.iter().map(String::as_str).collect();
         if let Err(err) = loader.resolve(&refs).await {
             load_errors.insert(path.clone(), err);
@@ -386,44 +325,24 @@ pub async fn analyze_workspace(
     // don't get duplicated by the diag loop below.
     for (uri, items) in &file_diagnostics {
         for d in items {
-            let severity_str = match d.severity {
-                Some(s) if s == lsp::DiagnosticSeverity::ERROR => "error",
-                Some(s) if s == lsp::DiagnosticSeverity::WARNING => "warning",
-                Some(s) if s == lsp::DiagnosticSeverity::INFORMATION => "info",
-                Some(s) if s == lsp::DiagnosticSeverity::HINT => "hint",
-                _ => "unknown",
-            };
             seen.entry(uri.clone()).or_default().insert((
                 d.range,
                 d.message.clone(),
-                severity_str.to_string(),
+                severity_label(d.severity).to_string(),
             ));
         }
     }
 
     for diag in diags.iter() {
         let (module_id, lsp_diag) = convert::to_lsp_diagnostic(diag);
-        let raw_id: sclc::RawModuleId = module_id
-            .package
-            .as_slice()
-            .iter()
-            .cloned()
-            .chain(module_id.path.iter().cloned())
-            .collect();
+        let raw_id: sclc::RawModuleId = module_id_to_raw_segments(&module_id);
         let ext = extensions.get(&raw_id).copied().unwrap_or("scl");
         let path = module_id_to_path(root, &module_id, ext);
         let uri = path_to_uri_string(&path);
-        let severity_str = match lsp_diag.severity {
-            Some(s) if s == lsp::DiagnosticSeverity::ERROR => "error",
-            Some(s) if s == lsp::DiagnosticSeverity::WARNING => "warning",
-            Some(s) if s == lsp::DiagnosticSeverity::INFORMATION => "info",
-            Some(s) if s == lsp::DiagnosticSeverity::HINT => "hint",
-            _ => "unknown",
-        };
         let key = (
             lsp_diag.range,
             lsp_diag.message.clone(),
-            severity_str.to_string(),
+            severity_label(lsp_diag.severity).to_string(),
         );
         if seen.entry(uri.clone()).or_default().insert(key) {
             file_diagnostics.entry(uri).or_default().push(lsp_diag);
@@ -547,6 +466,70 @@ fn symbol_kind_for_expr(expr: &sclc::Loc<sclc::Expr>) -> lsp::SymbolKind {
         sclc::Expr::Record(_) => lsp::SymbolKind::STRUCT,
         _ => lsp::SymbolKind::VARIABLE,
     }
+}
+
+/// Flatten a `ModuleId` into the raw segment list used by the loader
+/// (package segments followed by module path segments).
+fn module_id_to_raw_segments(module_id: &sclc::ModuleId) -> Vec<String> {
+    module_id
+        .package
+        .as_slice()
+        .iter()
+        .cloned()
+        .chain(module_id.path.iter().cloned())
+        .collect()
+}
+
+/// Convert an LSP diagnostic severity to a short string label for
+/// deduplication keys.
+fn severity_label(severity: Option<lsp::DiagnosticSeverity>) -> &'static str {
+    match severity {
+        Some(s) if s == lsp::DiagnosticSeverity::ERROR => "error",
+        Some(s) if s == lsp::DiagnosticSeverity::WARNING => "warning",
+        Some(s) if s == lsp::DiagnosticSeverity::INFORMATION => "info",
+        Some(s) if s == lsp::DiagnosticSeverity::HINT => "hint",
+        _ => "unknown",
+    }
+}
+
+/// Collect directory children from open editor documents whose paths fall
+/// under `prefix`. Used by `OverlayPackage::lookup` to merge or synthesize
+/// directory listings from unsaved buffers.
+fn dir_children_from_documents(
+    documents: &DocumentCache,
+    prefix: &Path,
+    exclude: &HashSet<String>,
+) -> Vec<sclc::DirChild> {
+    let prefix_str = prefix.to_string_lossy().to_string();
+    let null_hash = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);
+    let mut children = Vec::new();
+
+    for doc_path in documents.paths() {
+        let doc_str = doc_path.to_string_lossy().to_string();
+        let relative = if prefix_str.ends_with('/') || prefix_str.is_empty() {
+            doc_str.strip_prefix(&prefix_str).map(|s| s.to_string())
+        } else {
+            doc_str
+                .strip_prefix(&prefix_str)
+                .and_then(|r| r.strip_prefix('/'))
+                .map(|s| s.to_string())
+        };
+        if let Some(relative) = relative {
+            let (name, kind) = if let Some(slash_pos) = relative.find('/') {
+                (relative[..slash_pos].to_owned(), sclc::DirChildKind::Dir)
+            } else {
+                (relative, sclc::DirChildKind::File)
+            };
+            if !exclude.contains(&name) {
+                children.push(sclc::DirChild {
+                    name,
+                    kind,
+                    hash: null_hash,
+                });
+            }
+        }
+    }
+    children
 }
 
 fn module_id_to_path(root: &Path, module_id: &sclc::ModuleId, ext: &str) -> PathBuf {

--- a/crates/lsp/src/handlers/completion.rs
+++ b/crates/lsp/src/handlers/completion.rs
@@ -7,7 +7,7 @@ use super::{lock_cursor_info, resolve_document};
 use crate::analysis;
 use crate::convert;
 use crate::document::DocumentCache;
-use crate::server::{LspProgram, OutgoingMessage, RequestId};
+use crate::server::{LspProgram, OutgoingMessage, RequestId, to_json_value};
 
 pub fn completion(
     id: RequestId,
@@ -89,9 +89,6 @@ pub fn completion(
         })
         .collect();
 
-    let result = serde_json::to_value(items).unwrap_or_else(|err| {
-        eprintln!("lsp: failed to serialize completion items: {err}");
-        serde_json::Value::Null
-    });
+    let result = to_json_value(&items);
     vec![OutgoingMessage::response(id, result)]
 }

--- a/crates/lsp/src/handlers/formatting.rs
+++ b/crates/lsp/src/handlers/formatting.rs
@@ -2,7 +2,7 @@ use lsp_types as lsp;
 
 use crate::analysis::is_scle_path;
 use crate::document::DocumentCache;
-use crate::server::{OutgoingMessage, RequestId};
+use crate::server::{OutgoingMessage, RequestId, to_json_value};
 
 pub fn formatting(
     id: RequestId,
@@ -39,10 +39,7 @@ pub fn formatting(
 
     // If the formatted output is the same, return an empty edit list
     if formatted == ctx.source {
-        let empty_edits = serde_json::to_value(Vec::<lsp::TextEdit>::new()).unwrap_or_else(|err| {
-            eprintln!("lsp: failed to serialize empty edits: {err}");
-            serde_json::Value::Null
-        });
+        let empty_edits = to_json_value(&Vec::<lsp::TextEdit>::new());
         return vec![OutgoingMessage::response(id, empty_edits)];
     }
 
@@ -69,10 +66,7 @@ pub fn formatting(
         new_text: formatted,
     };
 
-    let result = serde_json::to_value(vec![edit]).unwrap_or_else(|err| {
-        eprintln!("lsp: failed to serialize formatting edits: {err}");
-        serde_json::Value::Null
-    });
+    let result = to_json_value(&vec![edit]);
     vec![OutgoingMessage::response(id, result)]
 }
 

--- a/crates/lsp/src/handlers/hover.rs
+++ b/crates/lsp/src/handlers/hover.rs
@@ -9,7 +9,7 @@ use super::{lock_cursor_info, resolve_document};
 use crate::analysis;
 use crate::convert;
 use crate::document::DocumentCache;
-use crate::server::{LspProgram, OutgoingMessage, RequestId};
+use crate::server::{LspProgram, OutgoingMessage, RequestId, to_json_value};
 
 pub fn hover(
     id: RequestId,
@@ -64,10 +64,7 @@ pub fn hover(
             contents: lsp::HoverContents::Array(parts),
             range: None,
         };
-        serde_json::to_value(hover).unwrap_or_else(|err| {
-            eprintln!("lsp: failed to serialize hover result: {err}");
-            serde_json::Value::Null
-        })
+        to_json_value(&hover)
     };
 
     vec![OutgoingMessage::response(id, result)]

--- a/crates/lsp/src/handlers/lifecycle.rs
+++ b/crates/lsp/src/handlers/lifecycle.rs
@@ -1,6 +1,6 @@
 use lsp_types as lsp;
 
-use crate::server::{OutgoingMessage, RequestId};
+use crate::server::{OutgoingMessage, RequestId, to_json_value};
 
 pub fn initialize(id: RequestId, params: serde_json::Value) -> Vec<OutgoingMessage> {
     let _params: lsp::InitializeParams = match serde_json::from_value(params) {
@@ -51,10 +51,7 @@ pub fn initialize(id: RequestId, params: serde_json::Value) -> Vec<OutgoingMessa
         }),
     };
 
-    let value = serde_json::to_value(result).unwrap_or_else(|err| {
-        eprintln!("lsp: failed to serialize initialize result: {err}");
-        serde_json::Value::Null
-    });
+    let value = to_json_value(&result);
     vec![OutgoingMessage::response(id, value)]
 }
 

--- a/crates/lsp/src/handlers/navigation.rs
+++ b/crates/lsp/src/handlers/navigation.rs
@@ -9,7 +9,7 @@ use super::{lock_cursor_info, resolve_document};
 use crate::analysis::{self, raw_module_id_to_uri};
 use crate::convert;
 use crate::document::DocumentCache;
-use crate::server::{LspProgram, OutgoingMessage, RequestId};
+use crate::server::{LspProgram, OutgoingMessage, RequestId, to_json_value};
 
 pub fn goto_definition(
     id: RequestId,
@@ -52,10 +52,7 @@ pub fn goto_definition(
                 uri: decl_uri,
                 range: convert::to_lsp_range(*decl_span),
             };
-            serde_json::to_value(location).unwrap_or_else(|err| {
-                eprintln!("lsp: failed to serialize definition result: {err}");
-                serde_json::Value::Null
-            })
+            to_json_value(&location)
         }
         None => serde_json::Value::Null,
     };
@@ -124,10 +121,7 @@ pub fn references(
     let result = if locations.is_empty() {
         serde_json::Value::Null
     } else {
-        serde_json::to_value(locations).unwrap_or_else(|err| {
-            eprintln!("lsp: failed to serialize references result: {err}");
-            serde_json::Value::Null
-        })
+        to_json_value(&locations)
     };
 
     vec![OutgoingMessage::response(id, result)]
@@ -247,10 +241,7 @@ pub fn prepare_rename(
     let result = match span_at_cursor(&info, &cursor_module, position) {
         Some(span) => {
             let response = lsp::PrepareRenameResponse::Range(convert::to_lsp_range(span));
-            serde_json::to_value(response).unwrap_or_else(|err| {
-                eprintln!("lsp: failed to serialize prepare_rename: {err}");
-                serde_json::Value::Null
-            })
+            to_json_value(&response)
         }
         None => serde_json::Value::Null,
     };
@@ -480,10 +471,7 @@ pub fn rename(
         document_changes: None,
         change_annotations: None,
     };
-    let result = serde_json::to_value(edit).unwrap_or_else(|err| {
-        eprintln!("lsp: failed to serialize rename result: {err}");
-        serde_json::Value::Null
-    });
+    let result = to_json_value(&edit);
     vec![OutgoingMessage::response(id, result)]
 }
 
@@ -506,10 +494,7 @@ pub fn document_symbol(
 
     let symbols = analysis::document_symbols(&ctx.source, &ctx.module_id);
 
-    let result = serde_json::to_value(symbols).unwrap_or_else(|err| {
-        eprintln!("lsp: failed to serialize document symbols: {err}");
-        serde_json::Value::Null
-    });
+    let result = to_json_value(&symbols);
     vec![OutgoingMessage::response(id, result)]
 }
 

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -116,7 +116,7 @@ impl OutgoingMessage {
 }
 
 /// Serialize a value to JSON, logging and returning Null on failure.
-fn to_json_value(value: &impl Serialize) -> serde_json::Value {
+pub(crate) fn to_json_value(value: &impl Serialize) -> serde_json::Value {
     serde_json::to_value(value).unwrap_or_else(|err| {
         eprintln!("lsp: failed to serialize value: {err}");
         serde_json::Value::Null


### PR DESCRIPTION
## Summary
- Use the existing `to_json_value` helper in all LSP handlers instead of repeating the `serde_json::to_value(...).unwrap_or_else(...)` pattern (9 occurrences removed)
- Extract `module_id_to_raw_segments` in `analysis.rs` to replace 3 identical package-chain-path segment constructions
- Extract `severity_label` in `analysis.rs` to replace 2 identical diagnostic severity match blocks
- Extract `dir_children_from_documents` in `analysis.rs` to replace 2 near-identical loops that collect directory children from open editor documents

Net result: **-47 lines** (91 added, 138 removed) with no behavioral changes. All 25 existing LSP tests pass.

## Test plan
- [x] `cargo check -p lsp` passes
- [x] `cargo clippy -p lsp -- -D warnings` passes (no new warnings)
- [x] `cargo test -p lsp` — all 25 tests pass
- [x] `cargo fmt -p lsp` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)