### PR TITLE
refactor(cli): extract atomic rename helper and optimize resource log lookup

### DIFF
--- a/crates/cli/src/cache.rs
+++ b/crates/cli/src/cache.rs
@@ -12,7 +12,7 @@
 //! │   └── ...
 //! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -39,6 +39,27 @@ pub fn package_version_dir(pkg_id: &sclc::PackageId, version: &str) -> anyhow::R
 pub fn is_cached(pkg_id: &sclc::PackageId, version: &str) -> anyhow::Result<bool> {
     let dir = package_version_dir(pkg_id, version)?;
     Ok(dir.is_dir())
+}
+
+/// Atomically moves `tmp` to `target` with race-condition handling.
+///
+/// If the rename fails because another process already placed the directory,
+/// the temporary directory is cleaned up. If the parent directory is missing,
+/// it is created and the rename is retried once.
+pub(crate) async fn atomic_rename_dir(tmp: &Path, target: &Path) -> anyhow::Result<()> {
+    if let Err(_e) = tokio::fs::rename(tmp, target).await {
+        if target.is_dir() {
+            let _ = tokio::fs::remove_dir_all(tmp).await;
+            return Ok(());
+        }
+        if let Some(parent) = target.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::rename(tmp, target).await.with_context(|| {
+            format!("failed to rename {} to {}", tmp.display(), target.display())
+        })?;
+    }
+    Ok(())
 }
 
 /// Writes the bundled stdlib `.scl` files to disk under the cache directory.
@@ -71,21 +92,7 @@ pub async fn populate_stdlib() -> anyhow::Result<PathBuf> {
         tokio::fs::write(&dest, content).await?;
     }
 
-    // Atomic rename into place. If another process raced us, ignore the
-    // rename error and verify the target exists.
-    if let Err(_e) = tokio::fs::rename(&tmp, &dir).await {
-        if dir.is_dir() {
-            let _ = tokio::fs::remove_dir_all(&tmp).await;
-            return Ok(dir);
-        }
-        // Ensure parent exists and retry once.
-        if let Some(parent) = dir.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        tokio::fs::rename(&tmp, &dir)
-            .await
-            .with_context(|| format!("failed to rename {} to {}", tmp.display(), dir.display()))?;
-    }
+    atomic_rename_dir(&tmp, &dir).await?;
 
     Ok(dir)
 }

--- a/crates/cli/src/resolver.rs
+++ b/crates/cli/src/resolver.rs
@@ -119,17 +119,7 @@ fn resolve_deps<'a>(
                     .await
                     .with_context(|| format!("failed to fetch {} at {}", repo_qid, commit_hash))?;
 
-                // Atomic rename.
-                if let Err(_e) = tokio::fs::rename(&tmp, &dir).await {
-                    if dir.is_dir() {
-                        let _ = tokio::fs::remove_dir_all(&tmp).await;
-                    } else {
-                        if let Some(parent) = dir.parent() {
-                            tokio::fs::create_dir_all(parent).await?;
-                        }
-                        tokio::fs::rename(&tmp, &dir).await?;
-                    }
-                }
+                cache::atomic_rename_dir(&tmp, &dir).await?;
                 dir
             } else {
                 cache::package_version_dir(&package_id, &commit_hash)?

--- a/crates/cli/src/resource.rs
+++ b/crates/cli/src/resource.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, anyhow};
 use clap::{Args, Subcommand};
 use graphql_client::GraphQLQuery;
@@ -231,34 +233,38 @@ async fn print_resource_last_logs(
     )
     .await?;
 
+    // Index all resources by QID for O(1) lookups instead of nested iteration.
+    let mut resource_logs: HashMap<String, Vec<output::LogOutput>> = HashMap::new();
+    for repo in &data.repositories {
+        for env in &repo.environments {
+            for resource in &env.resources {
+                let qid = build_resource_qid(&env.qid, &resource.type_, &resource.name);
+                resource_logs.insert(
+                    qid,
+                    resource
+                        .last_logs
+                        .iter()
+                        .map(|l| output::LogOutput {
+                            severity: format!("{:?}", l.severity),
+                            timestamp: l.timestamp.clone(),
+                            message: l.message.clone(),
+                        })
+                        .collect(),
+                );
+            }
+        }
+    }
+
     let mut results: Vec<ResourceLogOutput> = Vec::new();
     let mut missing: Vec<&str> = Vec::new();
 
     for qid in resource_qids {
-        let mut found = false;
-        for repo in &data.repositories {
-            for env in &repo.environments {
-                for resource in &env.resources {
-                    let candidate = build_resource_qid(&env.qid, &resource.type_, &resource.name);
-                    if candidate == *qid {
-                        found = true;
-                        results.push(ResourceLogOutput {
-                            resource_qid: qid.clone(),
-                            logs: resource
-                                .last_logs
-                                .iter()
-                                .map(|l| output::LogOutput {
-                                    severity: format!("{:?}", l.severity),
-                                    timestamp: l.timestamp.clone(),
-                                    message: l.message.clone(),
-                                })
-                                .collect(),
-                        });
-                    }
-                }
-            }
-        }
-        if !found {
+        if let Some(logs) = resource_logs.remove(qid.as_str()) {
+            results.push(ResourceLogOutput {
+                resource_qid: qid.clone(),
+                logs,
+            });
+        } else {
             missing.push(qid);
         }
     }


### PR DESCRIPTION
## Summary
- Extract duplicated atomic-rename-with-retry logic from `cache.rs` and `resolver.rs` into a shared `atomic_rename_dir` helper in `cache.rs`, eliminating code duplication across the two call sites
- Replace the O(n·m·p·q) triple-nested loop in `resource.rs` `print_resource_last_logs` with a HashMap-based index for O(1) resource QID lookups

## Test plan
- [x] `cargo check -p cli` passes
- [x] `cargo fmt -- --check` passes
- [ ] Verify `skyr resources logs` works correctly with single and multiple resource QIDs
- [ ] Verify `skyr` package caching works for stdlib and git-resolved dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)