### PR TITLE
Redesign deployment state machine to fix writer race conditions

### DIFF
--- a/crates/api/schema.graphql
+++ b/crates/api/schema.graphql
@@ -8,6 +8,7 @@ enum DeploymentState {
   DOWN
   UNDESIRED
   LINGERING
+  PENDING
   DESIRED
   UP
   FAILING

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1945,6 +1945,8 @@ enum DeploymentState {
     Undesired,
     #[graphql(name = "LINGERING")]
     Lingering,
+    #[graphql(name = "PENDING")]
+    Pending,
     #[graphql(name = "DESIRED")]
     Desired,
     #[graphql(name = "UP")]
@@ -1961,6 +1963,7 @@ impl From<cdb::DeploymentState> for DeploymentState {
             cdb::DeploymentState::Down => DeploymentState::Down,
             cdb::DeploymentState::Undesired => DeploymentState::Undesired,
             cdb::DeploymentState::Lingering => DeploymentState::Lingering,
+            cdb::DeploymentState::Pending => DeploymentState::Pending,
             cdb::DeploymentState::Desired => DeploymentState::Desired,
             cdb::DeploymentState::Up => DeploymentState::Up,
             cdb::DeploymentState::Failing => DeploymentState::Failing,

--- a/crates/cdb/src/client.rs
+++ b/crates/cdb/src/client.rs
@@ -7,7 +7,7 @@ use crate::deployment::{Deployment, InvalidDeploymentState};
 use crate::{DeploymentState, Repository};
 use chrono::{DateTime, Utc};
 use futures_util::stream::BoxStream;
-use futures_util::{Stream, StreamExt, TryStreamExt, pin_mut, stream};
+use futures_util::{Stream, StreamExt, TryStreamExt, stream};
 use gix_hash::ObjectId;
 use gix_object::{Blob, Commit, Kind, Object, Tree, WriteTo};
 use ids::{DeploymentId, EnvironmentId, ParseIdError, RepoQid};
@@ -1102,70 +1102,6 @@ impl DeploymentClient {
             .await?;
 
         Ok(superseded)
-    }
-
-    /// Pick a suitable deployment to roll back to after this deployment has
-    /// failed fatally.
-    ///
-    /// The primary candidate set is the deployments that this one directly
-    /// superseded (from the supersessions table). If several exist (e.g. a
-    /// racey double-push produced multiple superseded predecessors), the
-    /// most recent by `created_at` wins. Any predecessor that is itself
-    /// `Failing` or `Failed` is skipped.
-    ///
-    /// If no direct predecessor is a viable rollback target, falls back to
-    /// the most recent non-failed deployment in the same environment,
-    /// excluding `self`.
-    ///
-    /// Returns `None` if no suitable candidate exists.
-    pub async fn rollback_target(&self) -> Result<Option<Deployment>, DeploymentQueryError> {
-        // Primary: deployments we superseded directly.
-        let superseded = self.superseded().await?;
-        let mut candidates: Vec<Deployment> = Vec::new();
-        for client in superseded {
-            match client.get().await {
-                Ok(dep) => {
-                    if !matches!(
-                        dep.state,
-                        DeploymentState::Failed | DeploymentState::Failing
-                    ) {
-                        candidates.push(dep);
-                    }
-                }
-                Err(DeploymentQueryError::NotFound) => {}
-                Err(e) => return Err(e),
-            }
-        }
-        if let Some(best) = candidates.into_iter().max_by_key(|d| d.created_at) {
-            return Ok(Some(best));
-        }
-
-        // Fallback: most recent deployment in the same environment that
-        // isn't failing/failed or self.
-        let stream = self.repo.deployments().await?;
-        pin_mut!(stream);
-        let mut best: Option<Deployment> = None;
-        while let Some(dep) = stream.next().await {
-            let dep = dep?;
-            if dep.environment != self.environment {
-                continue;
-            }
-            if dep.deployment == self.deployment {
-                continue;
-            }
-            if matches!(
-                dep.state,
-                DeploymentState::Failed | DeploymentState::Failing
-            ) {
-                continue;
-            }
-            match &best {
-                None => best = Some(dep),
-                Some(b) if dep.created_at > b.created_at => best = Some(dep),
-                _ => {}
-            }
-        }
-        Ok(best)
     }
 
     /// Promote this deployment to be the tip of its environment by

--- a/crates/cdb/src/client.rs
+++ b/crates/cdb/src/client.rs
@@ -250,6 +250,15 @@ prepared_statements! {
                 environment_id,
                 superseded_commit_hash
             ) VALUES (?, ?, ?, ?, ?)
+            IF NOT EXISTS
+        "#,
+
+        delete_supersession = r#"
+            DELETE FROM cdb.supersessions
+            WHERE organization = ?
+            AND repository = ?
+            AND environment_id = ?
+            AND superseded_commit_hash = ?
         "#,
 
         get_superseded_commits = r#"
@@ -976,19 +985,82 @@ impl DeploymentClient {
             .map(|e| e.oid))
     }
 
+    /// Record that this deployment is superseded by `superseding_commit`.
+    ///
+    /// Uses a lightweight transaction (`IF NOT EXISTS`) so two concurrent
+    /// writers cannot silently clobber each other's supersession record. If
+    /// a supersession row already exists for this deployment, the write is
+    /// treated as idempotent iff the existing superseder matches
+    /// `superseding_commit`; otherwise [`SetDeploymentError::SupersessionConflict`]
+    /// is returned so the caller can react (e.g. rejecting a racey push).
     pub async fn mark_superseded_by(
         &self,
         superseding_commit: &DeploymentId,
     ) -> Result<(), SetDeploymentError> {
         let superseding_oid = ObjectId::from_bytes_or_panic(&superseding_commit.to_bytes());
         let this_oid = self.commit_hash();
-        self.repo
+        let result = self
+            .repo
             .client
             .session
             .execute_unpaged(
                 &self.repo.client.statements.create_supersession,
                 (
                     superseding_oid.as_bytes(),
+                    self.repo.name.org.as_str(),
+                    self.repo.name.repo.as_str(),
+                    self.environment.as_str(),
+                    this_oid.as_bytes(),
+                ),
+            )
+            .await?;
+
+        // LWT writes return a row with the `[applied]` pseudo-column plus
+        // the existing row's columns when the write wasn't applied.
+        let rows = result.into_rows_result()?;
+        let (applied, existing) = rows
+            .single_row::<(bool, Option<Vec<u8>>)>()
+            .unwrap_or((true, None));
+
+        if applied {
+            return Ok(());
+        }
+
+        // If the existing row names the same superseder, treat it as an
+        // idempotent re-write (e.g. a retried push).
+        if let Some(existing_bytes) = existing
+            && existing_bytes == superseding_oid.as_bytes()
+        {
+            return Ok(());
+        }
+
+        Err(SetDeploymentError::SupersessionConflict)
+    }
+
+    /// Remove every supersession row naming *self* as the superseder. This
+    /// is the core of the rollback mechanism: when a deployment reaches
+    /// `Failed`, its own worker clears the records pointing into it, and
+    /// the predecessors it had superseded observe the cleared row on their
+    /// next tick and self-transition from `Lingering` back to `Desired`.
+    pub async fn clear_predecessor_supersessions(&self) -> Result<(), SetDeploymentError> {
+        for predecessor in self.superseded().await? {
+            predecessor.clear_supersession().await?;
+        }
+        Ok(())
+    }
+
+    /// Remove this deployment's supersession record, if any. Used by the
+    /// rollback path: when a superseder reaches `Failed`, its predecessors'
+    /// supersession rows are cleared so they can self-transition back to
+    /// `Desired`.
+    pub async fn clear_supersession(&self) -> Result<(), SetDeploymentError> {
+        let this_oid = self.commit_hash();
+        self.repo
+            .client
+            .session
+            .execute_unpaged(
+                &self.repo.client.statements.delete_supersession,
+                (
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
                     self.environment.as_str(),
@@ -1096,16 +1168,36 @@ impl DeploymentClient {
         Ok(best)
     }
 
-    /// Transition this deployment into the `Desired` state, taking over
-    /// from whatever deployment is currently active in the same
-    /// environment.
+    /// Promote this deployment to be the tip of its environment by
+    /// manipulating *supersession rows only* — no deployment-state writes
+    /// are performed here. The affected deployments' own workers will
+    /// observe the supersession changes on their next tick and
+    /// self-transition accordingly.
     ///
-    /// Any currently-active deployment (`Desired`, `Up`, or `Failing`) in
-    /// this environment is transitioned to `Lingering` and a supersession
-    /// row is recorded linking it to this deployment. `Failed` and
-    /// `Lingering`/`Undesired`/`Down` deployments are left untouched.
+    /// Specifically:
+    /// * Any supersession row pointing *at* this deployment is cleared,
+    ///   so it is no longer superseded (this unblocks a `Lingering` self
+    ///   to `Desired`, or a `Failed` self to be resurrected by a
+    ///   re-reconcile).
+    /// * For every currently-active, non-superseded deployment in the
+    ///   same environment, a supersession row is written pointing from
+    ///   that deployment to this one. Those deployments' workers will
+    ///   observe the supersession and transition to `Lingering`.
+    ///
+    /// This replaces the previous cross-deployment state writes and
+    /// respects the self-transition invariant documented in the TLA
+    /// model (see `tla/DeploymentEngine.tla`): only a deployment's own
+    /// worker writes that deployment's `state` column.
     pub async fn make_desired(&self) -> Result<(), SetDeploymentError> {
-        // Find currently-active deployments in the same environment.
+        // Clear any supersession row naming *self* as the superseded
+        // deployment. This is the "rollback" half of make_desired: if
+        // someone else had superseded us (we're Lingering), we are now
+        // reclaiming the tip.
+        self.clear_supersession().await?;
+
+        // Find currently-active (state-wise) deployments in the same
+        // environment and write a supersession row pointing from each to
+        // self. Skip anything already superseded (including by self).
         let mut active: Vec<Deployment> = Vec::new();
         let mut stream = self.repo.active_deployments().await?;
         while let Some(dep) = stream.next().await {
@@ -1121,21 +1213,28 @@ impl DeploymentClient {
             }
         }
 
-        // Mark each as Lingering and record the supersession.
         for dep in active {
             let predecessor = self
                 .repo
                 .deployment(dep.environment.clone(), dep.deployment.clone());
-            let (r1, r2) = futures::join!(
-                predecessor.set(DeploymentState::Lingering),
-                predecessor.mark_superseded_by(&self.deployment),
-            );
-            r1?;
-            r2?;
+            // Only supersede predecessors that aren't already superseded
+            // by somebody. If they are, we leave their chain alone —
+            // whichever deployment is the tip of the env will be
+            // superseded the next time through.
+            if predecessor.get_superseding().await?.is_some() {
+                continue;
+            }
+            match predecessor.mark_superseded_by(&self.deployment).await {
+                Ok(()) => {}
+                // A concurrent write raced us. Treat as a transient
+                // no-op: whoever won will shape the env; our caller can
+                // retry if that's not what they wanted.
+                Err(SetDeploymentError::SupersessionConflict) => {}
+                Err(e) => return Err(e),
+            }
         }
 
-        // Promote self.
-        self.set(DeploymentState::Desired).await
+        Ok(())
     }
 
     pub async fn get_superseding(&self) -> Result<Option<DeploymentClient>, DeploymentQueryError> {
@@ -1284,4 +1383,10 @@ pub enum SetDeploymentError {
 
     #[error("failed to query: {0}")]
     Query(#[from] DeploymentQueryError),
+
+    #[error("failed to load row: {0}")]
+    IntoRows(#[from] IntoRowsResultError),
+
+    #[error("supersession row already exists with a different superseder")]
+    SupersessionConflict,
 }

--- a/crates/cdb/src/deployment.rs
+++ b/crates/cdb/src/deployment.rs
@@ -39,6 +39,10 @@ pub enum DeploymentState {
     Down,
     Undesired,
     Lingering,
+    /// Initial state for a freshly-created deployment. The deployment's own
+    /// worker promotes it to `Desired` once any predecessor it supersedes
+    /// has acknowledged the supersession (i.e. reached `Lingering`).
+    Pending,
     Desired,
     Up,
     Failing,
@@ -46,17 +50,21 @@ pub enum DeploymentState {
 }
 
 impl DeploymentState {
-    /// Whether a deployment in this state is considered "active" for
-    /// supersession purposes — i.e. a new `Desired` deployment arriving in
-    /// the same environment should transition it to `Lingering`.
+    /// Whether a deployment in this state is a "live" lifecycle state —
+    /// i.e. not yet terminal (`Down`, `Undesired`, `Failed`) and not
+    /// waiting for teardown (`Lingering`).
     ///
-    /// `Failed` is intentionally excluded: once a deployment has failed
-    /// fatally we may have already rolled back to a prior deployment, so it
-    /// is treated as a terminal state that does not get re-lingered.
+    /// In the redesigned state machine, "which deployment is the tip of an
+    /// environment" is determined by supersession-absence rather than this
+    /// predicate, so callers should generally prefer checking the
+    /// `supersessions` table directly.
     pub fn is_active(self) -> bool {
         matches!(
             self,
-            DeploymentState::Desired | DeploymentState::Up | DeploymentState::Failing
+            DeploymentState::Pending
+                | DeploymentState::Desired
+                | DeploymentState::Up
+                | DeploymentState::Failing
         )
     }
 }
@@ -67,6 +75,7 @@ impl fmt::Display for DeploymentState {
             Self::Down => write!(f, "DOWN"),
             Self::Undesired => write!(f, "UNDESIRED"),
             Self::Lingering => write!(f, "LINGERING"),
+            Self::Pending => write!(f, "PENDING"),
             Self::Desired => write!(f, "DESIRED"),
             Self::Up => write!(f, "UP"),
             Self::Failing => write!(f, "FAILING"),
@@ -87,6 +96,7 @@ impl FromStr for DeploymentState {
             "DOWN" => Ok(DeploymentState::Down),
             "UNDESIRED" => Ok(DeploymentState::Undesired),
             "LINGERING" => Ok(DeploymentState::Lingering),
+            "PENDING" => Ok(DeploymentState::Pending),
             "DESIRED" => Ok(DeploymentState::Desired),
             "UP" => Ok(DeploymentState::Up),
             "FAILING" => Ok(DeploymentState::Failing),

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -402,6 +402,12 @@ impl Worker {
         let deployment_id = deployment.deployment.clone();
         let sid = short_id(deployment_id.as_str()).to_string();
 
+        // Read the supersession record once up front. The self-transition
+        // invariant (see `tla/DeploymentEngine.tla`) says only our own
+        // worker writes our state column, so we react to the supersession
+        // *row* rather than waiting for someone else to write our state.
+        let is_superseded = self.client.get_superseding().await?.is_some();
+
         match deployment.state {
             DeploymentState::Down => {
                 tracing::info!("{sid} down, waiting to be decommissioned...");
@@ -413,9 +419,41 @@ impl Worker {
                 Ok(())
             }
 
-            DeploymentState::Desired => self.run_reconcile_active(&deployment).await,
+            DeploymentState::Pending => {
+                if is_superseded {
+                    // A newer push pre-empted us before we activated.
+                    tracing::info!("{sid} pre-empted while pending; marking DOWN");
+                    self.log_publisher
+                        .info(format!("{sid} pre-empted before activation"))
+                        .await;
+                    self.client.set(DeploymentState::Down).await?;
+                    return Ok(());
+                }
+                if self.predecessor_ready().await? {
+                    tracing::info!("{sid} predecessor ready; promoting PENDING → DESIRED");
+                    self.client.set(DeploymentState::Desired).await?;
+                } else {
+                    tracing::debug!("{sid} pending; waiting for predecessor to linger");
+                }
+                Ok(())
+            }
+
+            DeploymentState::Desired => {
+                if is_superseded {
+                    tracing::info!("{sid} superseded; DESIRED → LINGERING");
+                    self.client.set(DeploymentState::Lingering).await?;
+                    return Ok(());
+                }
+                self.run_reconcile_active(&deployment).await
+            }
 
             DeploymentState::Failing => {
+                if is_superseded {
+                    tracing::info!("{sid} superseded while failing; FAILING → LINGERING");
+                    self.client.set(DeploymentState::Lingering).await?;
+                    self.backoff = None;
+                    return Ok(());
+                }
                 // Respect in-memory backoff: if the next attempt isn't due
                 // yet, skip this iteration entirely.
                 if let Some(state) = self.backoff {
@@ -433,6 +471,11 @@ impl Worker {
             }
 
             DeploymentState::Up => {
+                if is_superseded {
+                    tracing::info!("{sid} superseded while up; UP → LINGERING");
+                    self.client.set(DeploymentState::Lingering).await?;
+                    return Ok(());
+                }
                 tracing::debug!("{sid} up; no reconciliation needed");
                 Ok(())
             }
@@ -545,7 +588,23 @@ impl Worker {
             }
 
             DeploymentState::Lingering => {
+                if !is_superseded {
+                    // Our supersession row has been cleared — typically
+                    // because our superseder failed and its worker ran
+                    // the rollback path. Reclaim the tip.
+                    tracing::info!("{sid} supersession cleared; LINGERING → DESIRED");
+                    self.log_publisher
+                        .info(format!("{sid} reclaiming tip (rollback)"))
+                        .await;
+                    self.client.set(DeploymentState::Desired).await?;
+                    return Ok(());
+                }
+
                 tracing::info!("{sid} lingering...");
+                // Walk the supersession chain to decide whether our
+                // superseder (or something further along the chain) has
+                // reached a steady `Up` state where tearing us down is
+                // safe.
                 let mut cursor = self.client.clone();
                 let mut seen = HashSet::new();
 
@@ -558,20 +617,9 @@ impl Worker {
                         break;
                     }
 
-                    if matches!(
-                        superseding_deployment.state,
-                        DeploymentState::Desired | DeploymentState::Up
-                    ) {
-                        self.client
-                            .mark_superseded_by(&superseding_deployment.deployment)
-                            .await?;
-
-                        // If the superseding deployment is already Up, it won't
-                        // re-check its superseded list, so transition ourselves.
-                        if superseding_deployment.state == DeploymentState::Up {
-                            self.client.set(DeploymentState::Undesired).await?;
-                        }
-
+                    if superseding_deployment.state == DeploymentState::Up {
+                        // Successor is fully converged; safe to tear down.
+                        self.client.set(DeploymentState::Undesired).await?;
                         break;
                     }
 
@@ -583,12 +631,43 @@ impl Worker {
         }
     }
 
+    /// Returns `true` if every deployment this one has superseded has
+    /// acknowledged the supersession by reaching `Lingering` (or a later
+    /// terminal state). Used by the `Pending` handler to decide when to
+    /// self-promote to `Desired`.
+    async fn predecessor_ready(&self) -> anyhow::Result<bool> {
+        for predecessor in self.client.superseded().await? {
+            match predecessor.get().await {
+                Ok(dep) => {
+                    if matches!(
+                        dep.state,
+                        DeploymentState::Lingering
+                            | DeploymentState::Undesired
+                            | DeploymentState::Down
+                            | DeploymentState::Failed
+                    ) {
+                        continue;
+                    }
+                    return Ok(false);
+                }
+                Err(cdb::DeploymentQueryError::NotFound) => {
+                    // Predecessor disappeared (shouldn't normally
+                    // happen). Treat as ready.
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(true)
+    }
+
     /// Dispatch to [`reconcile_active`](Self::reconcile_active) and apply
     /// the resulting state transition.
     ///
     /// * Ok with fatal errors → transition to `Failed`, clear backoff, and
-    ///   try to make the deployment this one superseded desired again
-    ///   (rollback).
+    ///   clear the supersession records naming us as superseder so any
+    ///   predecessors we superseded can self-recover from `Lingering`
+    ///   back to `Desired` on their next tick.
     /// * Ok without fatal errors → success. If we were previously
     ///   `Failing`, clear backoff and move back to `Desired` (unless the
     ///   reconciliation itself promoted us to `Up`).
@@ -607,7 +686,7 @@ impl Worker {
                         .await;
                     self.client.set(DeploymentState::Failed).await?;
                     self.backoff = None;
-                    self.attempt_rollback(&sid).await?;
+                    self.trigger_rollback(&sid).await?;
                     return Ok(());
                 }
 
@@ -640,30 +719,31 @@ impl Worker {
         }
     }
 
-    /// Attempt to roll back to a predecessor deployment after a fatal
-    /// failure. Best-effort: a failure to find or promote a target is
-    /// logged but not propagated, since the failing deployment has
-    /// already been marked `Failed`.
-    async fn attempt_rollback(&self, sid: &str) -> anyhow::Result<()> {
-        match self.client.rollback_target().await? {
-            Some(target) => {
-                let target_sid = short_id(target.deployment.as_str()).to_string();
-                let target_client = self
-                    .cdb_client
-                    .repo(target.repo.clone())
-                    .deployment(target.environment.clone(), target.deployment.clone());
-                target_client.make_desired().await?;
-                tracing::info!("{sid} rolled back to {target_sid}");
-                self.log_publisher
-                    .info(format!("rolled back {sid} to {target_sid}"))
-                    .await;
-            }
-            None => {
-                tracing::warn!("{sid} no rollback target found");
-                self.log_publisher
-                    .error(format!("no rollback target for failed {sid}"))
-                    .await;
-            }
+    /// Roll back to a predecessor after a fatal failure by clearing the
+    /// supersession rows that name us as superseder. Each predecessor's
+    /// own worker will observe the cleared row on its next tick and
+    /// self-transition from `Lingering` back to `Desired`.
+    ///
+    /// This replaces the previous cross-deployment `make_desired` write,
+    /// which violated the self-transition invariant and raced against
+    /// concurrent pushes. Best-effort: errors are logged but not
+    /// propagated since the deployment has already been marked `Failed`.
+    async fn trigger_rollback(&self, sid: &str) -> anyhow::Result<()> {
+        let predecessors = self.client.superseded().await?;
+        if predecessors.is_empty() {
+            tracing::warn!("{sid} no predecessor to roll back to");
+            self.log_publisher
+                .error(format!("no rollback target for failed {sid}"))
+                .await;
+            return Ok(());
+        }
+        self.client.clear_predecessor_supersessions().await?;
+        for predecessor in predecessors {
+            let target_sid = short_id(predecessor.deployment_id().as_str()).to_string();
+            tracing::info!("{sid} cleared supersession for {target_sid}");
+            self.log_publisher
+                .info(format!("rolled back {sid}: {target_sid} may reclaim tip"))
+                .await;
         }
         Ok(())
     }

--- a/crates/scs/src/main.rs
+++ b/crates/scs/src/main.rs
@@ -1596,33 +1596,66 @@ impl<'a> CommandHandler<'a> {
             let environment_id = EnvironmentId::from_git_ref(&update.name)
                 .map_err(|e| anyhow!("invalid git ref '{}': {}", update.name, e))?;
 
-            if update.new != null_oid {
-                let deployment_id = ids::DeploymentId::from_bytes(update.new.as_bytes())
-                    .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let deployment = self
-                    .client
-                    .deployment(environment_id.clone(), deployment_id);
-                deployment.set(DeploymentState::Desired).await?;
+            // A git push is a state-machine event, not a state write. SCS
+            // only writes two kinds of rows:
+            //   1. A supersession row from the previous tip to the new
+            //      commit (LWT, written first). The previous tip's own
+            //      worker will observe this and transition itself to
+            //      `Lingering`.
+            //   2. A fresh deployment row in `Pending` state for the new
+            //      commit. Its own worker promotes it to `Desired` once
+            //      the predecessor acknowledges the supersession.
+            //
+            // Ref deletion (update.new == null_oid) is the one exception:
+            // there is no new deployment to create, so we write
+            // `Undesired` directly to the old deployment as a teardown
+            // instruction. No supersession row is created because there
+            // is no superseder.
+            if update.new == null_oid {
+                // Deletion: tell the old deployment's worker to tear down.
+                if update.old != null_oid {
+                    let old_deployment_id = ids::DeploymentId::from_bytes(update.old.as_bytes())
+                        .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
+                    let deployment = self.client.deployment(environment_id, old_deployment_id);
+                    deployment.set(DeploymentState::Undesired).await?;
+                }
+                results.push(update.name.clone());
+                continue;
             }
 
+            let new_deployment_id = ids::DeploymentId::from_bytes(update.new.as_bytes())
+                .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
+
+            // 1. Record supersession first, *before* creating the new
+            //    deployment row. This preserves a key invariant from the
+            //    TLA model: if a worker observes the new deployment, the
+            //    supersession record it needs to see must already be
+            //    visible. Ordering the other way would let the new
+            //    deployment's worker race ahead of its predecessor's
+            //    teardown acknowledgement.
             if update.old != null_oid && update.old != update.new {
-                let state = if update.new == null_oid {
-                    DeploymentState::Undesired
-                } else {
-                    DeploymentState::Lingering
-                };
                 let old_deployment_id = ids::DeploymentId::from_bytes(update.old.as_bytes())
                     .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let deployment = self.client.deployment(environment_id, old_deployment_id);
-                let new_deployment_id = ids::DeploymentId::from_bytes(update.new.as_bytes())
-                    .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let (r1, r2) = futures::join!(
-                    deployment.set(state),
-                    deployment.mark_superseded_by(&new_deployment_id),
-                );
-                r1?;
-                r2?;
+                let predecessor = self
+                    .client
+                    .deployment(environment_id.clone(), old_deployment_id);
+                if let Err(e) = predecessor.mark_superseded_by(&new_deployment_id).await {
+                    // A concurrent push won the LWT. Git's fast-forward
+                    // check should have prevented this, but if it leaks
+                    // through, surface it rather than silently
+                    // overwriting.
+                    return Err(anyhow!(
+                        "failed to record supersession for {}: {e}",
+                        update.name
+                    ));
+                }
             }
+
+            // 2. Create the new deployment as `Pending`. Its worker will
+            //    promote it to `Desired` once the predecessor (if any)
+            //    reaches `Lingering`.
+            let deployment = self.client.deployment(environment_id, new_deployment_id);
+            deployment.set(DeploymentState::Pending).await?;
 
             results.push(update.name.clone());
         }
@@ -1686,24 +1719,35 @@ impl<'a> CommandHandler<'a> {
     async fn collect_refs(&self) -> anyhow::Result<Vec<Reference>> {
         let mut refs = vec![];
 
+        // The tip of an environment is the unique deployment whose state
+        // is live (not `Undesired`/`Failed`/`Down`) AND has no
+        // supersession row pointing at it. This matches the invariant
+        // verified in the TLA model (`tla/DeploymentEngine.tla`,
+        // `AtMostOneActive`). Ordinarily there is exactly one such
+        // deployment per environment; during brief windows (e.g. right
+        // after a rollback clears a supersession and before the
+        // predecessor's worker promotes itself back to `Desired`) there
+        // can be a `Lingering` with no superseder — we still advertise
+        // its commit as the ref.
         let mut deployments = self.client.active_deployments().await?;
         while let Some(deployment) = deployments.next().await {
             let deployment = deployment?;
 
-            // Filter out deployments that are not the current head of
-            // their environment:
-            //   * Undesired/Lingering — an older deployment being torn
-            //     down or waiting to be.
-            //   * Failed — this deployment is terminal; either there is a
-            //     rollback `Desired` deployment in the same env (which
-            //     would otherwise produce a duplicate ref), or this env
-            //     genuinely has no working HEAD.
-            // `Failing` is kept: it's an actively-reconciled deployment
-            // that still represents the env's latest intent.
             if matches!(
                 deployment.state,
-                DeploymentState::Undesired | DeploymentState::Lingering | DeploymentState::Failed
+                DeploymentState::Undesired | DeploymentState::Down | DeploymentState::Failed
             ) {
+                continue;
+            }
+
+            let deployment_client = self.client.deployment(
+                deployment.environment.clone(),
+                deployment.deployment.clone(),
+            );
+            if deployment_client.get_superseding().await?.is_some() {
+                // Something has superseded this deployment; a newer
+                // commit in the same environment will be advertised
+                // instead.
                 continue;
             }
 

--- a/web/src/lib/components/DeploymentState.svelte
+++ b/web/src/lib/components/DeploymentState.svelte
@@ -8,6 +8,10 @@ const styles: Record<DeploymentState, { bg: string; text: string }> = {
         bg: "bg-green-50 border-green-300",
         text: "text-green-700",
     },
+    [DeploymentState.Pending]: {
+        bg: "bg-slate-50 border-slate-300",
+        text: "text-slate-600",
+    },
     [DeploymentState.Desired]: {
         bg: "bg-blue-50 border-blue-300",
         text: "text-blue-700",
@@ -56,6 +60,19 @@ const iconSize = $derived(size === "small" ? 10 : 12);
             stroke-linejoin="round"
         >
             <polyline points="3,8.5 6.5,12 13,4" />
+        </svg>
+    {:else if state === DeploymentState.Pending}
+        <svg
+            class="spinner-slow"
+            width={iconSize}
+            height={iconSize}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+        >
+            <path d="M8 1.5a6.5 6.5 0 1 1-6.5 6.5" />
         </svg>
     {:else if state === DeploymentState.Desired}
         <svg

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -80,6 +80,7 @@ export enum DeploymentState {
   Failed = 'FAILED',
   Failing = 'FAILING',
   Lingering = 'LINGERING',
+  Pending = 'PENDING',
   Undesired = 'UNDESIRED',
   Up = 'UP'
 }

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
@@ -34,6 +34,7 @@ let deployment = $derived(
 );
 
 const liveStates: DeploymentState[] = [
+    DeploymentState.Pending,
     DeploymentState.Desired,
     DeploymentState.Lingering,
     DeploymentState.Undesired,


### PR DESCRIPTION
## Summary

Closes #244.

Implements the TLA+-verified deployment state machine redesign from the `tla-model` branch to eliminate race conditions between the three writers that previously all competed to mutate a deployment's `state` column (SCS on push, DE from its worker loop, API via `makeDeploymentDesired`).

The model enforces two invariants:

1. **Self-transition invariant** — a deployment's state column is only written by its own DE worker (the sole exception being SCS writing `Undesired` directly when a ref is deleted, since no new deployment exists to host a worker).
2. **Supersession-as-universal-coordination** — \"which deployment is the tip of an environment\" is determined by supersession-absence rather than a state predicate. Rollback is just clearing supersession rows; push and Make-Desired write supersessions and let each worker self-transition.

## Changes

- **cdb** — New `Pending` lifecycle state (initial state for a freshly-created deployment, promoted to `Desired` by its own worker once every predecessor it supersedes has acknowledged the supersession). `create_supersession` now uses `INSERT ... IF NOT EXISTS` (LWT) so concurrent pushes can't both win. Added `clear_supersession` / `clear_predecessor_supersessions` and rewrote `make_desired` to only manipulate supersession rows — no more cross-deployment state writes. Rollback path returns `SupersessionConflict` on LWT failure and is idempotent when the same superseder reasserts.
- **scs** — Push handler now writes the supersession row first (LWT), then creates the new deployment as `Pending`. Stopped mutating the predecessor's `state` column. Ref deletion (`new == null_oid`) still writes `Undesired` directly, as the sole permitted exception to self-transition. Tip predicate switched to \"state not in {Undesired, Down, Failed} AND no supersession points at this deployment.\"
- **de** — Worker loop reads `is_superseded` upfront and dispatches on `(state, is_superseded)`:
  - `Pending` → `Down` if superseded; `Desired` once every superseded predecessor is in Lingering/Undesired/Down/Failed.
  - `Desired` / `Failing` / `Up` → self-transition to `Lingering` if superseded.
  - `Lingering` → self-transition back to `Desired` if supersession has been cleared (rollback); otherwise wait for successor to reach `Up` before `Undesired`.
  - `attempt_rollback` replaced with `trigger_rollback`, which only clears predecessor supersessions.
- **api** — `makeDeploymentDesired` now works purely through `cdb::make_desired`'s supersession manipulation. `Pending` state exposed in the GraphQL enum; `schema.graphql` regenerated.
- **web** — `Pending` state rendered with a neutral slate badge and spinner; added to `liveStates` for the per-deployment page.

## Test plan

- [x] Push a new commit to an environment and confirm the new deployment starts in `Pending`, then transitions to `Desired` after the predecessor reports `Lingering`.
- [ ] Push two commits in rapid succession; confirm exactly one supersession wins (LWT) and the loser fails cleanly with a `SupersessionConflict`.
- [ ] Use `makeDeploymentDesired` on an older deployment; confirm it clears supersessions naming it as superseded and the worker self-transitions back from `Lingering` → `Desired`.
- [ ] Delete a ref; confirm the existing deployment transitions to `Undesired` (SCS direct write is preserved as the documented exception).
- [ ] Verify the web UI shows the `PENDING` badge and that it is treated as a live state on the per-deployment page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)