### PR TITLE
refactor(sclc): reduce diagnostic and extern function boilerplate

### DIFF
--- a/crates/sclc/src/checker.rs
+++ b/crates/sclc/src/checker.rs
@@ -34,349 +34,308 @@ pub fn next_type_id() -> usize {
 // Diagnostic error types
 // ═══════════════════════════════════════════════════════════════════════════════
 
-#[derive(Error, Debug)]
-#[error("undefined variable: {name}")]
-pub struct UndefinedVariable {
-    pub module_id: crate::ModuleId,
-    pub name: String,
-    pub var: crate::Loc<ast::Var>,
+/// Declares a diagnostic struct with `module_id` and additional fields.
+///
+/// The default span field is `span`; override the locate expression with
+/// `span_of(field.method())`. Override the diagnostic level with `level = Warning`.
+macro_rules! define_diag {
+    // With custom span expression + custom level
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident {
+            $( pub $field:ident : $ty:ty ),* $(,)?
+        }
+        span_of($span_field:ident . $span_method:ident ()),
+        level = $level:ident $(,)?
+    ) => {
+        define_diag!(@struct $(#[$meta])* $vis $name { $( $field : $ty ),* });
+        impl crate::Diag for $name {
+            fn locate(&self) -> (crate::ModuleId, crate::Span) {
+                (self.module_id.clone(), self.$span_field.$span_method())
+            }
+            fn level(&self) -> crate::DiagLevel { crate::DiagLevel::$level }
+        }
+    };
+    // With custom span expression only
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident {
+            $( pub $field:ident : $ty:ty ),* $(,)?
+        }
+        span_of($span_field:ident . $span_method:ident ()) $(,)?
+    ) => {
+        define_diag!(@struct $(#[$meta])* $vis $name { $( $field : $ty ),* });
+        impl crate::Diag for $name {
+            fn locate(&self) -> (crate::ModuleId, crate::Span) {
+                (self.module_id.clone(), self.$span_field.$span_method())
+            }
+        }
+    };
+    // With custom level only (default span = self.span)
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident {
+            $( pub $field:ident : $ty:ty ),* $(,)?
+        }
+        level = $level:ident $(,)?
+    ) => {
+        define_diag!(@struct $(#[$meta])* $vis $name { $( $field : $ty ),* });
+        impl crate::Diag for $name {
+            fn locate(&self) -> (crate::ModuleId, crate::Span) {
+                (self.module_id.clone(), self.span)
+            }
+            fn level(&self) -> crate::DiagLevel { crate::DiagLevel::$level }
+        }
+    };
+    // Default: span = self.span, level = Error
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident {
+            $( pub $field:ident : $ty:ty ),* $(,)?
+        }
+    ) => {
+        define_diag!(@struct $(#[$meta])* $vis $name { $( $field : $ty ),* });
+        impl crate::Diag for $name {
+            fn locate(&self) -> (crate::ModuleId, crate::Span) {
+                (self.module_id.clone(), self.span)
+            }
+        }
+    };
+    // Internal: generate the struct definition
+    (@struct
+        $(#[$meta:meta])*
+        $vis:vis $name:ident { $( $field:ident : $ty:ty ),* }
+    ) => {
+        $(#[$meta])*
+        $vis struct $name {
+            pub module_id: crate::ModuleId,
+            $( pub $field : $ty ),*
+        }
+    };
 }
 
-impl crate::Diag for UndefinedVariable {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.var.span())
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("undefined variable: {name}")]
+    pub struct UndefinedVariable {
+        pub name: String,
+        pub var: crate::Loc<ast::Var>,
+    }
+    span_of(var.span())
+}
+
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("undefined member: {name} in type {ty}")]
+    pub struct UndefinedMember {
+        pub name: String,
+        pub ty: Type,
+        pub property: crate::Loc<ast::Var>,
+    }
+    span_of(property.span())
+}
+
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("indexed access requires a Dict or List type, got {ty}")]
+    pub struct InvalidIndexTarget {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("undefined member: {name} in type {ty}")]
-pub struct UndefinedMember {
-    pub module_id: crate::ModuleId,
-    pub name: String,
-    pub ty: Type,
-    pub property: crate::Loc<ast::Var>,
-}
-
-impl crate::Diag for UndefinedMember {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.property.span())
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("not a function: {ty}")]
+    pub struct NotAFunction {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("indexed access requires a Dict or List type, got {ty}")]
-pub struct InvalidIndexTarget {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for InvalidIndexTarget {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("missing arguments: expected {expected}, got {got}")]
+    pub struct MissingArguments {
+        pub expected: usize,
+        pub got: usize,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("not a function: {ty}")]
-pub struct NotAFunction {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for NotAFunction {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("extraneous argument at index {index}")]
+    pub struct ExtraneousArgument {
+        pub index: usize,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("missing arguments: expected {expected}, got {got}")]
-pub struct MissingArguments {
-    pub module_id: crate::ModuleId,
-    pub expected: usize,
-    pub got: usize,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for MissingArguments {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("type mismatch: expected {expected}, got {actual}")]
+    pub struct TypeMismatch {
+        pub expected: Type,
+        pub actual: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("extraneous argument at index {index}")]
-pub struct ExtraneousArgument {
-    pub module_id: crate::ModuleId,
-    pub index: usize,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for ExtraneousArgument {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("invalid operands for {op}: {lhs} and {rhs}")]
+    pub struct InvalidBinaryOperands {
+        pub op: ast::BinaryOp,
+        pub lhs: Type,
+        pub rhs: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("type mismatch: expected {expected}, got {actual}")]
-pub struct TypeMismatch {
-    pub module_id: crate::ModuleId,
-    pub expected: Type,
-    pub actual: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for TypeMismatch {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("optional chaining (?.) on non-optional type {ty}")]
+    pub struct OptionalChainOnNonOptional {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("invalid operands for {op}: {lhs} and {rhs}")]
-pub struct InvalidBinaryOperands {
-    pub module_id: crate::ModuleId,
-    pub op: ast::BinaryOp,
-    pub lhs: Type,
-    pub rhs: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for InvalidBinaryOperands {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("nil coalescing (??) on non-optional type {ty}")]
+    pub struct NilCoalesceOnNonOptional {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("optional chaining (?.) on non-optional type {ty}")]
-pub struct OptionalChainOnNonOptional {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for OptionalChainOnNonOptional {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("invalid operand for {op}: {operand}")]
+    pub struct InvalidUnaryOperand {
+        pub op: ast::UnaryOp,
+        pub operand: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("nil coalescing (??) on non-optional type {ty}")]
-pub struct NilCoalesceOnNonOptional {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for NilCoalesceOnNonOptional {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("path not found: {resolved_path}")]
+    pub struct InvalidPath {
+        pub resolved_path: String,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("invalid operand for {op}: {operand}")]
-pub struct InvalidUnaryOperand {
-    pub module_id: crate::ModuleId,
-    pub op: ast::UnaryOp,
-    pub operand: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for InvalidUnaryOperand {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("type annotation required for parameter")]
+    pub struct MissingParameterType {
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("path not found: {resolved_path}")]
-pub struct InvalidPath {
-    pub module_id: crate::ModuleId,
-    pub resolved_path: String,
-    pub span: crate::Span,
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("comparison between disjoint types: {lhs} and {rhs}")]
+    pub struct DisjointEquality {
+        pub lhs: Type,
+        pub rhs: Type,
+        pub span: crate::Span,
+    }
+    level = Warning
 }
 
-impl crate::Diag for InvalidPath {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("invalid type: {error}")]
+    pub struct InvalidType {
+        pub error: TypeError,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("type annotation required for parameter")]
-pub struct MissingParameterType {
-    pub module_id: crate::ModuleId,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for MissingParameterType {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("raise requires an exception, got {ty}")]
+    pub struct NotAnException {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("comparison between disjoint types: {lhs} and {rhs}")]
-pub struct DisjointEquality {
-    pub module_id: crate::ModuleId,
-    pub lhs: Type,
-    pub rhs: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for DisjointEquality {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
-    }
-
-    fn level(&self) -> crate::DiagLevel {
-        crate::DiagLevel::Warning
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("catch variable must be an exception or function returning an exception, got {ty}")]
+    pub struct InvalidCatchTarget {
+        pub ty: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("invalid type: {error}")]
-pub struct InvalidType {
-    pub module_id: crate::ModuleId,
-    pub error: TypeError,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for InvalidType {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("catch argument provided but exception is not a function type")]
+    pub struct UnexpectedCatchArg {
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("raise requires an exception, got {ty}")]
-pub struct NotAnException {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for NotAnException {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("wrong number of type arguments: expected {expected}, got {got}")]
+    pub struct WrongTypeArgCount {
+        pub expected: usize,
+        pub got: usize,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("catch variable must be an exception or function returning an exception, got {ty}")]
-pub struct InvalidCatchTarget {
-    pub module_id: crate::ModuleId,
-    pub ty: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for InvalidCatchTarget {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("type arguments provided to non-generic function")]
+    pub struct UnexpectedTypeArgs {
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("catch argument provided but exception is not a function type")]
-pub struct UnexpectedCatchArg {
-    pub module_id: crate::ModuleId,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for UnexpectedCatchArg {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("type argument {actual} does not satisfy bound {bound}")]
+    pub struct TypeArgBoundViolation {
+        pub actual: Type,
+        pub bound: Type,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("wrong number of type arguments: expected {expected}, got {got}")]
-pub struct WrongTypeArgCount {
-    pub module_id: crate::ModuleId,
-    pub expected: usize,
-    pub got: usize,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for WrongTypeArgCount {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("unknown type: {name}")]
+    pub struct UnknownType {
+        pub name: String,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("type arguments provided to non-generic function")]
-pub struct UnexpectedTypeArgs {
-    pub module_id: crate::ModuleId,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for UnexpectedTypeArgs {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("unknown field \"{name}\" in record literal")]
+    pub struct UnknownField {
+        pub name: String,
+        pub span: crate::Span,
     }
 }
 
-#[derive(Error, Debug)]
-#[error("type argument {actual} does not satisfy bound {bound}")]
-pub struct TypeArgBoundViolation {
-    pub module_id: crate::ModuleId,
-    pub actual: Type,
-    pub bound: Type,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for TypeArgBoundViolation {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
-    }
-}
-
-#[derive(Error, Debug)]
-#[error("unknown type: {name}")]
-pub struct UnknownType {
-    pub module_id: crate::ModuleId,
-    pub name: String,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for UnknownType {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
-    }
-}
-
-#[derive(Error, Debug)]
-#[error("unknown field \"{name}\" in record literal")]
-pub struct UnknownField {
-    pub module_id: crate::ModuleId,
-    pub name: String,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for UnknownField {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
-    }
-}
-
-#[derive(Error, Debug)]
-#[error("cyclic dependency between {names} — recursive bindings must be functions")]
-pub struct CyclicDependency {
-    pub module_id: crate::ModuleId,
-    pub names: String,
-    pub span: crate::Span,
-}
-
-impl crate::Diag for CyclicDependency {
-    fn locate(&self) -> (crate::ModuleId, crate::Span) {
-        (self.module_id.clone(), self.span)
+define_diag! {
+    #[derive(Error, Debug)]
+    #[error("cyclic dependency between {names} — recursive bindings must be functions")]
+    pub struct CyclicDependency {
+        pub names: String,
+        pub span: crate::Span,
     }
 }
 

--- a/crates/sclc/src/std/artifact.rs
+++ b/crates/sclc/src/std/artifact.rs
@@ -33,17 +33,10 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     eval.add_extern_fn(FILE_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
 
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
-
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
 
         let name = config.get("name").assert_str_ref()?;
         let media_type = match config.get("mediaType") {

--- a/crates/sclc/src/std/container.rs
+++ b/crates/sclc/src/std/container.rs
@@ -41,17 +41,10 @@ fn image_extern_fn(
     args: Vec<TrackedValue>,
     eval_ctx: &EvalCtx,
 ) -> Result<TrackedValue, crate::EvalError> {
-    let mut args = args.into_iter();
-    let config_arg = args
-        .next()
-        .unwrap_or_else(|| TrackedValue::new(Value::Nil));
-    let argument_dependencies = config_arg.dependencies.clone();
-
-    if config_arg.value.has_pending() {
-        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
-    }
-
-    let config = config_arg.value.assert_record()?;
+    let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+        Ok(pair) => pair,
+        Err(pending) => return Ok(pending),
+    };
 
     // Extract inputs
     let name = config.get("name").assert_str_ref()?.to_owned();
@@ -154,17 +147,10 @@ fn pod_extern_fn(
     args: Vec<TrackedValue>,
     eval_ctx: &EvalCtx,
 ) -> Result<TrackedValue, crate::EvalError> {
-    let mut args = args.into_iter();
-    let config_arg = args
-        .next()
-        .unwrap_or_else(|| TrackedValue::new(Value::Nil));
-    let argument_dependencies = config_arg.dependencies.clone();
-
-    if config_arg.value.has_pending() {
-        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
-    }
-
-    let config = config_arg.value.assert_record()?;
+    let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+        Ok(pair) => pair,
+        Err(pending) => return Ok(pending),
+    };
 
     // Extract inputs
     let name = config.get("name").assert_str_ref()?.to_owned();
@@ -414,17 +400,10 @@ fn host_extern_fn(
     args: Vec<TrackedValue>,
     eval_ctx: &EvalCtx,
 ) -> Result<TrackedValue, crate::EvalError> {
-    let mut args = args.into_iter();
-    let config_arg = args
-        .next()
-        .unwrap_or_else(|| TrackedValue::new(Value::Nil));
-    let argument_dependencies = config_arg.dependencies.clone();
-
-    if config_arg.value.has_pending() {
-        return Ok(TrackedValue::pending().with_dependencies(argument_dependencies));
-    }
-
-    let config = config_arg.value.assert_record()?;
+    let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+        Ok(pair) => pair,
+        Err(pending) => return Ok(pending),
+    };
 
     // Extract the name from input
     let name = config.get("name").assert_str_ref()?.to_owned();

--- a/crates/sclc/src/std/crypto.rs
+++ b/crates/sclc/src/std/crypto.rs
@@ -25,17 +25,10 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     eval.add_extern_fn(ED25519_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
 
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
-
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
         let name = config.get("name").assert_str_ref()?;
 
         let resource_id = ids::ResourceId {
@@ -62,17 +55,10 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     eval.add_extern_fn(ECDSA_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
 
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
-
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
         let name = config.get("name").assert_str_ref()?;
 
         let curve = match config.get("curve") {
@@ -104,17 +90,11 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
 
     eval.add_extern_fn(CSR_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
 
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
         let private_key_pem = config.get("privateKeyPem").assert_str_ref()?;
         let subject = config.get("subject").assert_record_ref()?;
 
@@ -186,17 +166,10 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     eval.add_extern_fn(RSA_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
 
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
-
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
         let name = config.get("name").assert_str_ref()?;
 
         let size = match config.get("size") {
@@ -228,17 +201,11 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
 
     eval.add_extern_fn(CERT_SIG_RESOURCE_TYPE, |args, eval_ctx| {
         use crate::ValueAssertions;
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
 
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
+        let (config, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
 
         let mut inputs = crate::Record::default();
         inputs.insert(

--- a/crates/sclc/src/std/mod.rs
+++ b/crates/sclc/src/std/mod.rs
@@ -82,6 +82,33 @@ pub fn bundled_stdlib_files() -> &'static [(&'static str, &'static [u8])] {
     &BUNDLED_FILES
 }
 
+/// Extracts the first argument from an extern function call, handling the
+/// common pattern of defaulting to Nil and short-circuiting on pending values.
+///
+/// Returns `Ok(Ok((config_record, dependencies)))` on success,
+/// `Ok(Err(pending_result))` if the argument has pending values, or
+/// `Err(...)` if the value is not a record.
+pub(crate) fn extract_config_arg(
+    args: Vec<crate::TrackedValue>,
+) -> Result<
+    Result<(crate::Record, std::collections::BTreeSet<ids::ResourceId>), crate::TrackedValue>,
+    crate::EvalError,
+> {
+    let mut args = args.into_iter();
+    let config_arg = args
+        .next()
+        .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
+    let deps = config_arg.dependencies.clone();
+
+    if config_arg.value.has_pending() {
+        return Ok(Err(crate::TrackedValue::pending().with_dependencies(deps)));
+    }
+
+    use crate::ValueAssertions;
+    let config = config_arg.value.assert_record()?;
+    Ok(Ok((config, deps)))
+}
+
 std_modules! {
     artifact => "Artifact.scl",
     container => "Container.scl",

--- a/crates/sclc/src/std/time.rs
+++ b/crates/sclc/src/std/time.rs
@@ -57,29 +57,12 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     });
 
     eval.add_extern_fn("Std/Time.add", |args, _ctx| {
-        let mut args = args.into_iter();
-        let instant_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
-        let duration_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
-
-        let deps = instant_arg
-            .dependencies
-            .union(&duration_arg.dependencies)
-            .cloned()
-            .collect();
-
-        if instant_arg.value.has_pending() || duration_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(deps));
-        }
-
-        let instant = instant_arg.value.assert_record()?;
-        let duration = duration_arg.value.assert_record()?;
+        let (instant, duration, deps) = match extract_two_args(args)? {
+            Ok(triple) => triple,
+            Err(pending) => return Ok(pending),
+        };
         let epoch_millis = *instant.get("epochMillis").assert_int_ref()?;
         let dt = parse_instant(epoch_millis)?;
-
         let dt = apply_duration(dt, &duration, 1)?;
 
         let mut result = Record::default();
@@ -88,17 +71,10 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     });
 
     eval.add_extern_fn(SCHEDULE_RESOURCE_TYPE, |args, eval_ctx| {
-        let mut args = args.into_iter();
-        let duration_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
-        let argument_dependencies = duration_arg.dependencies.clone();
-
-        if duration_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let duration = duration_arg.value.assert_record()?;
+        let (duration, argument_dependencies) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
+        };
 
         let months = match duration.get("months") {
             Value::Nil => 0,
@@ -136,35 +112,51 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
     });
 
     eval.add_extern_fn("Std/Time.subtract", |args, _ctx| {
-        let mut args = args.into_iter();
-        let instant_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
-        let duration_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
-
-        let deps = instant_arg
-            .dependencies
-            .union(&duration_arg.dependencies)
-            .cloned()
-            .collect();
-
-        if instant_arg.value.has_pending() || duration_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(deps));
-        }
-
-        let instant = instant_arg.value.assert_record()?;
-        let duration = duration_arg.value.assert_record()?;
+        let (instant, duration, deps) = match extract_two_args(args)? {
+            Ok(triple) => triple,
+            Err(pending) => return Ok(pending),
+        };
         let epoch_millis = *instant.get("epochMillis").assert_int_ref()?;
         let dt = parse_instant(epoch_millis)?;
-
         let dt = apply_duration(dt, &duration, -1)?;
 
         let mut result = Record::default();
         result.insert("epochMillis".into(), Value::Int(dt.timestamp_millis()));
         Ok(crate::TrackedValue::new(Value::Record(result)).with_dependencies(deps))
     });
+}
+
+type TwoArgResult = Result<
+    (Record, Record, std::collections::BTreeSet<ids::ResourceId>),
+    crate::TrackedValue,
+>;
+
+/// Extracts two record arguments and their merged dependencies, short-circuiting
+/// on pending values.
+fn extract_two_args(
+    args: Vec<crate::TrackedValue>,
+) -> Result<TwoArgResult, crate::EvalError> {
+    let mut args = args.into_iter();
+    let first = args
+        .next()
+        .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+    let second = args
+        .next()
+        .unwrap_or_else(|| crate::TrackedValue::new(Value::Nil));
+
+    let deps = first
+        .dependencies
+        .union(&second.dependencies)
+        .cloned()
+        .collect();
+
+    if first.value.has_pending() || second.value.has_pending() {
+        return Ok(Err(crate::TrackedValue::pending().with_dependencies(deps)));
+    }
+
+    let first_record = first.value.assert_record()?;
+    let second_record = second.value.assert_record()?;
+    Ok(Ok((first_record, second_record, deps)))
 }
 
 fn parse_instant(epoch_millis: i64) -> Result<DateTime<chrono::Utc>, crate::EvalError> {


### PR DESCRIPTION
## Summary

- Introduce a `define_diag!` macro in `checker.rs` that generates diagnostic struct definitions and their `Diag` trait impls, replacing 22 near-identical struct/impl pairs (~345 lines of boilerplate). The macro supports custom span expressions via `span_of(field.method())` and diagnostic level overrides via `level = Warning`.
- Add an `extract_config_arg` helper in `std/mod.rs` that centralizes the repeated pattern of extracting the first argument from extern functions (default to Nil, short-circuit on pending, assert record). Applied across `crypto.rs`, `artifact.rs`, `container.rs`, and `time.rs`.
- Extract `extract_two_args` helper in `time.rs` for the two-argument add/subtract pattern, deduplicating dependency merging and pending checks.

Net result: **-83 lines** across 6 files, with no behavioral changes.

## Test plan

- [x] `cargo check -p sclc` passes
- [x] `cargo clippy -p sclc -- -D warnings` passes (no new warnings; 2 pre-existing warnings unchanged)
- [x] `cargo test -p sclc` — all 483 tests pass
- [x] `cargo fmt -p sclc` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)