### PR TITLE
Add docs search with pre-baked Fuse.js index

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@tanstack/svelte-query": "^6.1.3",
+                "fuse.js": "^7.3.0",
                 "graphql": "^16.9.0",
                 "graphql-ws": "^5.16.0",
                 "lucide-svelte": "^1.0.1",
@@ -4745,6 +4746,19 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/fuse.js": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+            "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/krisk"
+            }
+        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7273,21 +7287,6 @@
                 "picomatch": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/svelte-check/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/swap-case": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "@tanstack/svelte-query": "^6.1.3",
+        "fuse.js": "^7.3.0",
         "graphql": "^16.9.0",
         "graphql-ws": "^5.16.0",
         "lucide-svelte": "^1.0.1",

--- a/web/src/lib/docs-search.ts
+++ b/web/src/lib/docs-search.ts
@@ -1,0 +1,37 @@
+import Fuse from "fuse.js";
+import type { SearchEntry } from "./search-index";
+
+let fuse: Fuse<SearchEntry> | null = null;
+let loadPromise: Promise<void> | null = null;
+
+async function loadIndex(): Promise<void> {
+    const res = await fetch("/~docs/search-index.json");
+    const entries: SearchEntry[] = await res.json();
+    fuse = new Fuse(entries, {
+        keys: [
+            { name: "title", weight: 1.0 },
+            { name: "body", weight: 0.5 },
+            { name: "pageTitle", weight: 0.3 },
+        ],
+        threshold: 0.4,
+        ignoreLocation: true,
+        minMatchCharLength: 2,
+    });
+}
+
+/** Start loading the search index (call on focus). */
+export function ensureSearchIndex(): void {
+    if (!loadPromise) {
+        loadPromise = loadIndex();
+    }
+}
+
+/** Search the index. Returns empty array if index not yet loaded. */
+export async function search(query: string): Promise<SearchEntry[]> {
+    if (!loadPromise) {
+        ensureSearchIndex();
+    }
+    await loadPromise;
+    if (!fuse || !query.trim()) return [];
+    return fuse.search(query, { limit: 20 }).map((r) => r.item);
+}

--- a/web/src/lib/search-index.ts
+++ b/web/src/lib/search-index.ts
@@ -1,0 +1,224 @@
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { findAllDocPaths } from "./docs";
+import { getStdlibModules, type RecordType } from "./stdlib";
+
+export interface SearchEntry {
+    title: string;
+    path: string;
+    pageTitle: string;
+    body: string;
+    type: "page" | "heading";
+}
+
+const MAX_BODY = 200;
+
+function truncate(text: string, max: number): string {
+    if (text.length <= max) return text;
+    return `${text.slice(0, max).replace(/\s\S*$/, "")}\u2026`;
+}
+
+/** Strip markdown syntax to plain text. */
+function stripMarkdown(md: string): string {
+    return (
+        md
+            // Remove code blocks
+            .replace(/```[\s\S]*?```/g, "")
+            // Remove inline code
+            .replace(/`[^`]*`/g, "")
+            // Remove images
+            .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+            // Remove links, keep text
+            .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+            // Remove headings markers
+            .replace(/^#{1,6}\s+/gm, "")
+            // Remove bold/italic
+            .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, "$1")
+            // Remove HTML tags
+            .replace(/<[^>]*>/g, "")
+            // Collapse whitespace
+            .replace(/\s+/g, " ")
+            .trim()
+    );
+}
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/<[^>]*>/g, "")
+        .replace(/[^\w\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+}
+
+interface HeadingSection {
+    text: string;
+    slug: string;
+    depth: number;
+    body: string;
+}
+
+/** Parse markdown into page title, body, and heading sections. */
+function parseMarkdown(source: string): {
+    title: string;
+    body: string;
+    headings: HeadingSection[];
+} {
+    const lines = source.split("\n");
+    let title = "Documentation";
+    const headings: HeadingSection[] = [];
+    let currentBody: string[] = [];
+    let pageBody: string[] = [];
+    let inH1 = true;
+
+    for (const line of lines) {
+        const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+        if (headingMatch) {
+            const depth = headingMatch[1].length;
+            const text = headingMatch[2];
+
+            if (depth === 1 && inH1) {
+                title = text;
+                inH1 = false;
+                continue;
+            }
+            inH1 = false;
+
+            // Flush previous heading's body
+            if (headings.length > 0) {
+                headings[headings.length - 1].body = stripMarkdown(currentBody.join("\n"));
+            } else {
+                pageBody = [...currentBody];
+            }
+            currentBody = [];
+
+            headings.push({
+                text,
+                slug: slugify(text),
+                depth,
+                body: "",
+            });
+        } else {
+            currentBody.push(line);
+        }
+    }
+
+    // Flush last section
+    if (headings.length > 0) {
+        headings[headings.length - 1].body = stripMarkdown(currentBody.join("\n"));
+    } else {
+        pageBody = currentBody;
+    }
+
+    const body = stripMarkdown(pageBody.join("\n"));
+    return { title, body, headings };
+}
+
+function resolveDocsDir(): string {
+    const fromWeb = join(process.cwd(), "..", "docs");
+    try {
+        statSync(fromWeb);
+        return fromWeb;
+    } catch {
+        return "/docs";
+    }
+}
+
+function resolveFilePath(docsDir: string, urlPath: string): string {
+    const exactPath = join(docsDir, `${urlPath || "index"}.md`);
+    try {
+        statSync(exactPath);
+        return exactPath;
+    } catch {
+        return join(docsDir, urlPath, "index.md");
+    }
+}
+
+function collectStdlibEntries(): SearchEntry[] {
+    const entries: SearchEntry[] = [];
+    const modules = getStdlibModules();
+
+    for (const mod of modules) {
+        const pagePath = `/~docs/scl/stdlib-ref/${mod.slug}/`;
+        const pageTitle = mod.name;
+
+        // Page entry for the module
+        entries.push({
+            title: pageTitle,
+            path: pagePath,
+            pageTitle: "",
+            body: truncate(
+                `Standard library module ${mod.name}. ${describeExports(mod.valueExports, mod.typeExports)}`,
+                MAX_BODY,
+            ),
+            type: "page",
+        });
+
+        // Heading entries for each export
+        function addRecordEntries(record: RecordType, prefix: string) {
+            for (const name of Object.keys(record.fields)) {
+                const doc = record.doc_comments[name] ?? "";
+                entries.push({
+                    title: name,
+                    path: `${pagePath}#${prefix}${name.toLowerCase()}`,
+                    pageTitle,
+                    body: truncate(stripMarkdown(doc), MAX_BODY),
+                    type: "heading",
+                });
+            }
+        }
+
+        addRecordEntries(mod.typeExports, "type-");
+        addRecordEntries(mod.valueExports, "");
+    }
+
+    return entries;
+}
+
+function describeExports(values: RecordType, types: RecordType): string {
+    const parts: string[] = [];
+    const typeNames = Object.keys(types.fields);
+    const valueNames = Object.keys(values.fields);
+    if (typeNames.length > 0) parts.push(`Types: ${typeNames.join(", ")}`);
+    if (valueNames.length > 0) parts.push(`Functions: ${valueNames.join(", ")}`);
+    return parts.join(". ");
+}
+
+export function generateSearchIndex(): SearchEntry[] {
+    const entries: SearchEntry[] = [];
+    const docsDir = resolveDocsDir();
+    const docPaths = findAllDocPaths();
+
+    for (const urlPath of docPaths) {
+        const filePath = resolveFilePath(docsDir, urlPath);
+        const source = readFileSync(filePath, "utf-8");
+        const parsed = parseMarkdown(source);
+        const pagePath = `/~docs/${urlPath}${urlPath ? "/" : ""}`;
+
+        // Page entry
+        entries.push({
+            title: parsed.title,
+            path: pagePath,
+            pageTitle: "",
+            body: truncate(parsed.body, MAX_BODY),
+            type: "page",
+        });
+
+        // Heading entries
+        for (const heading of parsed.headings) {
+            entries.push({
+                title: heading.text,
+                path: `${pagePath}#${heading.slug}`,
+                pageTitle: parsed.title,
+                body: truncate(heading.body, MAX_BODY),
+                type: "heading",
+            });
+        }
+    }
+
+    // Add stdlib reference entries
+    entries.push(...collectStdlibEntries());
+
+    return entries;
+}

--- a/web/src/routes/~docs/+layout.svelte
+++ b/web/src/routes/~docs/+layout.svelte
@@ -1,11 +1,41 @@
 <script lang="ts">
 import { page } from "$app/state";
-import { Menu, X } from "lucide-svelte";
+import { goto } from "$app/navigation";
+import { Menu, X, Search } from "lucide-svelte";
 import { getStdlibModules } from "$lib/stdlib";
+import { ensureSearchIndex, search } from "$lib/docs-search";
+import type { SearchEntry } from "$lib/search-index";
 
 let { children } = $props();
 
 let mobileNavOpen = $state(false);
+let searchQuery = $state("");
+let searchResults = $state<SearchEntry[]>([]);
+let searchInputMobile: HTMLInputElement | undefined = $state();
+
+let searching = $derived(searchQuery.length > 0);
+
+$effect(() => {
+    if (searchQuery) {
+        search(searchQuery).then((results) => {
+            searchResults = results;
+        });
+    } else {
+        searchResults = [];
+    }
+});
+
+$effect(() => {
+    if (mobileNavOpen && searchInputMobile) {
+        searchInputMobile.focus();
+    }
+});
+
+function selectResult(entry: SearchEntry) {
+    searchQuery = "";
+    mobileNavOpen = false;
+    goto(entry.path);
+}
 
 const stdlibRefChildren = getStdlibModules().map((m) => ({
     title: m.shortName,
@@ -52,7 +82,33 @@ function findCurrentTitle(items: NavItem[]): string | null {
 }
 
 let currentTitle = $derived(findCurrentTitle(nav) ?? "Docs");
+
+const searchInputClass =
+    "w-full pl-8 pr-3 py-1.5 text-sm border border-gray-200 rounded-md bg-gray-50 focus:bg-white focus:border-gray-300 focus:outline-none";
 </script>
+
+{#snippet searchResultsList()}
+    <ul class="space-y-0.5">
+        {#each searchResults as entry}
+            <li>
+                <button
+                    onclick={() => selectResult(entry)}
+                    class="w-full text-left px-2 py-1.5 rounded hover:bg-gray-100 block"
+                >
+                    <span class="text-sm font-medium text-gray-900 block truncate">{entry.title}</span>
+                    {#if entry.pageTitle}
+                        <span class="text-xs text-gray-500 block truncate">{entry.pageTitle}</span>
+                    {/if}
+                    {#if entry.body}
+                        <span class="text-xs text-gray-400 block truncate">{entry.body}</span>
+                    {/if}
+                </button>
+            </li>
+        {:else}
+            <li class="px-2 py-3 text-xs text-gray-400 text-center">No results</li>
+        {/each}
+    </ul>
+{/snippet}
 
 {#snippet navTree(items: NavItem[])}
     <ul class="space-y-1">
@@ -102,7 +158,22 @@ let currentTitle = $derived(findCurrentTitle(nav) ?? "Docs");
             </button>
         </div>
         <nav class="flex-1 p-4 text-sm overflow-y-auto">
-            {@render navTree(nav)}
+            <div class="mb-3 relative">
+                <Search size={14} class="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+                <input
+                    type="text"
+                    placeholder="Search docs..."
+                    class={searchInputClass}
+                    bind:value={searchQuery}
+                    bind:this={searchInputMobile}
+                    onfocus={ensureSearchIndex}
+                />
+            </div>
+            {#if searching}
+                {@render searchResultsList()}
+            {:else}
+                {@render navTree(nav)}
+            {/if}
         </nav>
     </div>
 {/if}
@@ -110,7 +181,21 @@ let currentTitle = $derived(findCurrentTitle(nav) ?? "Docs");
 <div class="flex-1 bg-white flex">
     <!-- Desktop sidebar -->
     <nav class="hidden md:block w-56 shrink-0 border-r border-gray-200 p-4 text-sm sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto">
-        {@render navTree(nav)}
+        <div class="mb-3 relative">
+            <Search size={14} class="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" />
+            <input
+                type="text"
+                placeholder="Search docs..."
+                class={searchInputClass}
+                bind:value={searchQuery}
+                onfocus={ensureSearchIndex}
+            />
+        </div>
+        {#if searching}
+            {@render searchResultsList()}
+        {:else}
+            {@render navTree(nav)}
+        {/if}
     </nav>
 
     <main class="flex-1 min-w-0 max-w-3xl px-8 py-6">

--- a/web/src/routes/~docs/search-index.json/+server.ts
+++ b/web/src/routes/~docs/search-index.json/+server.ts
@@ -1,0 +1,9 @@
+import { json } from "@sveltejs/kit";
+import { generateSearchIndex } from "$lib/search-index";
+import type { RequestHandler } from "./$types";
+
+export const prerender = true;
+
+export const GET: RequestHandler = () => {
+    return json(generateSearchIndex());
+};


### PR DESCRIPTION
## Summary
- Adds client-side fuzzy search to the `/~docs` site using Fuse.js
- Search index is pre-baked at build time as a prerendered JSON endpoint (203 entries: 18 pages + 185 headings with body text previews)
- Index is lazily fetched on first search input focus, so no impact on initial page load
- Search results replace the sidebar navigation tree; heading results navigate to hash anchors
- On mobile, the search input auto-focuses when the nav menu is expanded

## Test plan
- [ ] `npm run build` in `web/` succeeds and generates `build/~docs/search-index.json`
- [ ] Search box appears at top of docs sidebar on desktop
- [ ] Typing a query replaces nav tree with results; clearing restores nav
- [ ] Clicking a page result navigates to the page
- [ ] Clicking a heading result navigates to the correct `#anchor`
- [ ] On narrow viewport: opening mobile nav auto-focuses search input
- [ ] `npm run check` and `npx biome check .` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)