### PR TITLE
refactor(cli): extract shared GraphQL request helpers

### DIFF
--- a/crates/cli/src/auth.rs
+++ b/crates/cli/src/auth.rs
@@ -7,7 +7,7 @@ use zeroize::Zeroizing;
 
 /// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
 #[allow(clippy::upper_case_acronyms)]
-type JSON = serde_json::Value;
+pub(crate) type JSON = serde_json::Value;
 
 const SIGNATURE_NAMESPACE: &str = "skyr-auth-challenge";
 
@@ -63,22 +63,16 @@ pub(crate) async fn signin_with_key(
     key_path: &Path,
 ) -> anyhow::Result<String> {
     let proof = build_auth_proof(client, endpoint, username, key_path).await?;
-    let body = Signin::build_query(signin::Variables {
-        username: username.to_owned(),
-        proof: serde_json::Value::String(proof),
-    });
-
-    let response = client
-        .post(endpoint)
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send signin mutation")?;
-    let response: graphql_client::Response<signin::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode signin response")?;
-    let data = graphql_response_data(response, "signin")?;
+    let data = graphql_query_unauth::<Signin>(
+        client,
+        endpoint,
+        signin::Variables {
+            username: username.to_owned(),
+            proof: serde_json::Value::String(proof),
+        },
+        "signin",
+    )
+    .await?;
     Ok(data.signin.token)
 }
 
@@ -114,22 +108,15 @@ async fn query_auth_challenge(
     endpoint: &str,
     username: &str,
 ) -> anyhow::Result<String> {
-    let body = AuthChallenge::build_query(auth_challenge::Variables {
-        username: username.to_owned(),
-    });
-
-    let response = client
-        .post(endpoint)
-        .json(&body)
-        .send()
-        .await
-        .context("failed to fetch auth challenge")?;
-
-    let response: graphql_client::Response<auth_challenge::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode auth challenge response")?;
-    let data = graphql_response_data(response, "auth challenge")?;
+    let data = graphql_query_unauth::<AuthChallenge>(
+        client,
+        endpoint,
+        auth_challenge::Variables {
+            username: username.to_owned(),
+        },
+        "auth challenge",
+    )
+    .await?;
     Ok(data.auth_challenge.challenge)
 }
 
@@ -218,6 +205,56 @@ pub(crate) fn graphql_response_data<T>(
     response
         .data
         .ok_or_else(|| anyhow!("{operation} response did not include data"))
+}
+
+/// Execute an authenticated GraphQL query/mutation and return the response data.
+pub(crate) async fn graphql_query<Q: GraphQLQuery>(
+    client: &reqwest::Client,
+    endpoint: &str,
+    token: &str,
+    variables: Q::Variables,
+    operation: &str,
+) -> anyhow::Result<Q::ResponseData>
+where
+    Q::ResponseData: serde::de::DeserializeOwned,
+{
+    let body = Q::build_query(variables);
+    let response = client
+        .post(endpoint)
+        .header(reqwest::header::AUTHORIZATION, bearer_header_value(token)?)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("failed to send {operation}"))?;
+    let response: graphql_client::Response<Q::ResponseData> = response
+        .json()
+        .await
+        .with_context(|| format!("failed to decode {operation} response"))?;
+    graphql_response_data(response, operation)
+}
+
+/// Execute an unauthenticated GraphQL query/mutation and return the response data.
+pub(crate) async fn graphql_query_unauth<Q: GraphQLQuery>(
+    client: &reqwest::Client,
+    endpoint: &str,
+    variables: Q::Variables,
+    operation: &str,
+) -> anyhow::Result<Q::ResponseData>
+where
+    Q::ResponseData: serde::de::DeserializeOwned,
+{
+    let body = Q::build_query(variables);
+    let response = client
+        .post(endpoint)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("failed to send {operation}"))?;
+    let response: graphql_client::Response<Q::ResponseData> = response
+        .json()
+        .await
+        .with_context(|| format!("failed to decode {operation} response"))?;
+    graphql_response_data(response, operation)
 }
 
 /// Construct an `Authorization: Bearer {token}` header value, validating the

--- a/crates/cli/src/deployment.rs
+++ b/crates/cli/src/deployment.rs
@@ -5,11 +5,7 @@ use serde::Serialize;
 use serde_json::json;
 use std::{collections::BTreeSet, time::Duration};
 
-use crate::{auth, output::OutputFormat, repo, ws};
-
-/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
-#[allow(clippy::upper_case_acronyms)]
-type JSON = serde_json::Value;
+use crate::{auth, auth::JSON, output::OutputFormat, repo, ws};
 
 #[derive(Args, Debug)]
 pub struct DeploymentsArgs {
@@ -196,24 +192,16 @@ async fn print_deployment_last_logs(
 ) -> anyhow::Result<()> {
     let (_, repository_name) = repo::parse_repository_path(repository)?;
 
-    let body = DeploymentLastLogs::build_query(deployment_last_logs::Variables {
-        amount: Some(amount),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send deployment logs query")?;
-    let response: graphql_client::Response<deployment_last_logs::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode deployment logs response")?;
-    let data = auth::graphql_response_data(response, "deployment logs")?;
+    let data = auth::graphql_query::<DeploymentLastLogs>(
+        client,
+        endpoint,
+        token,
+        deployment_last_logs::Variables {
+            amount: Some(amount),
+        },
+        "deployment logs",
+    )
+    .await?;
     let repo = data
         .repositories
         .into_iter()
@@ -367,22 +355,14 @@ async fn query_repository_environments(
 ) -> anyhow::Result<
     Vec<list_repository_deployments::ListRepositoryDeploymentsRepositoriesEnvironments>,
 > {
-    let body = ListRepositoryDeployments::build_query(list_repository_deployments::Variables {});
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send deployments query")?;
-    let response: graphql_client::Response<list_repository_deployments::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode deployments response")?;
-    let data = auth::graphql_response_data(response, "deployment list")?;
+    let data = auth::graphql_query::<ListRepositoryDeployments>(
+        client,
+        endpoint,
+        token,
+        list_repository_deployments::Variables {},
+        "deployment list",
+    )
+    .await?;
     let repository = data
         .repositories
         .into_iter()

--- a/crates/cli/src/org.rs
+++ b/crates/cli/src/org.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use clap::{Args, Subcommand};
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
@@ -89,22 +88,14 @@ async fn list_organizations(
     token: &str,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = ListOrganizations::build_query(list_organizations::Variables {});
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send organizations query")?;
-    let response: graphql_client::Response<list_organizations::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode organizations response")?;
-    let data = auth::graphql_response_data(response, "organization list")?;
+    let data = auth::graphql_query::<ListOrganizations>(
+        client,
+        endpoint,
+        token,
+        list_organizations::Variables {},
+        "organization list",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct OrgOutput {
@@ -145,24 +136,16 @@ async fn create_organization(
     name: &str,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = CreateOrganization::build_query(create_organization::Variables {
-        name: name.to_owned(),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send create organization mutation")?;
-    let response: graphql_client::Response<create_organization::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode create organization response")?;
-    let data = auth::graphql_response_data(response, "organization create")?;
+    let data = auth::graphql_query::<CreateOrganization>(
+        client,
+        endpoint,
+        token,
+        create_organization::Variables {
+            name: name.to_owned(),
+        },
+        "organization create",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct CreateOrgOutput {
@@ -189,25 +172,17 @@ async fn add_organization_member(
     username: &str,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = AddOrganizationMember::build_query(add_organization_member::Variables {
-        organization: organization.to_owned(),
-        username: username.to_owned(),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send add organization member mutation")?;
-    let response: graphql_client::Response<add_organization_member::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode add organization member response")?;
-    let data = auth::graphql_response_data(response, "organization add-member")?;
+    let data = auth::graphql_query::<AddOrganizationMember>(
+        client,
+        endpoint,
+        token,
+        add_organization_member::Variables {
+            organization: organization.to_owned(),
+            username: username.to_owned(),
+        },
+        "organization add-member",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct AddMemberOutput {
@@ -243,24 +218,16 @@ async fn leave_organization(
     organization: &str,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = LeaveOrganization::build_query(leave_organization::Variables {
-        organization: organization.to_owned(),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send leave organization mutation")?;
-    let response: graphql_client::Response<leave_organization::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode leave organization response")?;
-    auth::graphql_response_data(response, "organization leave")?;
+    auth::graphql_query::<LeaveOrganization>(
+        client,
+        endpoint,
+        token,
+        leave_organization::Variables {
+            organization: organization.to_owned(),
+        },
+        "organization leave",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct LeaveOrgOutput {

--- a/crates/cli/src/repo.rs
+++ b/crates/cli/src/repo.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
@@ -58,25 +58,17 @@ async fn create_repository(
     format: OutputFormat,
 ) -> anyhow::Result<()> {
     let (organization, repository) = parse_repository_path(repository)?;
-    let body = CreateRepository::build_query(create_repository::Variables {
-        organization: organization.to_owned(),
-        repository: repository.to_owned(),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send create repository mutation")?;
-    let response: graphql_client::Response<create_repository::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode create repository response")?;
-    let data = auth::graphql_response_data(response, "repository create")?;
+    let data = auth::graphql_query::<CreateRepository>(
+        client,
+        endpoint,
+        token,
+        create_repository::Variables {
+            organization: organization.to_owned(),
+            repository: repository.to_owned(),
+        },
+        "repository create",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct CreateRepositoryOutput {
@@ -101,22 +93,14 @@ async fn list_repositories(
     token: &str,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = ListRepositories::build_query(list_repositories::Variables {});
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send repositories query")?;
-    let response: graphql_client::Response<list_repositories::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode repositories response")?;
-    let data = auth::graphql_response_data(response, "repository list")?;
+    let data = auth::graphql_query::<ListRepositories>(
+        client,
+        endpoint,
+        token,
+        list_repositories::Variables {},
+        "repository list",
+    )
+    .await?;
 
     #[derive(Serialize)]
     struct RepositoryOutput {

--- a/crates/cli/src/resource.rs
+++ b/crates/cli/src/resource.rs
@@ -4,11 +4,7 @@ use graphql_client::GraphQLQuery;
 use serde::Serialize;
 use serde_json::json;
 
-use crate::{auth, output::OutputFormat, repo, ws};
-
-/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
-#[allow(clippy::upper_case_acronyms)]
-type JSON = serde_json::Value;
+use crate::{auth, auth::JSON, output::OutputFormat, repo, ws};
 
 #[derive(Args, Debug)]
 pub struct ResourcesArgs {
@@ -121,22 +117,14 @@ async fn list_resources(
 ) -> anyhow::Result<()> {
     let (_, repository_name) = repo::parse_repository_path(repository)?;
 
-    let body = ListRepositoryResources::build_query(list_repository_resources::Variables {});
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send resources query")?;
-    let response: graphql_client::Response<list_repository_resources::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode resources response")?;
-    let data = auth::graphql_response_data(response, "resource list")?;
+    let data = auth::graphql_query::<ListRepositoryResources>(
+        client,
+        endpoint,
+        token,
+        list_repository_resources::Variables {},
+        "resource list",
+    )
+    .await?;
     let repo = data
         .repositories
         .into_iter()
@@ -239,24 +227,16 @@ async fn print_resource_last_logs(
     amount: i64,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let body = ResourceLastLogs::build_query(resource_last_logs::Variables {
-        amount: Some(amount),
-    });
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send resource logs query")?;
-    let response: graphql_client::Response<resource_last_logs::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode resource logs response")?;
-    let data = auth::graphql_response_data(response, "resource logs")?;
+    let data = auth::graphql_query::<ResourceLastLogs>(
+        client,
+        endpoint,
+        token,
+        resource_last_logs::Variables {
+            amount: Some(amount),
+        },
+        "resource logs",
+    )
+    .await?;
 
     let mut results: Vec<ResourceLogOutput> = Vec::new();
     let mut missing: Vec<&str> = Vec::new();

--- a/crates/cli/src/signup.rs
+++ b/crates/cli/src/signup.rs
@@ -1,13 +1,8 @@
-use anyhow::Context;
 use clap::Args;
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
 
-use crate::{auth, output::OutputFormat};
-
-/// Custom scalar required by `graphql_client` derive for the `JSON` scalar in the schema.
-#[allow(clippy::upper_case_acronyms)]
-type JSON = serde_json::Value;
+use crate::{auth, auth::JSON, output::OutputFormat};
 
 #[derive(Args, Debug)]
 pub struct SignupArgs {
@@ -38,25 +33,18 @@ pub async fn run_signup(args: SignupArgs, format: OutputFormat) -> anyhow::Resul
     let key_path = auth::expand_tilde(&args.key)?;
     let proof = auth::build_auth_proof(&client, &endpoint, &args.username, &key_path).await?;
 
-    let body = Signup::build_query(signup::Variables {
-        username: args.username.clone(),
-        email: args.email.clone(),
-        proof: serde_json::Value::String(proof),
-        fullname: args.fullname.clone(),
-    });
-
-    let response = client
-        .post(endpoint)
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send signup mutation")?;
-
-    let response: graphql_client::Response<signup::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode graphql response")?;
-    let data = auth::graphql_response_data(response, "signup")?;
+    let data = auth::graphql_query_unauth::<Signup>(
+        &client,
+        &endpoint,
+        signup::Variables {
+            username: args.username.clone(),
+            email: args.email.clone(),
+            proof: serde_json::Value::String(proof),
+            fullname: args.fullname.clone(),
+        },
+        "signup",
+    )
+    .await?;
     auth::persist_auth_state(&data.signup.user.username, &key_path, &data.signup.token).await?;
 
     #[derive(Serialize)]

--- a/crates/cli/src/whoami.rs
+++ b/crates/cli/src/whoami.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use clap::Args;
 use graphql_client::GraphQLQuery;
 use serde::Serialize;
@@ -24,22 +23,8 @@ pub async fn run_whoami(args: WhoamiArgs, format: OutputFormat) -> anyhow::Resul
     let token = auth::acquire_token(&client, &args.api_url).await?;
     let endpoint = auth::graphql_endpoint(&args.api_url);
 
-    let body = Me::build_query(me::Variables {});
-    let response = client
-        .post(endpoint)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            auth::bearer_header_value(&token)?,
-        )
-        .json(&body)
-        .send()
-        .await
-        .context("failed to send me query")?;
-    let response: graphql_client::Response<me::ResponseData> = response
-        .json()
-        .await
-        .context("failed to decode me response")?;
-    let data = auth::graphql_response_data(response, "whoami")?;
+    let data =
+        auth::graphql_query::<Me>(&client, &endpoint, &token, me::Variables {}, "whoami").await?;
 
     #[derive(Serialize)]
     struct WhoamiOutput {


### PR DESCRIPTION
## Summary
- Add `graphql_query` and `graphql_query_unauth` generic helpers to `auth.rs` that encapsulate the repeated build-query → send → decode → unwrap cycle
- Replace 13 duplicated GraphQL request blocks across 7 files (org, repo, resource, deployment, whoami, signup, auth) with single-line helper calls
- Centralize the `JSON` scalar type alias in `auth.rs` and re-export it, removing 3 duplicate definitions

Net effect: **-79 lines** of boilerplate, and future GraphQL operations only need a one-liner instead of 10-15 lines of copy-paste.

## Test plan
- [x] `cargo check -p cli` passes
- [x] `cargo fmt -- --check` passes
- [x] Pre-existing `clippy` warnings in `sclc` dep are unchanged; no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)