### PR TITLE
refactor(cli): deduplicate LogOutput struct and log formatting

### DIFF
--- a/crates/cli/src/deployment.rs
+++ b/crates/cli/src/deployment.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use serde_json::json;
 use std::{collections::BTreeSet, time::Duration};
 
-use crate::{auth, auth::JSON, output::OutputFormat, repo, ws};
+use crate::{auth, auth::JSON, output, output::OutputFormat, repo, ws};
 
 #[derive(Args, Debug)]
 pub struct DeploymentsArgs {
@@ -143,10 +143,10 @@ async fn list_deployments(
         .collect();
 
     match format {
-        OutputFormat::Json => crate::output::print_json(&deployments)?,
+        OutputFormat::Json => output::print_json(&deployments)?,
         OutputFormat::Text => {
-            let mut table = crate::output::table("{:<}  {:<}  {:<}  {:<}  {:>}");
-            table.add_row(crate::output::row(vec![
+            let mut table = output::table("{:<}  {:<}  {:<}  {:<}  {:>}");
+            table.add_row(output::row(vec![
                 String::from("REF"),
                 String::from("COMMIT"),
                 String::from("CREATED"),
@@ -154,10 +154,10 @@ async fn list_deployments(
                 String::from("RESOURCES"),
             ]));
             for deployment in deployments {
-                table.add_row(crate::output::row(vec![
+                table.add_row(output::row(vec![
                     deployment.r#ref,
-                    crate::output::shorten_commit_hash(&deployment.commit),
-                    crate::output::format_created_at(&deployment.created_at),
+                    output::shorten_commit_hash(&deployment.commit),
+                    output::format_created_at(&deployment.created_at),
                     deployment.state,
                     deployment.resources.len().to_string(),
                 ]));
@@ -172,14 +172,7 @@ async fn list_deployments(
 #[derive(Serialize)]
 struct DeploymentLogOutput {
     deployment_id: String,
-    logs: Vec<LogOutput>,
-}
-
-#[derive(Serialize)]
-struct LogOutput {
-    severity: String,
-    timestamp: String,
-    message: String,
+    logs: Vec<output::LogOutput>,
 }
 
 async fn print_deployment_last_logs(
@@ -223,7 +216,7 @@ async fn print_deployment_last_logs(
                     logs: d
                         .last_logs
                         .into_iter()
-                        .map(|l| LogOutput {
+                        .map(|l| output::LogOutput {
                             severity: format!("{:?}", l.severity),
                             timestamp: l.timestamp,
                             message: l.message,
@@ -241,17 +234,13 @@ async fn print_deployment_last_logs(
     }
 
     match format {
-        OutputFormat::Json => crate::output::print_json(&deployments)?,
+        OutputFormat::Json => output::print_json(&deployments)?,
         OutputFormat::Text => {
-            for (i, deployment) in deployments.iter().enumerate() {
-                if i > 0 {
-                    println!();
-                }
-                println!("==> {} <==", deployment.deployment_id);
-                for log in &deployment.logs {
-                    println!("[{}] [{}] {}", log.timestamp, log.severity, log.message);
-                }
-            }
+            let groups: Vec<_> = deployments
+                .iter()
+                .map(|d| (d.deployment_id.as_str(), d.logs.as_slice()))
+                .collect();
+            output::print_logs_text(&groups);
         }
     }
 

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -60,6 +60,26 @@ pub(crate) fn report_diagnostics<T>(diagnosed: sclc::Diagnosed<T>) -> Option<T> 
     Some(diagnosed.into_inner())
 }
 
+#[derive(Clone, Serialize)]
+pub(crate) struct LogOutput {
+    pub(crate) severity: String,
+    pub(crate) timestamp: String,
+    pub(crate) message: String,
+}
+
+/// Print groups of logs in text format, where each group has a label header.
+pub(crate) fn print_logs_text(groups: &[(&str, &[LogOutput])]) {
+    for (i, (label, logs)) in groups.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        println!("==> {label} <==");
+        for log in *logs {
+            println!("[{}] [{}] {}", log.timestamp, log.severity, log.message);
+        }
+    }
+}
+
 pub(crate) fn shorten_commit_hash(hash: &str) -> String {
     hash.chars().take(16).collect::<String>()
 }

--- a/crates/cli/src/resource.rs
+++ b/crates/cli/src/resource.rs
@@ -4,7 +4,7 @@ use graphql_client::GraphQLQuery;
 use serde::Serialize;
 use serde_json::json;
 
-use crate::{auth, auth::JSON, output::OutputFormat, repo, ws};
+use crate::{auth, auth::JSON, output, output::OutputFormat, repo, ws};
 
 #[derive(Args, Debug)]
 pub struct ResourcesArgs {
@@ -165,10 +165,10 @@ async fn list_resources(
         .collect();
 
     match format {
-        OutputFormat::Json => crate::output::print_json(&resources)?,
+        OutputFormat::Json => output::print_json(&resources)?,
         OutputFormat::Text => {
-            let mut table = crate::output::table("{:<}  {:<}  {:<}  {:<}  {:<}  {:<}");
-            table.add_row(crate::output::row(vec![
+            let mut table = output::table("{:<}  {:<}  {:<}  {:<}  {:<}  {:<}");
+            table.add_row(output::row(vec![
                 String::from("ENVIRONMENT"),
                 String::from("TYPE"),
                 String::from("NAME"),
@@ -185,7 +185,7 @@ async fn list_resources(
                     .outputs
                     .map(|v| serde_json::to_string(&v).unwrap_or_default())
                     .unwrap_or_default();
-                table.add_row(crate::output::row(vec![
+                table.add_row(output::row(vec![
                     resource.environment,
                     resource.r#type,
                     resource.name,
@@ -209,14 +209,7 @@ fn build_resource_qid(env_qid: &str, resource_type: &str, resource_name: &str) -
 #[derive(Serialize)]
 struct ResourceLogOutput {
     resource_qid: String,
-    logs: Vec<LogOutput>,
-}
-
-#[derive(Serialize)]
-struct LogOutput {
-    severity: String,
-    timestamp: String,
-    message: String,
+    logs: Vec<output::LogOutput>,
 }
 
 async fn print_resource_last_logs(
@@ -254,7 +247,7 @@ async fn print_resource_last_logs(
                             logs: resource
                                 .last_logs
                                 .iter()
-                                .map(|l| LogOutput {
+                                .map(|l| output::LogOutput {
                                     severity: format!("{:?}", l.severity),
                                     timestamp: l.timestamp.clone(),
                                     message: l.message.clone(),
@@ -275,17 +268,13 @@ async fn print_resource_last_logs(
     }
 
     match format {
-        OutputFormat::Json => crate::output::print_json(&results)?,
+        OutputFormat::Json => output::print_json(&results)?,
         OutputFormat::Text => {
-            for (i, result) in results.iter().enumerate() {
-                if i > 0 {
-                    println!();
-                }
-                println!("==> {} <==", result.resource_qid);
-                for log in &result.logs {
-                    println!("[{}] [{}] {}", log.timestamp, log.severity, log.message);
-                }
-            }
+            let groups: Vec<_> = results
+                .iter()
+                .map(|r| (r.resource_qid.as_str(), r.logs.as_slice()))
+                .collect();
+            output::print_logs_text(&groups);
         }
     }
 


### PR DESCRIPTION
## Summary

- Move the identical `LogOutput` struct (which was defined separately in both `deployment.rs` and `resource.rs`) into `output.rs` as a shared type
- Extract the duplicated log-group text formatting pattern into a reusable `print_logs_text` helper in `output.rs`
- Simplify both `deployment.rs` and `resource.rs` to use the shared type and helper, also normalizing `crate::output::` references to use the existing `output` import

## Test plan

- [x] `cargo check -p cli` passes
- [x] `cargo fmt` clean
- [ ] Verify `skyr deployments logs` text and JSON output unchanged
- [ ] Verify `skyr resources logs` text and JSON output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)