### PR TITLE
feat(de): DE v2 lifecycle model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
 name = "ids"
 version = "0.1.0"
 dependencies = [
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/crates/api/schema.graphql
+++ b/crates/api/schema.graphql
@@ -9,9 +9,6 @@ enum DeploymentState {
   UNDESIRED
   LINGERING
   DESIRED
-  UP
-  FAILING
-  FAILED
 }
 
 enum ResourceMarker {
@@ -65,6 +62,9 @@ type Deployment {
   commit: Commit!
   createdAt: String!
   state: DeploymentState!
+  bootstrapped: Boolean!
+  failures: Int!
+  nonce: String!
   resources: [Resource!]!
   lastLogs(amount: Int): [Log!]!
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -697,21 +697,13 @@ impl Mutation {
             .map_err(|_| field_error("Invalid deployment hash"))?;
         let repo_qid = ids::RepoQid { org, repo };
 
+        // Create a new deployment with a fresh nonce — each deployment
+        // lives once, so re-promoting the same commit creates a new identity.
+        let nonce = ids::DeploymentNonce::random();
         let client = context
             .cdb_client
             .repo(repo_qid)
-            .deployment(env, deployment_id);
-
-        // Verify the deployment exists before mutating anything.
-        if let Err(e) = client.get().await {
-            return Err(match e {
-                cdb::DeploymentQueryError::NotFound => field_error("Deployment not found"),
-                other => {
-                    tracing::error!("Failed to load deployment: {}", other);
-                    internal_error()
-                }
-            });
-        }
+            .deployment(env, deployment_id, nonce);
 
         client.make_desired().await.map_err(|e| {
             tracing::error!("Failed to make deployment desired: {}", e);

--- a/crates/api/src/schema.rs
+++ b/crates/api/src/schema.rs
@@ -274,18 +274,32 @@ impl Environment {
         let deployment_id: ids::DeploymentId = commit
             .parse()
             .map_err(|_| field_error("Invalid commit hash"))?;
-        let deployment = context
-            .cdb_client
-            .find_deployment(&self.qid.repo, &self.qid.environment, &deployment_id)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to find deployment {deployment_id} in {}: {e}",
-                    self.qid
-                );
+        // Find the deployment by commit hash within this environment.
+        // Since nonces make commit hashes non-unique, return the most
+        // recent deployment matching this commit.
+        let repo_client = context.cdb_client.repo(self.qid.repo.clone());
+        let mut stream = repo_client.deployments().await.map_err(|e| {
+            tracing::error!("Failed to list deployments in {}: {e}", self.qid);
+            internal_error()
+        })?;
+        let mut best: Option<cdb::Deployment> = None;
+        while let Some(dep) = stream.next().await {
+            let dep = dep.map_err(|e| {
+                tracing::error!("Failed to load deployment in {}: {e}", self.qid);
                 internal_error()
             })?;
-        Ok(Deployment { deployment })
+            if dep.environment == self.qid.environment && dep.deployment == deployment_id {
+                match &best {
+                    None => best = Some(dep),
+                    Some(b) if dep.created_at > b.created_at => best = Some(dep),
+                    _ => {}
+                }
+            }
+        }
+        match best {
+            Some(deployment) => Ok(Deployment { deployment }),
+            None => Err(field_error("Deployment not found")),
+        }
     }
 
     fn deployments(&self) -> Vec<Deployment> {
@@ -610,6 +624,18 @@ impl Deployment {
         self.deployment.state.into()
     }
 
+    fn bootstrapped(&self) -> bool {
+        self.deployment.bootstrapped
+    }
+
+    fn failures(&self) -> i32 {
+        self.deployment.failures as i32
+    }
+
+    fn nonce(&self) -> String {
+        self.deployment.nonce.to_string()
+    }
+
     async fn resources(&self, context: &Context) -> FieldResult<Vec<Resource>> {
         let namespace = self.deployment.environment_qid().to_string();
         let owner = self.deployment.deployment_qid().to_string();
@@ -861,12 +887,6 @@ pub(crate) enum DeploymentState {
     Lingering,
     #[graphql(name = "DESIRED")]
     Desired,
-    #[graphql(name = "UP")]
-    Up,
-    #[graphql(name = "FAILING")]
-    Failing,
-    #[graphql(name = "FAILED")]
-    Failed,
 }
 
 impl From<cdb::DeploymentState> for DeploymentState {
@@ -876,9 +896,6 @@ impl From<cdb::DeploymentState> for DeploymentState {
             cdb::DeploymentState::Undesired => DeploymentState::Undesired,
             cdb::DeploymentState::Lingering => DeploymentState::Lingering,
             cdb::DeploymentState::Desired => DeploymentState::Desired,
-            cdb::DeploymentState::Up => DeploymentState::Up,
-            cdb::DeploymentState::Failing => DeploymentState::Failing,
-            cdb::DeploymentState::Failed => DeploymentState::Failed,
         }
     }
 }

--- a/crates/cdb/src/client.rs
+++ b/crates/cdb/src/client.rs
@@ -7,10 +7,10 @@ use crate::deployment::{Deployment, InvalidDeploymentState};
 use crate::{DeploymentState, Repository};
 use chrono::{DateTime, Utc};
 use futures_util::stream::BoxStream;
-use futures_util::{Stream, StreamExt, TryStreamExt, pin_mut, stream};
+use futures_util::{Stream, StreamExt, TryStreamExt, stream};
 use gix_hash::ObjectId;
 use gix_object::{Blob, Commit, Kind, Object, Tree, WriteTo};
-use ids::{DeploymentId, EnvironmentId, ParseIdError, RepoQid};
+use ids::{DeploymentId, DeploymentNonce, EnvironmentId, ParseIdError, RepoQid};
 use scylla::{
     client::{session::Session, session_builder::SessionBuilder},
     errors::{
@@ -95,9 +95,12 @@ prepared_statements! {
                 created_at TIMESTAMP,
                 environment_id TEXT,
                 commit_hash BLOB,
+                nonce BIGINT,
                 state TEXT,
-                PRIMARY KEY ((organization, repository), created_at, environment_id, commit_hash)
-            ) WITH CLUSTERING ORDER BY (created_at DESC, environment_id ASC, commit_hash ASC)
+                bootstrapped BOOLEAN,
+                failures INT,
+                PRIMARY KEY ((organization, repository), created_at, environment_id, commit_hash, nonce)
+            ) WITH CLUSTERING ORDER BY (created_at DESC, environment_id ASC, commit_hash ASC, nonce ASC)
         "#,
 
         create_deployments_by_id_table = r#"
@@ -107,8 +110,11 @@ prepared_statements! {
                 repository TEXT,
                 environment_id TEXT,
                 commit_hash BLOB,
+                nonce BIGINT,
                 created_at TIMESTAMP,
                 state TEXT,
+                bootstrapped BOOLEAN,
+                failures INT,
                 PRIMARY KEY ((deployment_qid))
             )
         "#,
@@ -119,8 +125,9 @@ prepared_statements! {
                 repository TEXT,
                 environment_id TEXT,
                 commit_hash BLOB,
+                nonce BIGINT,
                 deployment_qid TEXT,
-                PRIMARY KEY ((organization), repository, environment_id, commit_hash)
+                PRIMARY KEY ((organization), repository, environment_id, commit_hash, nonce)
             )
         "#,
 
@@ -141,8 +148,10 @@ prepared_statements! {
                 repository TEXT,
                 environment_id TEXT,
                 superseding_commit_hash BLOB,
+                superseding_nonce BIGINT,
                 superseded_commit_hash BLOB,
-                PRIMARY KEY ((organization), repository, environment_id, superseded_commit_hash)
+                superseded_nonce BIGINT,
+                PRIMARY KEY ((organization), repository, environment_id, superseded_commit_hash, superseded_nonce)
             )
         "#,
     }
@@ -173,19 +182,19 @@ prepared_statements! {
         "#,
 
         find_deployment_by_qid = r#"
-            SELECT organization, repository, environment_id, commit_hash, created_at, state
+            SELECT organization, repository, environment_id, commit_hash, nonce, created_at, state, bootstrapped, failures
             FROM cdb.deployments_by_id
             WHERE deployment_qid = ?
         "#,
 
         find_deployments_by_qids = r#"
-            SELECT organization, repository, environment_id, commit_hash, created_at, state
+            SELECT organization, repository, environment_id, commit_hash, nonce, created_at, state, bootstrapped, failures
             FROM cdb.deployments_by_id
             WHERE deployment_qid IN ?
         "#,
 
         list_deployments_by_repo = r#"
-            SELECT created_at, environment_id, commit_hash, state
+            SELECT created_at, environment_id, commit_hash, nonce, state, bootstrapped, failures
             FROM cdb.deployments
             WHERE organization = ?
             AND repository = ?
@@ -212,8 +221,8 @@ prepared_statements! {
         "#,
 
         set_deployment = r#"
-            INSERT INTO cdb.deployments (organization, repository, created_at, environment_id, commit_hash, state)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO cdb.deployments (organization, repository, created_at, environment_id, commit_hash, nonce, state, bootstrapped, failures)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
 
         set_deployment_by_id = r#"
@@ -223,15 +232,18 @@ prepared_statements! {
                 repository,
                 environment_id,
                 commit_hash,
+                nonce,
                 created_at,
-                state
+                state,
+                bootstrapped,
+                failures
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         "#,
 
         set_active_deployment = r#"
-            INSERT INTO cdb.active_deployments (organization, repository, environment_id, commit_hash, deployment_qid)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO cdb.active_deployments (organization, repository, environment_id, commit_hash, nonce, deployment_qid)
+            VALUES (?, ?, ?, ?, ?, ?)
         "#,
 
         unset_active_deployment = r#"
@@ -240,35 +252,40 @@ prepared_statements! {
             AND repository = ?
             AND environment_id = ?
             AND commit_hash = ?
+            AND nonce = ?
         "#,
 
         create_supersession = r#"
             INSERT INTO cdb.supersessions (
                 superseding_commit_hash,
+                superseding_nonce,
                 organization,
                 repository,
                 environment_id,
-                superseded_commit_hash
-            ) VALUES (?, ?, ?, ?, ?)
+                superseded_commit_hash,
+                superseded_nonce
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
         "#,
 
-        get_superseded_commits = r#"
-            SELECT superseded_commit_hash
+        get_superseded_deployments = r#"
+            SELECT superseded_commit_hash, superseded_nonce
             FROM cdb.supersessions
             WHERE organization = ?
             AND repository = ?
             AND environment_id = ?
             AND superseding_commit_hash = ?
+            AND superseding_nonce = ?
             ALLOW FILTERING
         "#,
 
-        get_superseding_commit = r#"
-            SELECT superseding_commit_hash
+        get_superseding_deployment = r#"
+            SELECT superseding_commit_hash, superseding_nonce
             FROM cdb.supersessions
             WHERE organization = ?
             AND repository = ?
             AND environment_id = ?
             AND superseded_commit_hash = ?
+            AND superseded_nonce = ?
         "#,
     }
 }
@@ -340,13 +357,17 @@ impl ClientBuilder {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn deployment_from_row(
     organization: String,
     repository: String,
     environment_id: String,
     commit_hash: Vec<u8>,
+    nonce: i64,
     created_at: DateTime<Utc>,
     state: String,
+    bootstrapped: Option<bool>,
+    failures: Option<i32>,
 ) -> Result<Deployment, DeploymentQueryError> {
     let deploy_id =
         DeploymentId::from_bytes(&commit_hash).map_err(|_| DeploymentQueryError::NotFound)?;
@@ -357,8 +378,11 @@ fn deployment_from_row(
         repo: RepoQid::new(org, repo),
         environment,
         deployment: deploy_id,
+        nonce: DeploymentNonce::from_u64(nonce as u64),
         created_at,
         state: state.parse()?,
+        bootstrapped: bootstrapped.unwrap_or(false),
+        failures: failures.unwrap_or(0) as u32,
     })
 }
 
@@ -452,10 +476,11 @@ impl Client {
         repo: &RepoQid,
         environment: &EnvironmentId,
         deployment: &DeploymentId,
+        nonce: &DeploymentNonce,
     ) -> Result<Deployment, DeploymentQueryError> {
         let qid = repo
             .environment(environment.clone())
-            .deployment(deployment.clone())
+            .deployment(deployment.clone(), *nonce)
             .to_string();
         let pager = self
             .session
@@ -463,7 +488,17 @@ impl Client {
             .await?;
 
         match pager
-            .rows_stream::<(String, String, String, Vec<u8>, DateTime<Utc>, String)>()?
+            .rows_stream::<(
+                String,
+                String,
+                String,
+                Vec<u8>,
+                i64,
+                DateTime<Utc>,
+                String,
+                Option<bool>,
+                Option<i32>,
+            )>()?
             .next()
             .await
         {
@@ -474,8 +509,11 @@ impl Client {
                 repository,
                 environment_id,
                 commit_hash,
+                nonce_val,
                 created_at,
                 state,
+                bootstrapped,
+                failures,
             ))) => {
                 if organization != repo.org.as_str() || repository != repo.repo.as_str() {
                     return Err(DeploymentQueryError::NotFound);
@@ -485,8 +523,11 @@ impl Client {
                     repository,
                     environment_id,
                     commit_hash,
+                    nonce_val,
                     created_at,
                     state,
+                    bootstrapped,
+                    failures,
                 )
             }
         }
@@ -499,6 +540,7 @@ impl Client {
         let deployment_qid = deployment.deployment_qid().to_string();
         let repo = &deployment.repo;
         let commit_hash = ObjectId::from_bytes_or_panic(&deployment.deployment.to_bytes());
+        let nonce_val = deployment.nonce.as_u64() as i64;
         let (dep, dep_by_id, active_dep) = futures::join!(
             self.session.execute_unpaged(
                 &self.statements.set_deployment,
@@ -508,7 +550,10 @@ impl Client {
                     deployment.created_at,
                     deployment.environment.as_str(),
                     commit_hash.as_slice(),
+                    nonce_val,
                     deployment.state.to_string(),
+                    deployment.bootstrapped,
+                    deployment.failures as i32,
                 ),
             ),
             self.session.execute_unpaged(
@@ -519,8 +564,11 @@ impl Client {
                     repo.repo.as_str(),
                     deployment.environment.as_str(),
                     commit_hash.as_slice(),
+                    nonce_val,
                     deployment.created_at,
                     deployment.state.to_string(),
+                    deployment.bootstrapped,
+                    deployment.failures as i32,
                 ),
             ),
             async {
@@ -533,6 +581,7 @@ impl Client {
                                 repo.repo.as_str(),
                                 deployment.environment.as_str(),
                                 commit_hash.as_slice(),
+                                nonce_val,
                             ),
                         )
                         .await
@@ -545,6 +594,7 @@ impl Client {
                                 repo.repo.as_str(),
                                 deployment.environment.as_str(),
                                 commit_hash.as_slice(),
+                                nonce_val,
                                 deployment_qid.as_str(),
                             ),
                         )
@@ -585,16 +635,39 @@ impl Client {
             .await?;
 
         Ok(deployments
-            .rows_stream::<(String, String, String, Vec<u8>, DateTime<Utc>, String)>()?
+            .rows_stream::<(
+                String,
+                String,
+                String,
+                Vec<u8>,
+                i64,
+                DateTime<Utc>,
+                String,
+                Option<bool>,
+                Option<i32>,
+            )>()?
             .map(|r| {
-                let (organization, repository, environment_id, commit_hash, created_at, state) = r?;
+                let (
+                    organization,
+                    repository,
+                    environment_id,
+                    commit_hash,
+                    nonce,
+                    created_at,
+                    state,
+                    bootstrapped,
+                    failures,
+                ) = r?;
                 deployment_from_row(
                     organization,
                     repository,
                     environment_id,
                     commit_hash,
+                    nonce,
                     created_at,
                     state,
+                    bootstrapped,
+                    failures,
                 )
             })
             .boxed())
@@ -639,11 +712,13 @@ impl RepositoryClient {
         &self,
         environment: EnvironmentId,
         deployment: DeploymentId,
+        nonce: DeploymentNonce,
     ) -> DeploymentClient {
         DeploymentClient {
             repo: self.clone(),
             environment,
             deployment,
+            nonce,
         }
     }
 
@@ -768,16 +843,39 @@ impl RepositoryClient {
             .await?;
 
         Ok(deployments
-            .rows_stream::<(String, String, String, Vec<u8>, DateTime<Utc>, String)>()?
+            .rows_stream::<(
+                String,
+                String,
+                String,
+                Vec<u8>,
+                i64,
+                DateTime<Utc>,
+                String,
+                Option<bool>,
+                Option<i32>,
+            )>()?
             .map(|r| {
-                let (organization, repository, environment_id, commit_hash, created_at, state) = r?;
+                let (
+                    organization,
+                    repository,
+                    environment_id,
+                    commit_hash,
+                    nonce,
+                    created_at,
+                    state,
+                    bootstrapped,
+                    failures,
+                ) = r?;
                 deployment_from_row(
                     organization,
                     repository,
                     environment_id,
                     commit_hash,
+                    nonce,
                     created_at,
                     state,
+                    bootstrapped,
+                    failures,
                 )
             })
             .boxed())
@@ -797,19 +895,40 @@ impl RepositoryClient {
             .await?;
 
         let repo = self.name.clone();
-        Ok(pager
-            .rows_stream::<(DateTime<Utc>, String, Vec<u8>, String)>()?
-            .map(move |r| {
-                let (created_at, environment_id, commit_hash, state) = r?;
-                deployment_from_row(
-                    repo.org.to_string(),
-                    repo.repo.to_string(),
-                    environment_id,
-                    commit_hash,
-                    created_at,
-                    state,
-                )
-            }))
+        Ok(
+            pager
+                .rows_stream::<(
+                    DateTime<Utc>,
+                    String,
+                    Vec<u8>,
+                    i64,
+                    String,
+                    Option<bool>,
+                    Option<i32>,
+                )>()?
+                .map(move |r| {
+                    let (
+                        created_at,
+                        environment_id,
+                        commit_hash,
+                        nonce,
+                        state,
+                        bootstrapped,
+                        failures,
+                    ) = r?;
+                    deployment_from_row(
+                        repo.org.to_string(),
+                        repo.repo.to_string(),
+                        environment_id,
+                        commit_hash,
+                        nonce,
+                        created_at,
+                        state,
+                        bootstrapped,
+                        failures,
+                    )
+                }),
+        )
     }
 }
 
@@ -822,6 +941,7 @@ pub struct DeploymentClient {
     repo: RepositoryClient,
     environment: EnvironmentId,
     deployment: DeploymentId,
+    nonce: DeploymentNonce,
 }
 
 impl DeploymentClient {
@@ -837,11 +957,15 @@ impl DeploymentClient {
         &self.deployment
     }
 
+    pub fn deployment_nonce(&self) -> &DeploymentNonce {
+        &self.nonce
+    }
+
     pub fn deployment_qid(&self) -> ids::DeploymentQid {
         self.repo
             .name
             .environment(self.environment.clone())
-            .deployment(self.deployment.clone())
+            .deployment(self.deployment.clone(), self.nonce)
     }
 
     pub fn environment_qid(&self) -> ids::EnvironmentQid {
@@ -855,7 +979,12 @@ impl DeploymentClient {
     pub async fn get(&self) -> Result<Deployment, DeploymentQueryError> {
         self.repo
             .client
-            .find_deployment(&self.repo.name, &self.environment, &self.deployment)
+            .find_deployment(
+                &self.repo.name,
+                &self.environment,
+                &self.deployment,
+                &self.nonce,
+            )
             .await
     }
 
@@ -877,11 +1006,33 @@ impl DeploymentClient {
             repo: self.repo.name.clone(),
             environment: self.environment.clone(),
             deployment: self.deployment.clone(),
+            nonce: self.nonce,
             created_at: prev_state
                 .as_ref()
                 .map(|s| s.created_at)
                 .unwrap_or_else(Utc::now),
             state,
+            bootstrapped: prev_state.as_ref().map(|s| s.bootstrapped).unwrap_or(false),
+            failures: prev_state.as_ref().map(|s| s.failures).unwrap_or(0),
+        };
+
+        self.repo.client.set_deployment(deployment).await?;
+
+        Ok(())
+    }
+
+    /// Update the bootstrapped flag and failures counter without changing the state.
+    pub async fn set_progress(
+        &self,
+        bootstrapped: bool,
+        failures: u32,
+    ) -> Result<(), SetDeploymentError> {
+        let prev = self.get().await?;
+
+        let deployment = Deployment {
+            bootstrapped,
+            failures,
+            ..prev
         };
 
         self.repo.client.set_deployment(deployment).await?;
@@ -979,6 +1130,7 @@ impl DeploymentClient {
     pub async fn mark_superseded_by(
         &self,
         superseding_commit: &DeploymentId,
+        superseding_nonce: &DeploymentNonce,
     ) -> Result<(), SetDeploymentError> {
         let superseding_oid = ObjectId::from_bytes_or_panic(&superseding_commit.to_bytes());
         let this_oid = self.commit_hash();
@@ -989,10 +1141,12 @@ impl DeploymentClient {
                 &self.repo.client.statements.create_supersession,
                 (
                     superseding_oid.as_bytes(),
+                    superseding_nonce.as_u64() as i64,
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
                     self.environment.as_str(),
                     this_oid.as_bytes(),
+                    self.nonce.as_u64() as i64,
                 ),
             )
             .await?;
@@ -1006,25 +1160,32 @@ impl DeploymentClient {
             .client
             .session
             .execute_iter(
-                self.repo.client.statements.get_superseded_commits.clone(),
+                self.repo
+                    .client
+                    .statements
+                    .get_superseded_deployments
+                    .clone(),
                 (
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
                     self.environment.as_str(),
                     this_oid.as_bytes(),
+                    self.nonce.as_u64() as i64,
                 ),
             )
             .await?;
 
         let superseded = pager
-            .rows_stream::<(Vec<u8>,)>()?
+            .rows_stream::<(Vec<u8>, i64)>()?
             .map(|row| {
-                let (commit_hash,) = row?;
+                let (commit_hash, nonce) = row?;
                 let deploy_id = DeploymentId::from_bytes(&commit_hash)
                     .map_err(|_| DeploymentQueryError::NotFound)?;
-                Ok::<_, DeploymentQueryError>(
-                    self.repo.deployment(self.environment.clone(), deploy_id),
-                )
+                Ok::<_, DeploymentQueryError>(self.repo.deployment(
+                    self.environment.clone(),
+                    deploy_id,
+                    DeploymentNonce::from_u64(nonce as u64),
+                ))
             })
             .try_collect::<Vec<_>>()
             .await?;
@@ -1032,78 +1193,13 @@ impl DeploymentClient {
         Ok(superseded)
     }
 
-    /// Pick a suitable deployment to roll back to after this deployment has
-    /// failed fatally.
-    ///
-    /// The primary candidate set is the deployments that this one directly
-    /// superseded (from the supersessions table). If several exist (e.g. a
-    /// racey double-push produced multiple superseded predecessors), the
-    /// most recent by `created_at` wins. Any predecessor that is itself
-    /// `Failing` or `Failed` is skipped.
-    ///
-    /// If no direct predecessor is a viable rollback target, falls back to
-    /// the most recent non-failed deployment in the same environment,
-    /// excluding `self`.
-    ///
-    /// Returns `None` if no suitable candidate exists.
-    pub async fn rollback_target(&self) -> Result<Option<Deployment>, DeploymentQueryError> {
-        // Primary: deployments we superseded directly.
-        let superseded = self.superseded().await?;
-        let mut candidates: Vec<Deployment> = Vec::new();
-        for client in superseded {
-            match client.get().await {
-                Ok(dep) => {
-                    if !matches!(
-                        dep.state,
-                        DeploymentState::Failed | DeploymentState::Failing
-                    ) {
-                        candidates.push(dep);
-                    }
-                }
-                Err(DeploymentQueryError::NotFound) => {}
-                Err(e) => return Err(e),
-            }
-        }
-        if let Some(best) = candidates.into_iter().max_by_key(|d| d.created_at) {
-            return Ok(Some(best));
-        }
-
-        // Fallback: most recent deployment in the same environment that
-        // isn't failing/failed or self.
-        let stream = self.repo.deployments().await?;
-        pin_mut!(stream);
-        let mut best: Option<Deployment> = None;
-        while let Some(dep) = stream.next().await {
-            let dep = dep?;
-            if dep.environment != self.environment {
-                continue;
-            }
-            if dep.deployment == self.deployment {
-                continue;
-            }
-            if matches!(
-                dep.state,
-                DeploymentState::Failed | DeploymentState::Failing
-            ) {
-                continue;
-            }
-            match &best {
-                None => best = Some(dep),
-                Some(b) if dep.created_at > b.created_at => best = Some(dep),
-                _ => {}
-            }
-        }
-        Ok(best)
-    }
-
     /// Transition this deployment into the `Desired` state, taking over
     /// from whatever deployment is currently active in the same
     /// environment.
     ///
-    /// Any currently-active deployment (`Desired`, `Up`, or `Failing`) in
-    /// this environment is transitioned to `Lingering` and a supersession
-    /// row is recorded linking it to this deployment. `Failed` and
-    /// `Lingering`/`Undesired`/`Down` deployments are left untouched.
+    /// Any currently-active (`Desired`) deployment in this environment is
+    /// transitioned to `Lingering` and a supersession row is recorded
+    /// linking it to this deployment.
     pub async fn make_desired(&self) -> Result<(), SetDeploymentError> {
         // Find currently-active deployments in the same environment.
         let mut active: Vec<Deployment> = Vec::new();
@@ -1113,7 +1209,7 @@ impl DeploymentClient {
             if dep.environment != self.environment {
                 continue;
             }
-            if dep.deployment == self.deployment {
+            if dep.deployment == self.deployment && dep.nonce == self.nonce {
                 continue;
             }
             if dep.state.is_active() {
@@ -1123,12 +1219,12 @@ impl DeploymentClient {
 
         // Mark each as Lingering and record the supersession.
         for dep in active {
-            let predecessor = self
-                .repo
-                .deployment(dep.environment.clone(), dep.deployment.clone());
+            let predecessor =
+                self.repo
+                    .deployment(dep.environment.clone(), dep.deployment.clone(), dep.nonce);
             let (r1, r2) = futures::join!(
                 predecessor.set(DeploymentState::Lingering),
-                predecessor.mark_superseded_by(&self.deployment),
+                predecessor.mark_superseded_by(&self.deployment, &self.nonce),
             );
             r1?;
             r2?;
@@ -1145,22 +1241,27 @@ impl DeploymentClient {
             .client
             .session
             .execute_unpaged(
-                &self.repo.client.statements.get_superseding_commit,
+                &self.repo.client.statements.get_superseding_deployment,
                 (
                     self.repo.name.org.as_str(),
                     self.repo.name.repo.as_str(),
                     self.environment.as_str(),
                     this_oid.as_bytes(),
+                    self.nonce.as_u64() as i64,
                 ),
             )
             .await?;
 
         Ok(r.into_rows_result()?
-            .single_row::<(Vec<u8>,)>()
+            .single_row::<(Vec<u8>, i64)>()
             .ok()
-            .and_then(|(superseding,)| {
+            .and_then(|(superseding, nonce)| {
                 let deploy_id = DeploymentId::from_bytes(&superseding).ok()?;
-                Some(self.repo.deployment(self.environment.clone(), deploy_id))
+                Some(self.repo.deployment(
+                    self.environment.clone(),
+                    deploy_id,
+                    DeploymentNonce::from_u64(nonce as u64),
+                ))
             }))
     }
 }

--- a/crates/cdb/src/deployment.rs
+++ b/crates/cdb/src/deployment.rs
@@ -1,12 +1,15 @@
 use std::{fmt, str::FromStr};
 
 use chrono::{DateTime, Utc};
-use ids::{DeploymentId, DeploymentQid, EnvironmentId, EnvironmentQid, RepoQid};
+use ids::{DeploymentId, DeploymentNonce, DeploymentQid, EnvironmentId, EnvironmentQid, RepoQid};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// A deployment is a revision of an environment. It represents a specific commit
 /// being applied to a particular environment (Git ref) within a repository.
+///
+/// The deployment identity is the pair `(commit_hash, nonce)`, allowing the same
+/// commit to be deployed multiple times.
 #[derive(Clone, Debug)]
 pub struct Deployment {
     /// The repository this deployment belongs to.
@@ -15,16 +18,24 @@ pub struct Deployment {
     pub environment: EnvironmentId,
     /// The deployment ID (commit hash).
     pub deployment: DeploymentId,
+    /// Random nonce distinguishing deployments of the same commit.
+    pub nonce: DeploymentNonce,
     /// When this deployment was created.
     pub created_at: DateTime<Utc>,
-    /// Current lifecycle state.
+    /// Current lifecycle label.
     pub state: DeploymentState,
+    /// Whether the DAG has been fully explored to stability at least once.
+    pub bootstrapped: bool,
+    /// Consecutive failed iteration count (for exponential backoff).
+    /// Resets to 0 on success. Observational only — does not alter lifecycle transitions.
+    pub failures: u32,
 }
 
 impl Deployment {
     /// Returns the fully qualified deployment identifier.
     pub fn deployment_qid(&self) -> DeploymentQid {
-        self.environment_qid().deployment(self.deployment.clone())
+        self.environment_qid()
+            .deployment(self.deployment.clone(), self.nonce)
     }
 
     /// Returns the fully qualified environment identifier.
@@ -40,24 +51,14 @@ pub enum DeploymentState {
     Undesired,
     Lingering,
     Desired,
-    Up,
-    Failing,
-    Failed,
 }
 
 impl DeploymentState {
     /// Whether a deployment in this state is considered "active" for
     /// supersession purposes — i.e. a new `Desired` deployment arriving in
     /// the same environment should transition it to `Lingering`.
-    ///
-    /// `Failed` is intentionally excluded: once a deployment has failed
-    /// fatally we may have already rolled back to a prior deployment, so it
-    /// is treated as a terminal state that does not get re-lingered.
     pub fn is_active(self) -> bool {
-        matches!(
-            self,
-            DeploymentState::Desired | DeploymentState::Up | DeploymentState::Failing
-        )
+        matches!(self, DeploymentState::Desired)
     }
 }
 
@@ -68,9 +69,6 @@ impl fmt::Display for DeploymentState {
             Self::Undesired => write!(f, "UNDESIRED"),
             Self::Lingering => write!(f, "LINGERING"),
             Self::Desired => write!(f, "DESIRED"),
-            Self::Up => write!(f, "UP"),
-            Self::Failing => write!(f, "FAILING"),
-            Self::Failed => write!(f, "FAILED"),
         }
     }
 }
@@ -88,9 +86,6 @@ impl FromStr for DeploymentState {
             "UNDESIRED" => Ok(DeploymentState::Undesired),
             "LINGERING" => Ok(DeploymentState::Lingering),
             "DESIRED" => Ok(DeploymentState::Desired),
-            "UP" => Ok(DeploymentState::Up),
-            "FAILING" => Ok(DeploymentState::Failing),
-            "FAILED" => Ok(DeploymentState::Failed),
             v => Err(InvalidDeploymentState(v.to_string())),
         }
     }

--- a/crates/de/spec/.gitignore
+++ b/crates/de/spec/.gitignore
@@ -1,0 +1,3 @@
+states/
+*_TTrace_*.tla
+*_TTrace_*.bin

--- a/crates/de/spec/DeploymentEngine.cfg
+++ b/crates/de/spec/DeploymentEngine.cfg
@@ -1,0 +1,9 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANT MaxDeployments = 3
+CONSTANT AllResources = {r1, r2, r3}
+
+INVARIANT TypeOK
+INVARIANT CurrentResourcesSafe
+INVARIANT NoResourceContention

--- a/crates/de/spec/DeploymentEngine.tla
+++ b/crates/de/spec/DeploymentEngine.tla
@@ -6,7 +6,12 @@ EXTENDS Naturals, FiniteSets
 
 CONSTANTS
     MaxDeployments,  \* Maximum number of deployments (finite for model checking)
-    AllResources     \* Set of all possible resource identifiers
+    AllResources,    \* Set of all possible resource identifiers
+    Deps             \* [AllResources -> SUBSET AllResources] — global dependency relation
+                     \* Deps[r] = set of resources that r depends on (must be acyclic)
+
+ASSUME \A r \in AllResources : Deps[r] \subseteq AllResources
+ASSUME \A r \in AllResources : r \notin Deps[r]
 
 VARIABLES
     state,          \* Lifecycle label per deployment: "none" | "DESIRED" | "LINGERING" | "UNDESIRED" | "DOWN"
@@ -41,6 +46,20 @@ CurrentResources ==
 \* Resources a deployment must destroy during teardown.
 Teardown(d) == res[d] \ CurrentResources
 
+\* Effective dependencies of resource r within deployment d's scope.
+\* D(r, µ) in the design doc — only deps that are in the deployment's resource set.
+EffDeps(r, d) == Deps[r] \cap res[d]
+
+\* Whether resource r can be safely destroyed. A resource is safe to destroy
+\* when no living, non-Current resource (across any active deployment) depends
+\* on it. Resources in CurrentResources are excluded because Current has adopted
+\* them — their dependencies reflect Current's DAG, where r ∉ R(Current).
+CanDestroy(r) ==
+    ~\E d2 \in 1..num :
+        state[d2] \notin {"none", "DOWN"} /\
+        \E r2 \in ((res[d2] \ CurrentResources) \cap (alive \ {r})) :
+            r \in EffDeps(r2, d2)
+
 \* ---------------------------------------------------------------------------
 \* Initial state
 \* ---------------------------------------------------------------------------
@@ -71,11 +90,12 @@ CreateDeployment ==
         /\ num'   = new
         /\ UNCHANGED alive
 
-\* DESIRED: create a resource that should exist but doesn't yet.
+\* DESIRED: create a resource whose dependencies are all alive.
 DesiredCreate(d) ==
     /\ state[d] = "DESIRED"
     /\ ~Superseded(d)
     /\ \E r \in res[d] \ alive :
+        /\ EffDeps(r, d) \subseteq alive
         /\ alive' = alive \cup {r}
         /\ UNCHANGED <<state, boot, res, sup, num>>
 
@@ -102,10 +122,11 @@ LingeringToUndesired(d) ==
     /\ state' = [state EXCEPT ![d] = "UNDESIRED"]
     /\ UNCHANGED <<boot, res, sup, num, alive>>
 
-\* UNDESIRED: destroy a resource no longer desired by Current.
+\* UNDESIRED: destroy a resource with no living dependents.
 UndesiredDestroy(d) ==
     /\ state[d] = "UNDESIRED"
     /\ \E r \in Teardown(d) \cap alive :
+        /\ CanDestroy(r)
         /\ alive' = alive \ {r}
         /\ UNCHANGED <<state, boot, res, sup, num>>
 

--- a/crates/de/spec/DeploymentEngine.tla
+++ b/crates/de/spec/DeploymentEngine.tla
@@ -1,0 +1,181 @@
+---- MODULE DeploymentEngine ----
+\* TLA+ specification of the Deployment Engine v2 lifecycle model.
+\* See DE_V2.md for the design document.
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    MaxDeployments,  \* Maximum number of deployments (finite for model checking)
+    AllResources     \* Set of all possible resource identifiers
+
+VARIABLES
+    state,          \* Lifecycle label per deployment: "none" | "DESIRED" | "LINGERING" | "UNDESIRED" | "DOWN"
+    boot,           \* Bootstrapped flag per deployment
+    res,            \* Resource set per deployment (R(µ) in the design doc)
+    sup,            \* Supersession: maps deployment to its successor (0 = none)
+    num,            \* Number of deployments created so far
+    alive           \* Set of resources that currently exist in reality
+
+vars == <<state, boot, res, sup, num, alive>>
+
+Ids == 1..MaxDeployments
+Labels == {"none", "DESIRED", "LINGERING", "UNDESIRED", "DOWN"}
+
+\* ---------------------------------------------------------------------------
+\* Derived state
+\* ---------------------------------------------------------------------------
+
+Superseded(d) == sup[d] # 0
+
+\* Current deployment (the unsuperseded one), or 0 if none exist.
+Current ==
+    IF num = 0 THEN 0
+    ELSE CHOOSE d \in 1..num : ~Superseded(d)
+
+CurrentBootstrapped ==
+    Current # 0 /\ boot[Current]
+
+CurrentResources ==
+    IF Current = 0 THEN {} ELSE res[Current]
+
+\* Resources a deployment must destroy during teardown.
+Teardown(d) == res[d] \ CurrentResources
+
+\* ---------------------------------------------------------------------------
+\* Initial state
+\* ---------------------------------------------------------------------------
+
+Init ==
+    /\ state = [d \in Ids |-> "none"]
+    /\ boot  = [d \in Ids |-> FALSE]
+    /\ res   = [d \in Ids |-> {}]
+    /\ sup   = [d \in Ids |-> 0]
+    /\ num   = 0
+    /\ alive = {}
+
+\* ---------------------------------------------------------------------------
+\* Actions
+\* ---------------------------------------------------------------------------
+
+\* A new deployment arrives with an arbitrary set of resources.
+CreateDeployment ==
+    /\ num < MaxDeployments
+    /\ \E resources \in SUBSET AllResources :
+        LET new == num + 1 IN
+        /\ state' = [state EXCEPT ![new] = "DESIRED"]
+        /\ boot'  = boot
+        /\ res'   = [res EXCEPT ![new] = resources]
+        /\ sup'   = IF num > 0
+                     THEN [sup EXCEPT ![Current] = new]
+                     ELSE sup
+        /\ num'   = new
+        /\ UNCHANGED alive
+
+\* DESIRED: create a resource that should exist but doesn't yet.
+DesiredCreate(d) ==
+    /\ state[d] = "DESIRED"
+    /\ ~Superseded(d)
+    /\ \E r \in res[d] \ alive :
+        /\ alive' = alive \cup {r}
+        /\ UNCHANGED <<state, boot, res, sup, num>>
+
+\* DESIRED: all resources converged — become bootstrapped.
+DesiredBootstrap(d) ==
+    /\ state[d] = "DESIRED"
+    /\ ~Superseded(d)
+    /\ res[d] \subseteq alive
+    /\ ~boot[d]
+    /\ boot' = [boot EXCEPT ![d] = TRUE]
+    /\ UNCHANGED <<state, res, sup, num, alive>>
+
+\* DESIRED -> LINGERING on supersession.
+DesiredToLingering(d) ==
+    /\ state[d] = "DESIRED"
+    /\ Superseded(d)
+    /\ state' = [state EXCEPT ![d] = "LINGERING"]
+    /\ UNCHANGED <<boot, res, sup, num, alive>>
+
+\* LINGERING -> UNDESIRED when Current is bootstrapped.
+LingeringToUndesired(d) ==
+    /\ state[d] = "LINGERING"
+    /\ CurrentBootstrapped
+    /\ state' = [state EXCEPT ![d] = "UNDESIRED"]
+    /\ UNCHANGED <<boot, res, sup, num, alive>>
+
+\* UNDESIRED: destroy a resource no longer desired by Current.
+UndesiredDestroy(d) ==
+    /\ state[d] = "UNDESIRED"
+    /\ \E r \in Teardown(d) \cap alive :
+        /\ alive' = alive \ {r}
+        /\ UNCHANGED <<state, boot, res, sup, num>>
+
+\* UNDESIRED -> DOWN when teardown is complete.
+UndesiredToDown(d) ==
+    /\ state[d] = "UNDESIRED"
+    /\ Teardown(d) \cap alive = {}
+    /\ state' = [state EXCEPT ![d] = "DOWN"]
+    /\ UNCHANGED <<boot, res, sup, num, alive>>
+
+\* ---------------------------------------------------------------------------
+\* Specification
+\* ---------------------------------------------------------------------------
+
+Next ==
+    \/ CreateDeployment
+    \/ \E d \in 1..num :
+        \/ DesiredCreate(d)
+        \/ DesiredBootstrap(d)
+        \/ DesiredToLingering(d)
+        \/ LingeringToUndesired(d)
+        \/ UndesiredDestroy(d)
+        \/ UndesiredToDown(d)
+
+Spec == Init /\ [][Next]_vars
+
+\* Fair specification for liveness checking.
+\* No fairness on CreateDeployment — it models an external event.
+FairSpec == Spec /\ \A d \in Ids :
+    /\ WF_vars(DesiredCreate(d))
+    /\ WF_vars(DesiredBootstrap(d))
+    /\ WF_vars(DesiredToLingering(d))
+    /\ WF_vars(LingeringToUndesired(d))
+    /\ WF_vars(UndesiredDestroy(d))
+    /\ WF_vars(UndesiredToDown(d))
+
+\* ---------------------------------------------------------------------------
+\* Invariants (safety)
+\* ---------------------------------------------------------------------------
+
+TypeOK ==
+    /\ state \in [Ids -> Labels]
+    /\ boot  \in [Ids -> BOOLEAN]
+    /\ res   \in [Ids -> SUBSET AllResources]
+    /\ sup   \in [Ids -> 0..MaxDeployments]
+    /\ num   \in 0..MaxDeployments
+    /\ alive \subseteq AllResources
+
+\* A bootstrapped Current deployment's resources are always alive.
+\* UNDESIRED deployments only destroy Teardown(d) = R(d) \ R(Current),
+\* so Current's resources are never touched.
+CurrentResourcesSafe ==
+    CurrentBootstrapped => CurrentResources \subseteq alive
+
+\* No two deployments can simultaneously create/adopt resources.
+\* Only a DESIRED, un-superseded (Current) deployment operates on resources,
+\* and there can be at most one such deployment at any time.
+NoResourceContention ==
+    \A d1, d2 \in 1..num :
+        (state[d1] = "DESIRED" /\ ~Superseded(d1) /\
+         state[d2] = "DESIRED" /\ ~Superseded(d2))
+        => d1 = d2
+
+\* ---------------------------------------------------------------------------
+\* Temporal properties (require FairSpec)
+\* ---------------------------------------------------------------------------
+
+\* Every superseded deployment eventually reaches DOWN.
+AllSupersededReachDown ==
+    \A d \in Ids :
+        (state[d] # "none" /\ Superseded(d)) ~> (state[d] = "DOWN")
+
+====

--- a/crates/de/spec/MC.cfg
+++ b/crates/de/spec/MC.cfg
@@ -1,4 +1,4 @@
-SPECIFICATION Spec
+SPECIFICATION FairSpec
 CHECK_DEADLOCK FALSE
 
 CONSTANT r1 = r1
@@ -11,3 +11,5 @@ CONSTANT Deps <- const_Deps
 INVARIANT TypeOK
 INVARIANT CurrentResourcesSafe
 INVARIANT NoResourceContention
+
+PROPERTY AllSupersededReachDown

--- a/crates/de/spec/MC.cfg
+++ b/crates/de/spec/MC.cfg
@@ -1,8 +1,12 @@
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 
+CONSTANT r1 = r1
+CONSTANT r2 = r2
+CONSTANT r3 = r3
 CONSTANT MaxDeployments = 3
-CONSTANT AllResources = {r1, r2, r3}
+CONSTANT AllResources <- const_AllResources
+CONSTANT Deps <- const_Deps
 
 INVARIANT TypeOK
 INVARIANT CurrentResourcesSafe

--- a/crates/de/spec/MC.tla
+++ b/crates/de/spec/MC.tla
@@ -1,0 +1,12 @@
+---- MODULE MC ----
+\* Model-checking configuration for DeploymentEngine.
+EXTENDS DeploymentEngine, TLC
+
+CONSTANTS r1, r2, r3
+
+const_AllResources == {r1, r2, r3}
+
+\* Dependency chain: r3 depends on r2, r2 depends on r1, r1 has no deps.
+const_Deps == (r1 :> {} @@ r2 :> {r1} @@ r3 :> {r2})
+
+====

--- a/crates/de/spec/README.md
+++ b/crates/de/spec/README.md
@@ -1,0 +1,53 @@
+# Deployment Engine — TLA+ Specification
+
+This directory contains a TLA+ model of the Deployment Engine's lifecycle state machine. The model captures the core invariants that the implementation must uphold: safe resource ownership, correct supersession ordering, and guaranteed convergence.
+
+## What the model covers
+
+The model focuses on the lifecycle of deployments within a single environment. Everything is implicitly scoped to one environment — there is no cross-environment interaction modeled.
+
+### Deployments
+
+A deployment is identified by a commit hash and a random nonce (the same commit can be deployed multiple times, but each deployment is distinct). A deployment carries a lifecycle label, a bootstrapped flag, and a failure counter:
+
+- **Label**: `DESIRED`, `LINGERING`, `UNDESIRED`, or `DOWN`.
+- **Bootstrapped**: whether the deployment's resource DAG has been fully explored to stability at least once.
+- **Failures**: consecutive failed iterations (used for exponential backoff). This is observational — it does not alter lifecycle transitions.
+
+### Supersession
+
+Deployments form a singly-linked chain via supersession. When a new deployment arrives, the current one is superseded. The chain only grows (supersessions are never removed). The "current" deployment is the one at the head — the unsuperseded one.
+
+### Resources
+
+Each deployment defines a set of resources with a dependency relation (a DAG). Resources are identified by type and name, and they persist across deployments: if two deployments reference the same resource identity, they refer to the same underlying resource.
+
+A desired deployment adopts or creates resources from the environment's shared pool based on resource identity. Creation respects topological order (a resource's dependencies must be alive first). Destruction respects reverse topological order (a resource is only destroyed when nothing alive depends on it).
+
+### Lifecycle
+
+The full lifecycle of a deployment:
+
+1. **DESIRED** — The deployment is active and reconciling. It iteratively creates, updates, or adopts resources until every resource in its DAG is alive and matching. Once no more transitions are needed, it becomes bootstrapped.
+
+2. **LINGERING** — The deployment has been superseded. It idles until the current deployment (evaluated dynamically — if the current is itself superseded, wait for the new one) is bootstrapped.
+
+3. **UNDESIRED** — The current deployment is bootstrapped, so this deployment tears down resources it owns that are no longer needed. Teardown is the set of resources owned by this deployment minus those in the current deployment's resource set. Multiple undesired deployments may emit overlapping destroy messages for the same resource; this is safe because resource transitions are idempotent.
+
+4. **DOWN** — Terminal. All excess resources have been destroyed. The deployment performs no further work.
+
+## Safety invariants
+
+The model checks three invariants:
+
+- **TypeOK** — All variables stay within their declared domains.
+- **CurrentResourcesSafe** — Once the current deployment is bootstrapped, its resources remain alive. Undesired deployments only destroy resources outside the current set.
+- **NoResourceContention** — At most one deployment is actively creating/adopting resources at any time (only the unsuperseded desired deployment operates on resources).
+
+## Liveness
+
+Under fair scheduling (every enabled action eventually fires, except deployment creation which is an external event), the model checks that every superseded deployment eventually reaches DOWN.
+
+## Model checking configuration
+
+`MC.tla` and `MC.cfg` configure a small instance for TLC: 3 deployments, 3 resources (`r1`, `r2`, `r3`) with a linear dependency chain (`r3 → r2 → r1`). Deadlock checking is disabled because the system can legitimately quiesce when all deployments are down and no new ones arrive.

--- a/crates/de/src/main.rs
+++ b/crates/de/src/main.rs
@@ -48,13 +48,14 @@ fn serialize_inputs(
     })
 }
 
-/// Returns the deployment ID portion of an owner QID string, validating
-/// that it parses as a well-formed `DeploymentQid`.
-fn extract_deployment_id(owner_qid: &str) -> anyhow::Result<ids::DeploymentId> {
+/// Parses an owner QID string and extracts its deployment ID and nonce.
+fn extract_deployment_identity(
+    owner_qid: &str,
+) -> anyhow::Result<(ids::DeploymentId, ids::DeploymentNonce)> {
     let qid: ids::DeploymentQid = owner_qid
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid owner QID: {owner_qid}"))?;
-    Ok(qid.deployment)
+    Ok((qid.deployment, qid.nonce))
 }
 
 /// Returns a short (up to 8 char) prefix of the deployment ID for log messages.
@@ -250,6 +251,7 @@ async fn process(
                 client: client.repo(deployment.repo.clone()).deployment(
                     deployment.environment.clone(),
                     deployment.deployment.clone(),
+                    deployment.nonce,
                 ),
                 cdb_client: client.clone(),
                 rdb_client: rdb_client.clone(),
@@ -257,7 +259,7 @@ async fn process(
                 namespace: rdb_client.namespace(environment_qid),
                 rtq_publisher: rtq_publisher.clone(),
                 log_publisher,
-                backoff: None,
+                last_failure_at: None,
             };
 
             let span = tracing::info_span!("worker", dep = %deployment_qid);
@@ -283,54 +285,29 @@ struct Worker {
     namespace: rdb::NamespaceClient,
     rtq_publisher: rtq::Publisher,
     log_publisher: ldb::NamespacePublisher,
-    /// In-memory backoff state for `Failing` deployments. Reset whenever
-    /// the deployment transitions out of `Failing` (by recovery or fatal
-    /// escalation). Intentionally not persisted: on worker restart we start
-    /// fresh at attempt 1, which is acceptable since backoff is an
-    /// optimisation to reduce reconciliation pressure, not a correctness
-    /// property.
-    backoff: Option<BackoffState>,
+    /// Tracks when the last failure occurred, used together with the
+    /// persisted `failures` counter to compute exponential backoff.
+    last_failure_at: Option<Instant>,
 }
 
-/// Initial backoff delay after the first transient failure (`Desired` →
-/// `Failing`).
+/// Initial backoff delay after the first failure.
 const BACKOFF_INITIAL: Duration = Duration::from_secs(5);
-/// Maximum backoff delay between reconciliation attempts for a `Failing`
-/// deployment. Long, because a fatal-in-practice failure may require
-/// operator work that is not worth hammering on; the operator can manually
-/// nudge the deployment back to `Desired` once they've addressed the
-/// underlying issue.
+/// Maximum backoff delay between reconciliation attempts.
 const BACKOFF_MAX: Duration = Duration::from_secs(24 * 60 * 60);
-/// Multiplicative growth factor per failed attempt. With a 5s base and 1.1
-/// growth, cumulative retry time reaches roughly a day after ~80 attempts.
+/// Multiplicative growth factor per failed attempt.
 const BACKOFF_FACTOR: f64 = 1.1;
 
-#[derive(Clone, Copy, Debug)]
-struct BackoffState {
-    attempts: u32,
-    next_attempt_at: Instant,
-}
-
-impl BackoffState {
-    /// Compute the next backoff entry given the previous state (if any).
-    fn bump(prev: Option<Self>, now: Instant) -> Self {
-        let attempts = prev.map_or(0, |s| s.attempts).saturating_add(1);
-        let factor = BACKOFF_FACTOR.powi(attempts.saturating_sub(1) as i32);
-        let delay_secs = (BACKOFF_INITIAL.as_secs_f64() * factor).min(BACKOFF_MAX.as_secs_f64());
-        Self {
-            attempts,
-            next_attempt_at: now + Duration::from_secs_f64(delay_secs),
-        }
+/// Compute the backoff duration for the given number of consecutive failures.
+fn backoff_duration(failures: u32) -> Duration {
+    if failures == 0 {
+        return Duration::ZERO;
     }
-}
-
-enum EvalCompleteness {
-    Complete,
-    Partial,
+    let factor = BACKOFF_FACTOR.powi(failures.saturating_sub(1) as i32);
+    let delay_secs = (BACKOFF_INITIAL.as_secs_f64() * factor).min(BACKOFF_MAX.as_secs_f64());
+    Duration::from_secs_f64(delay_secs)
 }
 
 struct EvalOutcome {
-    completeness: EvalCompleteness,
     /// Resource IDs referenced during evaluation. When `fully_explored` is
     /// true, this is the complete set — any owned resource NOT in this set
     /// is no longer desired and should be destroyed.
@@ -339,15 +316,14 @@ struct EvalOutcome {
     /// resource function returned concrete outputs and all code paths
     /// were fully evaluated.
     fully_explored: bool,
+    /// True when at least one effect was emitted (Create, Update, Adopt, etc).
+    had_effect: bool,
     /// Whether the deployment's manifest declares any volatile (branch or
-    /// tag) cross-repo pins. Such deployments stay in `Desired` and keep
-    /// reconciling so the foreign upstream's changes propagate. See
-    /// `CROSS_REPO_IMPORTS.md` §6a.
+    /// tag) cross-repo pins. Preserved for observability.
+    #[allow(dead_code)]
     has_volatile_cross_repo_pins: bool,
     /// True when compilation produced one or more `Error`-severity
-    /// diagnostics. These are treated as *fatal* — retrying will not
-    /// recover without a code change — so the deployment is escalated to
-    /// `Failed` rather than kept in retry.
+    /// diagnostics.
     had_fatal_errors: bool,
 }
 
@@ -399,8 +375,7 @@ impl Worker {
 
     async fn work(&mut self) -> anyhow::Result<()> {
         let deployment = self.client.get().await?;
-        let deployment_id = deployment.deployment.clone();
-        let sid = short_id(deployment_id.as_str()).to_string();
+        let sid = short_id(deployment.deployment.as_str()).to_string();
 
         match deployment.state {
             DeploymentState::Down => {
@@ -408,372 +383,316 @@ impl Worker {
                 Ok(())
             }
 
-            DeploymentState::Failed => {
-                tracing::debug!("{sid} failed; no reconciliation");
-                Ok(())
-            }
+            DeploymentState::Desired => self.run_desired(&deployment).await,
 
-            DeploymentState::Desired => self.run_reconcile_active(&deployment).await,
+            DeploymentState::Lingering => self.run_lingering(&deployment).await,
 
-            DeploymentState::Failing => {
-                // Respect in-memory backoff: if the next attempt isn't due
-                // yet, skip this iteration entirely.
-                if let Some(state) = self.backoff {
-                    let now = Instant::now();
-                    if now < state.next_attempt_at {
-                        tracing::debug!(
-                            "{sid} failing (attempt {}); backoff in {:.0}s",
-                            state.attempts,
-                            (state.next_attempt_at - now).as_secs_f64(),
-                        );
-                        return Ok(());
-                    }
-                }
-                self.run_reconcile_active(&deployment).await
-            }
-
-            DeploymentState::Up => {
-                tracing::debug!("{sid} up; no reconciliation needed");
-                Ok(())
-            }
-
-            DeploymentState::Undesired => {
-                tracing::info!("{sid} tearing down");
-
-                let owner_deployment_qid = deployment.deployment_qid().to_string();
-                let mut all_resources = Vec::new();
-                let mut resources = self.namespace.list_resources().await?;
-                while let Some(resource) = resources.try_next().await? {
-                    all_resources.push(resource);
-                }
-
-                let owned_resources = all_resources
-                    .iter()
-                    .filter(|resource| {
-                        resource.owner.as_deref() == Some(owner_deployment_qid.as_str())
-                    })
-                    .collect::<Vec<_>>();
-                let mut emitted = 0usize;
-                let mut blocked = 0usize;
-                // Exclude dependencies from sticky resources owned by this
-                // deployment so they don't block teardown of their own deps.
-                let living_dependency_targets = all_resources
-                    .iter()
-                    .filter(|resource| {
-                        !(resource.owner.as_deref() == Some(owner_deployment_qid.as_str())
-                            && resource.markers.contains(&sclc::Marker::Sticky))
-                    })
-                    .flat_map(|resource| resource.dependencies.iter().cloned())
-                    .collect::<HashSet<_>>();
-
-                for resource in &owned_resources {
-                    let resource_id = resource_id_from(resource);
-
-                    if resource.markers.contains(&sclc::Marker::Sticky) {
-                        tracing::info!(
-                            resource_type = %resource.resource_type,
-                            resource_name = %resource.name,
-                            "sticky resource; skipping destroy",
-                        );
-                        continue;
-                    }
-
-                    if living_dependency_targets.contains(&resource_id) {
-                        blocked += 1;
-                        tracing::info!(
-                            resource_type = %resource.resource_type,
-                            resource_name = %resource.name,
-                            owner = ?resource.owner,
-                            "resource still has living dependents; deferring destroy",
-                        );
-                        continue;
-                    }
-
-                    let message = rtq::Message::Destroy(rtq::DestroyMessage {
-                        resource: resource_ref(&self.environment_qid, &resource_id),
-                        deployment_id: deployment.deployment.clone(),
-                    });
-                    self.rtq_publisher.enqueue(&message).await?;
-                    emitted += 1;
-
-                    tracing::info!(
-                        resource_type = %resource.resource_type,
-                        resource_name = %resource.name,
-                        owner = ?resource.owner,
-                        "queued destroy",
-                    );
-                }
-
-                if emitted > 0 {
-                    tracing::info!("queued {} destroy messages", emitted);
-                    return Ok(());
-                }
-
-                let has_non_sticky = owned_resources
-                    .iter()
-                    .any(|r| !r.markers.contains(&sclc::Marker::Sticky));
-
-                if !has_non_sticky {
-                    for resource in &owned_resources {
-                        self.log_publisher
-                            .info(format!(
-                                "{} will stick around",
-                                ids::ResourceId::new(&resource.resource_type, &resource.name)
-                            ))
-                            .await;
-                    }
-                    tracing::info!("{sid} no more non-sticky resources, setting state to DOWN");
-                    self.client.set(DeploymentState::Down).await?;
-                    self.log_publisher
-                        .info(format!("Undesired {sid} is fully torn down"))
-                        .await;
-                    return Ok(());
-                }
-
-                if blocked > 0 {
-                    tracing::info!(
-                        blocked_resources = blocked,
-                        "{sid} teardown waiting on living dependents",
-                    );
-                    self.log_publisher
-                        .info(format!(
-                            "Undesired {sid} still has {blocked} resources with living dependents"
-                        ))
-                        .await;
-                }
-                Ok(())
-            }
-
-            DeploymentState::Lingering => {
-                tracing::info!("{sid} lingering...");
-                let mut cursor = self.client.clone();
-                let mut seen = HashSet::new();
-
-                while let Some(superseding) = cursor.get_superseding().await? {
-                    let superseding_deployment = superseding.get().await?;
-                    let commit_hash = superseding_deployment.deployment.clone();
-
-                    if !seen.insert(commit_hash) {
-                        tracing::warn!("detected supersession cycle while lingering");
-                        break;
-                    }
-
-                    if matches!(
-                        superseding_deployment.state,
-                        DeploymentState::Desired | DeploymentState::Up
-                    ) {
-                        self.client
-                            .mark_superseded_by(&superseding_deployment.deployment)
-                            .await?;
-
-                        // If the superseding deployment is already Up, it won't
-                        // re-check its superseded list, so transition ourselves.
-                        if superseding_deployment.state == DeploymentState::Up {
-                            self.client.set(DeploymentState::Undesired).await?;
-                        }
-
-                        break;
-                    }
-
-                    cursor = superseding;
-                }
-
-                Ok(())
-            }
+            DeploymentState::Undesired => self.run_undesired(&deployment).await,
         }
     }
 
-    /// Dispatch to [`reconcile_active`](Self::reconcile_active) and apply
-    /// the resulting state transition.
+    /// DESIRED state handler.
     ///
-    /// * Ok with fatal errors → transition to `Failed`, clear backoff, and
-    ///   try to make the deployment this one superseded desired again
-    ///   (rollback).
-    /// * Ok without fatal errors → success. If we were previously
-    ///   `Failing`, clear backoff and move back to `Desired` (unless the
-    ///   reconciliation itself promoted us to `Up`).
-    /// * Err → transient failure. Transition to `Failing` if not already,
-    ///   and bump the in-memory backoff so the next attempt is delayed.
-    async fn run_reconcile_active(&mut self, deployment: &Deployment) -> anyhow::Result<()> {
+    /// 1. Check backoff (based on persisted failures counter).
+    /// 2. Check supersession — if superseded, transition to LINGERING.
+    /// 3. Compile and evaluate.
+    /// 4. On success: set bootstrapped, transition superseded deployments.
+    /// 5. On error: increment failures counter.
+    async fn run_desired(&mut self, deployment: &Deployment) -> anyhow::Result<()> {
         let sid = short_id(deployment.deployment.as_str()).to_string();
-        let was_failing = deployment.state == DeploymentState::Failing;
 
-        match self.reconcile_active(deployment).await {
-            Ok(had_fatal_errors) => {
-                if had_fatal_errors {
-                    tracing::error!("{sid} fatal compile errors; marking FAILED");
-                    self.log_publisher
-                        .error(format!("{sid} failed fatally: compile errors"))
-                        .await;
-                    self.client.set(DeploymentState::Failed).await?;
-                    self.backoff = None;
-                    self.attempt_rollback(&sid).await?;
+        // Backoff: if we have failures, check whether enough time has passed.
+        if deployment.failures > 0 {
+            let delay = backoff_duration(deployment.failures);
+            if let Some(last_failure) = self.last_failure_at {
+                let elapsed = last_failure.elapsed();
+                if elapsed < delay {
+                    tracing::debug!(
+                        "{sid} backing off (failures={}, {:.0}s remaining)",
+                        deployment.failures,
+                        (delay - elapsed).as_secs_f64(),
+                    );
                     return Ok(());
                 }
-
-                if was_failing {
-                    self.backoff = None;
-                    // The reconciliation may have already promoted us to
-                    // `Up`; only move back to `Desired` if we're still
-                    // `Failing`.
-                    let current = self.client.get().await?;
-                    if current.state == DeploymentState::Failing {
-                        self.client.set(DeploymentState::Desired).await?;
-                        self.log_publisher
-                            .info(format!("{sid} recovered; resuming as DESIRED"))
-                            .await;
-                    }
-                }
-                Ok(())
             }
-            Err(error) => {
-                tracing::warn!("{sid} transient error: {error:#}");
-                self.log_publisher
-                    .warn(format!("{sid} transient error: {error}"))
-                    .await;
-                if !was_failing {
-                    self.client.set(DeploymentState::Failing).await?;
-                }
-                self.backoff = Some(BackoffState::bump(self.backoff, Instant::now()));
-                Ok(())
-            }
+            // If last_failure_at is None (e.g., after restart), proceed
+            // immediately — the first attempt after restart is free.
         }
-    }
 
-    /// Attempt to roll back to a predecessor deployment after a fatal
-    /// failure. Best-effort: a failure to find or promote a target is
-    /// logged but not propagated, since the failing deployment has
-    /// already been marked `Failed`.
-    async fn attempt_rollback(&self, sid: &str) -> anyhow::Result<()> {
-        match self.client.rollback_target().await? {
-            Some(target) => {
-                let target_sid = short_id(target.deployment.as_str()).to_string();
-                let target_client = self
-                    .cdb_client
-                    .repo(target.repo.clone())
-                    .deployment(target.environment.clone(), target.deployment.clone());
-                target_client.make_desired().await?;
-                tracing::info!("{sid} rolled back to {target_sid}");
-                self.log_publisher
-                    .info(format!("rolled back {sid} to {target_sid}"))
-                    .await;
-            }
-            None => {
-                tracing::warn!("{sid} no rollback target found");
-                self.log_publisher
-                    .error(format!("no rollback target for failed {sid}"))
-                    .await;
-            }
+        // Supersession check: if this deployment has been superseded,
+        // transition to LINGERING immediately.
+        if self.client.get_superseding().await?.is_some() {
+            tracing::info!("{sid} superseded; transitioning to LINGERING");
+            self.log_publisher
+                .info(format!("{sid} superseded; transitioning to LINGERING"))
+                .await;
+            self.client.set(DeploymentState::Lingering).await?;
+            return Ok(());
         }
-        Ok(())
-    }
 
-    /// Perform one iteration of reconciliation for an active deployment
-    /// (`Desired` or `Failing`). Returns `true` if compilation produced
-    /// fatal errors — the caller is responsible for escalating the state.
-    ///
-    /// Any error returned is considered *transient*: the caller will bump
-    /// the backoff and retry later.
-    async fn reconcile_active(&mut self, deployment: &Deployment) -> anyhow::Result<bool> {
-        let deployment_id = deployment.deployment.clone();
-        let sid = short_id(deployment_id.as_str()).to_string();
         tracing::info!("{sid} reconciling");
 
         // If the commit has no Main.scl, there is nothing to evaluate.
-        // Log an info note and transition directly to Up instead of
-        // treating it as a compilation error.
+        // Mark as bootstrapped immediately.
         if self
             .client
             .path_hash(std::path::Path::new("Main.scl"))
             .await?
             .is_none()
         {
-            tracing::info!("{sid} no Main.scl; transitioning to UP");
+            tracing::info!("{sid} no Main.scl; marking bootstrapped");
             self.log_publisher
-                .info(format!("{sid} is up (no Main.scl in commit)"))
+                .info(format!("{sid} bootstrapped (no Main.scl in commit)"))
                 .await;
-            self.client.set(DeploymentState::Up).await?;
-            return Ok(false);
+            self.client.set_progress(true, 0).await?;
+            self.transition_superseded_to_undesired().await?;
+            return Ok(());
         }
 
-        let outcome = self.compile_and_evaluate().await?;
-
-        // Fatal compile errors short-circuit: skip teardown work and
-        // return early so the caller can escalate. We intentionally do
-        // NOT transition volatile or partial-evaluation bookkeeping on a
-        // failed compile, because the evaluation tree is unreliable.
-        if outcome.had_fatal_errors {
-            return Ok(true);
-        }
-
-        let owner_deployment_qid = deployment.deployment_qid().to_string();
-
-        // When the evaluation tree was fully explored (no pending
-        // Create/Update effects), we know the complete set of
-        // referenced resources. Destroy any owned resources that
-        // the evaluation never touched.
-        if outcome.fully_explored {
-            self.destroy_untouched_resources(
-                &owner_deployment_qid,
-                &deployment_id,
-                &outcome.touched_resource_ids,
-            )
-            .await?;
-        }
-
-        match outcome.completeness {
-            EvalCompleteness::Complete => {
-                for superseded in self.client.superseded().await? {
-                    let superseded_deployment = superseded.get().await?;
-                    if superseded_deployment.state == DeploymentState::Lingering {
-                        superseded.set(DeploymentState::Undesired).await?;
-                    }
-                }
-
-                // Check if all owned resources are non-volatile.
-                // If so, transition to Up (no further reconciliation needed).
-                let mut has_volatile = false;
-                let mut resources = self
-                    .namespace
-                    .list_resources_by_owner(&owner_deployment_qid)
-                    .await?;
-                while let Some(resource) = resources.try_next().await? {
-                    if resource.markers.contains(&sclc::Marker::Volatile) {
-                        has_volatile = true;
-                        break;
-                    }
-                }
-                drop(resources);
-
-                if has_volatile {
-                    // Has at least one intrinsically-volatile resource —
-                    // stay in Desired so reconciliation keeps probing.
-                } else if outcome.has_volatile_cross_repo_pins {
-                    tracing::info!("{sid} has volatile cross-repo pins; staying in Desired");
-                } else {
-                    tracing::info!("{sid} all resources non-volatile; transitioning to UP");
-                    self.client.set(DeploymentState::Up).await?;
+        // Compile and evaluate.
+        match self.compile_and_evaluate().await {
+            Ok(outcome) => {
+                if outcome.had_fatal_errors {
+                    // Fatal compile errors: increment failures, stay DESIRED.
+                    let new_failures = deployment.failures.saturating_add(1);
+                    self.last_failure_at = Some(Instant::now());
+                    self.client
+                        .set_progress(deployment.bootstrapped, new_failures)
+                        .await?;
+                    tracing::warn!("{sid} fatal compile errors (failures={})", new_failures,);
                     self.log_publisher
-                        .info(format!("{sid} is up (all resources non-volatile)"))
+                        .error(format!("{sid} compile errors (failures={new_failures})"))
+                        .await;
+                    return Ok(());
+                }
+
+                // Success: reset failures.
+                let owner_deployment_qid = deployment.deployment_qid().to_string();
+                let deployment_id = deployment.deployment.clone();
+                let deployment_nonce = deployment.nonce;
+
+                if outcome.fully_explored {
+                    self.destroy_untouched_resources(
+                        &owner_deployment_qid,
+                        &deployment_id,
+                        deployment_nonce,
+                        &outcome.touched_resource_ids,
+                    )
+                    .await?;
+                }
+
+                if !outcome.had_effect {
+                    // Fully converged — set bootstrapped.
+                    if !deployment.bootstrapped {
+                        tracing::info!("{sid} bootstrapped");
+                        self.log_publisher.info(format!("{sid} bootstrapped")).await;
+                    }
+                    self.client.set_progress(true, 0).await?;
+                    self.transition_superseded_to_undesired().await?;
+                } else {
+                    // Partial evaluation — reset failures but not yet bootstrapped.
+                    if deployment.failures > 0 {
+                        self.client.set_progress(deployment.bootstrapped, 0).await?;
+                    }
+                    self.last_failure_at = None;
+                    tracing::info!(
+                        "{sid} evaluation incomplete; deferring superseded deployment teardown"
+                    );
+                }
+
+                Ok(())
+            }
+            Err(error) => {
+                // Transient error: increment failures, stay DESIRED.
+                let new_failures = deployment.failures.saturating_add(1);
+                self.last_failure_at = Some(Instant::now());
+                self.client
+                    .set_progress(deployment.bootstrapped, new_failures)
+                    .await?;
+                tracing::warn!(
+                    "{sid} transient error (failures={}): {error:#}",
+                    new_failures,
+                );
+                self.log_publisher
+                    .warn(format!("{sid} transient error: {error}"))
+                    .await;
+                Ok(())
+            }
+        }
+    }
+
+    /// Transition all superseded LINGERING deployments to UNDESIRED.
+    /// Called when this deployment becomes bootstrapped.
+    async fn transition_superseded_to_undesired(&self) -> anyhow::Result<()> {
+        for superseded in self.client.superseded().await? {
+            let superseded_deployment = superseded.get().await?;
+            if superseded_deployment.state == DeploymentState::Lingering {
+                superseded.set(DeploymentState::Undesired).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// LINGERING state handler.
+    ///
+    /// Idle until Current (the unsuperseded deployment) is bootstrapped,
+    /// then transition to UNDESIRED.
+    async fn run_lingering(&self, deployment: &Deployment) -> anyhow::Result<()> {
+        let sid = short_id(deployment.deployment.as_str()).to_string();
+        tracing::info!("{sid} lingering...");
+
+        // Follow the supersession chain to find Current.
+        let mut cursor = self.client.clone();
+        let mut seen = HashSet::new();
+
+        while let Some(superseding) = cursor.get_superseding().await? {
+            let superseding_deployment = superseding.get().await?;
+            let commit_hash = superseding_deployment.deployment.clone();
+
+            if !seen.insert((commit_hash.clone(), superseding_deployment.nonce)) {
+                tracing::warn!("detected supersession cycle while lingering");
+                break;
+            }
+
+            // Check if this is Current (unsuperseded).
+            if superseding.get_superseding().await?.is_none() {
+                // This is Current. Check if it's bootstrapped.
+                if superseding_deployment.bootstrapped {
+                    tracing::info!(
+                        "{sid} current deployment is bootstrapped; transitioning to UNDESIRED"
+                    );
+                    self.client.set(DeploymentState::Undesired).await?;
+                    self.log_publisher
+                        .info(format!("{sid} current is bootstrapped; now UNDESIRED"))
                         .await;
                 }
+                break;
             }
-            EvalCompleteness::Partial => {
-                tracing::info!("evaluation incomplete; deferring superseded deployment teardown");
-            }
+
+            cursor = superseding;
         }
 
-        Ok(false)
+        Ok(())
+    }
+
+    /// UNDESIRED state handler.
+    ///
+    /// Destroy resources in Teardown(µ) — resources owned by this deployment
+    /// that are no longer needed by Current. Transition to DOWN when complete.
+    async fn run_undesired(&self, deployment: &Deployment) -> anyhow::Result<()> {
+        let sid = short_id(deployment.deployment.as_str()).to_string();
+        tracing::info!("{sid} tearing down");
+
+        let owner_deployment_qid = deployment.deployment_qid().to_string();
+        let mut all_resources = Vec::new();
+        let mut resources = self.namespace.list_resources().await?;
+        while let Some(resource) = resources.try_next().await? {
+            all_resources.push(resource);
+        }
+
+        let owned_resources = all_resources
+            .iter()
+            .filter(|resource| resource.owner.as_deref() == Some(owner_deployment_qid.as_str()))
+            .collect::<Vec<_>>();
+        let mut emitted = 0usize;
+        let mut blocked = 0usize;
+        // Exclude dependencies from sticky resources owned by this
+        // deployment so they don't block teardown of their own deps.
+        let living_dependency_targets = all_resources
+            .iter()
+            .filter(|resource| {
+                !(resource.owner.as_deref() == Some(owner_deployment_qid.as_str())
+                    && resource.markers.contains(&sclc::Marker::Sticky))
+            })
+            .flat_map(|resource| resource.dependencies.iter().cloned())
+            .collect::<HashSet<_>>();
+
+        for resource in &owned_resources {
+            let resource_id = resource_id_from(resource);
+
+            if resource.markers.contains(&sclc::Marker::Sticky) {
+                tracing::info!(
+                    resource_type = %resource.resource_type,
+                    resource_name = %resource.name,
+                    "sticky resource; skipping destroy",
+                );
+                continue;
+            }
+
+            if living_dependency_targets.contains(&resource_id) {
+                blocked += 1;
+                tracing::info!(
+                    resource_type = %resource.resource_type,
+                    resource_name = %resource.name,
+                    owner = ?resource.owner,
+                    "resource still has living dependents; deferring destroy",
+                );
+                continue;
+            }
+
+            let message = rtq::Message::Destroy(rtq::DestroyMessage {
+                resource: resource_ref(&self.environment_qid, &resource_id),
+                deployment_id: deployment.deployment.clone(),
+                deployment_nonce: deployment.nonce,
+            });
+            self.rtq_publisher.enqueue(&message).await?;
+            emitted += 1;
+
+            tracing::info!(
+                resource_type = %resource.resource_type,
+                resource_name = %resource.name,
+                owner = ?resource.owner,
+                "queued destroy",
+            );
+        }
+
+        if emitted > 0 {
+            tracing::info!("queued {} destroy messages", emitted);
+            return Ok(());
+        }
+
+        let has_non_sticky = owned_resources
+            .iter()
+            .any(|r| !r.markers.contains(&sclc::Marker::Sticky));
+
+        if !has_non_sticky {
+            for resource in &owned_resources {
+                self.log_publisher
+                    .info(format!(
+                        "{} will stick around",
+                        ids::ResourceId::new(&resource.resource_type, &resource.name)
+                    ))
+                    .await;
+            }
+            tracing::info!("{sid} no more non-sticky resources, setting state to DOWN");
+            self.client.set(DeploymentState::Down).await?;
+            self.log_publisher
+                .info(format!("Undesired {sid} is fully torn down"))
+                .await;
+            return Ok(());
+        }
+
+        if blocked > 0 {
+            tracing::info!(
+                blocked_resources = blocked,
+                "{sid} teardown waiting on living dependents",
+            );
+            self.log_publisher
+                .info(format!(
+                    "Undesired {sid} still has {blocked} resources with living dependents"
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     /// Destroy resources owned by this deployment that were not referenced
-    /// during the latest evaluation. This handles the case where volatile
-    /// resources change in a way that causes previously-created resources
-    /// to disappear from the configuration.
+    /// during the latest evaluation.
     async fn destroy_untouched_resources(
         &self,
         owner_deployment_qid: &str,
         deployment_id: &ids::DeploymentId,
+        deployment_nonce: ids::DeploymentNonce,
         touched_resource_ids: &HashSet<ids::ResourceId>,
     ) -> anyhow::Result<()> {
         let mut all_resources = Vec::new();
@@ -795,14 +714,10 @@ impl Worker {
             return Ok(());
         }
 
-        // Collect dependency targets from all living resources (excluding
-        // untouched resources themselves) to avoid destroying resources
-        // that are still depended upon.
         let living_dependency_targets: HashSet<ids::ResourceId> = all_resources
             .iter()
             .filter(|resource| {
                 let id = resource_id_from(resource);
-                // Don't let untouched owned resources block each other.
                 resource.owner.as_deref() != Some(owner_deployment_qid)
                     || touched_resource_ids.contains(&id)
             })
@@ -833,6 +748,7 @@ impl Worker {
             let message = rtq::Message::Destroy(rtq::DestroyMessage {
                 resource: resource_ref(&self.environment_qid, &resource_id),
                 deployment_id: deployment_id.clone(),
+                deployment_nonce,
             });
             self.rtq_publisher.enqueue(&message).await?;
 
@@ -879,8 +795,6 @@ impl Worker {
         let user_pkg: Arc<dyn sclc::Package> = Arc::new(self.client.clone());
         let repo_qid = self.client.repo_qid().clone();
 
-        // Resolve cross-repo dependencies, if any. Manifest parsing itself
-        // only needs the local package + the standard library.
         let cross_repo_finder = self
             .build_cross_repo_finder(Arc::clone(&user_pkg), &repo_qid)
             .await?;
@@ -900,9 +814,9 @@ impl Worker {
         if diagnosed.diags().has_errors() {
             tracing::info!("compile produced errors; skipping evaluation");
             return Ok(EvalOutcome {
-                completeness: EvalCompleteness::Partial,
                 touched_resource_ids: HashSet::new(),
                 fully_explored: false,
+                had_effect: false,
                 has_volatile_cross_repo_pins: cross_repo_finder
                     .as_ref()
                     .is_some_and(|f| f.has_volatile_pins()),
@@ -914,14 +828,7 @@ impl Worker {
         let full_deployment_qid = self.client.deployment_qid();
         let owner_deployment_qid = full_deployment_qid.to_string();
         let deployment_id = full_deployment_qid.deployment.clone();
-
-        // Collect the set of superseded deployment QIDs so we can validate
-        // that adoption only happens from deployments we legitimately supersede.
-        let mut superseded_deployment_qids = HashSet::new();
-        for superseded in self.client.superseded().await? {
-            let dep = superseded.get().await?;
-            superseded_deployment_qids.insert(dep.deployment_qid().to_string());
-        }
+        let deployment_nonce = full_deployment_qid.nonce;
 
         let (effects_tx, mut effects_rx) = mpsc::unbounded_channel();
         let environment_qid_str = self.environment_qid.to_string();
@@ -932,10 +839,6 @@ impl Worker {
             local_deployment_qid.clone(),
         );
 
-        // Register foreign-package owners so the evaluator stamps the right
-        // owner on effects produced by foreign global expressions, and
-        // pre-load each foreign deployment's resources so remote-state
-        // reads can return concrete outputs.
         if let Some(finder) = &cross_repo_finder {
             for (foreign_repo, foreign_owner) in finder.resolved_owners().await {
                 self.log_publisher
@@ -1017,9 +920,6 @@ impl Worker {
                     let mut had_mutation = false;
                     let mut touched_resource_ids = HashSet::new();
                     while let Some(effect) = effects_rx.recv().await {
-                        // Drop foreign-owned effects. Phase 3 will route
-                        // these through remote-state-read logic; for now we
-                        // simply log and skip.
                         if effect.owner() != &local_deployment_qid_for_drain {
                             tracing::debug!(
                                 owner = %effect.owner(),
@@ -1052,6 +952,7 @@ impl Worker {
                                 let message = rtq::Message::Create(rtq::CreateMessage {
                                     resource: resource_ref(&env_qid, &id),
                                     deployment_id: deployment_id.clone(),
+                                    deployment_nonce,
                                     inputs: inputs_value,
                                     dependencies: map_dependencies(&env_qid, dependencies),
                                     source_trace,
@@ -1085,40 +986,24 @@ impl Worker {
                                 had_effect = true;
                                 had_mutation = true;
                                 touched_resource_ids.insert(id.clone());
-                                let desired_inputs =
-                                    match serialize_inputs(&id, &inputs, "update") {
-                                        Ok(v) => v,
-                                        Err(error) => {
-                                            tracing::error!("{error:#}");
-                                            log_publisher
-                                                .error(format!("Skipping UPDATE {id}: {error}"))
-                                                .await;
-                                            continue;
-                                        }
-                                    };
+                                let desired_inputs = match serialize_inputs(&id, &inputs, "update")
+                                {
+                                    Ok(v) => v,
+                                    Err(error) => {
+                                        tracing::error!("{error:#}");
+                                        log_publisher
+                                            .error(format!("Skipping UPDATE {id}: {error}"))
+                                            .await;
+                                        continue;
+                                    }
+                                };
                                 let dependencies = map_dependencies(&env_qid, dependencies);
                                 let message = if let Some(from_owner_qid) =
                                     unowned_resource_owner_by_id.get(&id).cloned()
                                 {
-                                    // Validate that we are only adopting from a
-                                    // superseded deployment.
-                                    if !superseded_deployment_qids.contains(&from_owner_qid) {
-                                        tracing::warn!(
-                                            resource_type = %id.typ,
-                                            resource_name = %id.name,
-                                            from_owner = %from_owner_qid,
-                                            "refusing to adopt resource from non-superseded deployment",
-                                        );
-                                        log_publisher
-                                            .error(format!(
-                                                "Cannot adopt {id}: owner {from_owner_qid} is not a superseded deployment",
-                                            ))
-                                            .await;
-                                        continue;
-                                    }
-                                    let from_deployment_id =
-                                        match extract_deployment_id(&from_owner_qid) {
-                                            Ok(id) => id,
+                                    let (from_deployment_id, from_deployment_nonce) =
+                                        match extract_deployment_identity(&from_owner_qid) {
+                                            Ok(v) => v,
                                             Err(error) => {
                                                 tracing::error!(
                                                     from_owner = %from_owner_qid,
@@ -1130,7 +1015,9 @@ impl Worker {
                                     rtq::Message::Adopt(rtq::AdoptMessage {
                                         resource: resource_ref(&env_qid, &id),
                                         from_deployment_id,
+                                        from_deployment_nonce,
                                         to_deployment_id: deployment_id.clone(),
+                                        to_deployment_nonce: deployment_nonce,
                                         desired_inputs,
                                         dependencies,
                                         source_trace,
@@ -1139,6 +1026,7 @@ impl Worker {
                                     rtq::Message::Restore(rtq::RestoreMessage {
                                         resource: resource_ref(&env_qid, &id),
                                         deployment_id: deployment_id.clone(),
+                                        deployment_nonce,
                                         desired_inputs,
                                         dependencies,
                                         source_trace,
@@ -1174,24 +1062,6 @@ impl Worker {
                                 if let Some(from_owner_deployment_qid) =
                                     unowned_resource_owner_by_id.get(&id).cloned()
                                 {
-                                    // Validate that we are only adopting from a
-                                    // superseded deployment.
-                                    if !superseded_deployment_qids
-                                        .contains(&from_owner_deployment_qid)
-                                    {
-                                        tracing::warn!(
-                                            resource_type = %id.typ,
-                                            resource_name = %id.name,
-                                            from_owner = %from_owner_deployment_qid,
-                                            "refusing to adopt-touch resource from non-superseded deployment",
-                                        );
-                                        log_publisher
-                                            .error(format!(
-                                                "Cannot adopt {id}: owner {from_owner_deployment_qid} is not a superseded deployment",
-                                            ))
-                                            .await;
-                                        continue;
-                                    }
                                     had_effect = true;
                                     let desired_inputs =
                                         match serialize_inputs(&id, &inputs, "touch") {
@@ -1199,29 +1069,30 @@ impl Worker {
                                             Err(error) => {
                                                 tracing::error!("{error:#}");
                                                 log_publisher
-                                                    .error(format!(
-                                                        "Skipping ADOPT {id}: {error}"
-                                                    ))
+                                                    .error(format!("Skipping ADOPT {id}: {error}"))
                                                     .await;
                                                 continue;
                                             }
                                         };
-                                    let from_deployment_id = match extract_deployment_id(
-                                        &from_owner_deployment_qid,
-                                    ) {
-                                        Ok(id) => id,
-                                        Err(error) => {
-                                            tracing::error!(
-                                                from_owner = %from_owner_deployment_qid,
-                                                "{error:#}",
-                                            );
-                                            continue;
-                                        }
-                                    };
+                                    let (from_deployment_id, from_deployment_nonce) =
+                                        match extract_deployment_identity(
+                                            &from_owner_deployment_qid,
+                                        ) {
+                                            Ok(v) => v,
+                                            Err(error) => {
+                                                tracing::error!(
+                                                    from_owner = %from_owner_deployment_qid,
+                                                    "{error:#}",
+                                                );
+                                                continue;
+                                            }
+                                        };
                                     let message = rtq::Message::Adopt(rtq::AdoptMessage {
                                         resource: resource_ref(&env_qid, &id),
                                         from_deployment_id,
+                                        from_deployment_nonce,
                                         to_deployment_id: deployment_id.clone(),
+                                        to_deployment_nonce: deployment_nonce,
                                         desired_inputs,
                                         dependencies: map_dependencies(&env_qid, dependencies),
                                         source_trace,
@@ -1245,13 +1116,10 @@ impl Worker {
                                         "effect touch resource adopt",
                                     );
                                 } else if volatile_resource_ids.contains(&id) {
-                                    // Volatile checks verify resource health but do not
-                                    // count as effects that block completeness. This
-                                    // allows supersession of prior deployments even when
-                                    // volatile resources are present.
                                     let message = rtq::Message::Check(rtq::CheckMessage {
                                         resource: resource_ref(&env_qid, &id),
                                         deployment_id: deployment_id.clone(),
+                                        deployment_nonce,
                                     });
                                     if !enqueue_message(
                                         &rtq_publisher,
@@ -1276,13 +1144,9 @@ impl Worker {
                     }
 
                     EvalOutcome {
-                        completeness: if had_effect {
-                            EvalCompleteness::Partial
-                        } else {
-                            EvalCompleteness::Complete
-                        },
                         touched_resource_ids,
                         fully_explored: !had_mutation,
+                        had_effect,
                         has_volatile_cross_repo_pins,
                         had_fatal_errors: false,
                     }
@@ -1306,15 +1170,11 @@ impl Worker {
         user_pkg: Arc<dyn sclc::Package>,
         local_repo: &ids::RepoQid,
     ) -> anyhow::Result<Option<Arc<sclc::CrossRepoPackageFinder>>> {
-        // For manifest parsing only, a (user + std) finder is sufficient —
-        // `Package.scle` is expected to import only `Std/...`.
         let manifest_finder = sclc::build_default_finder(Arc::clone(&user_pkg));
         let manifest = match sclc::load_manifest(Arc::clone(&user_pkg), manifest_finder).await {
             Ok(Some(m)) => m,
             Ok(None) => return Ok(None),
             Err(e) => {
-                // Surface the error as a deployment failure so the operator
-                // can see why the deployment didn't proceed.
                 self.log_publisher
                     .error(format!("failed to load Package.scle: {e}"))
                     .await;
@@ -1336,11 +1196,7 @@ impl Worker {
 
 /// Compose the finder chain used during compile: local user package →
 /// cross-repo finder (if any) → CDB-backed cross-repo fallback for the
-/// local environment → standard library. The CDB fallback preserves the
-/// pre-cross-repo behaviour: a deployment can still resolve `Org/Repo`
-/// imports against active deployments in its own environment without
-/// declaring them in the manifest. (The cross-repo finder takes
-/// precedence when the manifest declares a specifier.)
+/// local environment → standard library.
 fn build_full_finder(
     user_pkg: Arc<dyn sclc::Package>,
     cdb_client: cdb::Client,

--- a/crates/ids/Cargo.toml
+++ b/crates/ids/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+rand = "0.9.2"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
 

--- a/crates/ids/src/lib.rs
+++ b/crates/ids/src/lib.rs
@@ -19,7 +19,8 @@
 //!
 //! 4. **Deployment** — a revision of an environment. Deployments own resources temporarily
 //!    (since adoption can change the owner), but all resources belong to the same environment
-//!    during their entire lifecycle. Deployments are identified by commit hash.
+//!    during their entire lifecycle. Deployments are identified by a commit hash and a random
+//!    nonce, allowing the same commit to be deployed multiple times.
 //!
 //! ## IDs vs QIDs
 //!
@@ -31,7 +32,7 @@
 //! | Org | `MyOrg` | N/A (top level) | `MyOrg` |
 //! | Repo | `MyRepo` | `OrgId/RepoId` | `MyOrg/MyRepo` |
 //! | Env | `main` | `RepoQid::EnvironmentId` | `MyOrg/MyRepo::main` |
-//! | Deploy | `2cbec...` | `EnvironmentQid@DeploymentId` | `MyOrg/MyRepo::main@2cbec...` |
+//! | Deploy | `2cbec...` | `EnvironmentQid@DeploymentId.Nonce` | `MyOrg/MyRepo::main@2cbec....a1b2` |
 //! | Resource | `Std/Random.Int:seed` | `EnvironmentQid::ResourceId` | `MyOrg/MyRepo::main::Std/Random.Int:seed` |
 //!
 //! ## Separators
@@ -97,6 +98,13 @@ fn is_valid_oid_hex(s: &str) -> bool {
             .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
+/// Returns `true` if `s` is a valid 16-character lowercase hexadecimal string.
+fn is_valid_nonce_hex(s: &str) -> bool {
+    s.len() == 16
+        && s.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -122,8 +130,11 @@ pub enum ParseIdError {
     #[error("invalid deployment ID: {0:?} (must be 40-char lowercase hex)")]
     InvalidDeploymentId(String),
 
+    #[error("invalid deployment nonce: {0:?} (must be 16-char lowercase hex)")]
+    InvalidDeploymentNonce(String),
+
     #[error(
-        "invalid deployment QID: {0:?} (expected format: OrgId/RepoId::EnvironmentId@DeploymentId)"
+        "invalid deployment QID: {0:?} (expected format: OrgId/RepoId::EnvironmentId@DeploymentId.Nonce)"
     )]
     InvalidDeploymentQid(String),
 
@@ -521,11 +532,13 @@ impl EnvironmentQid {
         }
     }
 
-    /// Creates a [`DeploymentQid`] by combining this environment QID with a deployment ID.
-    pub fn deployment(&self, deployment: DeploymentId) -> DeploymentQid {
+    /// Creates a [`DeploymentQid`] by combining this environment QID with a deployment ID
+    /// and nonce.
+    pub fn deployment(&self, deployment: DeploymentId, nonce: DeploymentNonce) -> DeploymentQid {
         DeploymentQid {
             environment: self.clone(),
             deployment,
+            nonce,
         }
     }
 }
@@ -677,6 +690,92 @@ impl TryFrom<String> for DeploymentId {
             return Err(ParseIdError::InvalidDeploymentId(s));
         }
         Ok(Self(s))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeploymentNonce
+// ---------------------------------------------------------------------------
+
+/// Deployment nonce. A random number that distinguishes deployments of the same
+/// commit, allowing the same commit to be deployed multiple times.
+///
+/// Represented as a 16-character zero-padded lowercase hexadecimal string (a `u64`).
+///
+/// # Examples
+///
+/// ```
+/// use ids::DeploymentNonce;
+/// let nonce = DeploymentNonce::random();
+/// assert_eq!(nonce.to_string().len(), 16);
+///
+/// let zero = DeploymentNonce::zero();
+/// assert_eq!(zero.to_string(), "0000000000000000");
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeploymentNonce(u64);
+
+impl DeploymentNonce {
+    /// Creates a nonce with value zero.
+    pub fn zero() -> Self {
+        Self(0)
+    }
+
+    /// Generates a random nonce.
+    pub fn random() -> Self {
+        Self(rand::random())
+    }
+
+    /// Creates a nonce from a raw `u64` value.
+    pub fn from_u64(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Returns the raw `u64` value.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the nonce as a 16-character hex string.
+    pub fn as_hex(&self) -> String {
+        format!("{:016x}", self.0)
+    }
+}
+
+impl fmt::Display for DeploymentNonce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:016x}", self.0)
+    }
+}
+
+impl fmt::Debug for DeploymentNonce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DeploymentNonce({self})")
+    }
+}
+
+impl FromStr for DeploymentNonce {
+    type Err = ParseIdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !is_valid_nonce_hex(s) {
+            return Err(ParseIdError::InvalidDeploymentNonce(s.to_string()));
+        }
+        let v = u64::from_str_radix(s, 16)
+            .map_err(|_| ParseIdError::InvalidDeploymentNonce(s.to_string()))?;
+        Ok(Self(v))
+    }
+}
+
+impl Serialize for DeploymentNonce {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for DeploymentNonce {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -890,17 +989,18 @@ impl<'de> Deserialize<'de> for ResourceQid {
 // DeploymentQid
 // ---------------------------------------------------------------------------
 
-/// Qualified deployment identifier: `OrgId/RepoId::EnvironmentId@DeploymentId`.
+/// Qualified deployment identifier: `OrgId/RepoId::EnvironmentId@DeploymentId.Nonce`.
 ///
 /// This is the most specific identifier in the hierarchy, uniquely identifying
-/// a single deployment (revision) of an environment.
+/// a single deployment (revision) of an environment. The nonce distinguishes
+/// multiple deployments of the same commit.
 ///
 /// # Examples
 ///
 /// ```
 /// use ids::DeploymentQid;
-/// let qid: DeploymentQid = "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268".parse().unwrap();
-/// assert_eq!(qid.to_string(), "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268");
+/// let qid: DeploymentQid = "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268.a1b2c3d4e5f60718".parse().unwrap();
+/// assert_eq!(qid.to_string(), "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268.a1b2c3d4e5f60718");
 /// assert_eq!(qid.environment_qid().to_string(), "MyOrg/MyRepo::main");
 /// assert_eq!(qid.repo_qid().to_string(), "MyOrg/MyRepo");
 /// ```
@@ -908,14 +1008,20 @@ impl<'de> Deserialize<'de> for ResourceQid {
 pub struct DeploymentQid {
     pub environment: EnvironmentQid,
     pub deployment: DeploymentId,
+    pub nonce: DeploymentNonce,
 }
 
 impl DeploymentQid {
     /// Creates a new `DeploymentQid`.
-    pub fn new(environment: EnvironmentQid, deployment: DeploymentId) -> Self {
+    pub fn new(
+        environment: EnvironmentQid,
+        deployment: DeploymentId,
+        nonce: DeploymentNonce,
+    ) -> Self {
         Self {
             environment,
             deployment,
+            nonce,
         }
     }
 
@@ -932,7 +1038,7 @@ impl DeploymentQid {
 
 impl fmt::Display for DeploymentQid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@{}", self.environment, self.deployment)
+        write!(f, "{}@{}.{}", self.environment, self.deployment, self.nonce)
     }
 }
 
@@ -945,8 +1051,12 @@ impl fmt::Debug for DeploymentQid {
 impl FromStr for DeploymentQid {
     type Err = ParseIdError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Split on the last "@" — the deployment ID is always 40 hex chars at the end.
-        let Some((env_part, deploy_part)) = s.rsplit_once('@') else {
+        // Split on the last "@" — everything after is "DeploymentId.Nonce".
+        let Some((env_part, deploy_nonce_part)) = s.rsplit_once('@') else {
+            return Err(ParseIdError::InvalidDeploymentQid(s.to_string()));
+        };
+        // Split the deployment+nonce part on the last ".".
+        let Some((deploy_part, nonce_part)) = deploy_nonce_part.rsplit_once('.') else {
             return Err(ParseIdError::InvalidDeploymentQid(s.to_string()));
         };
         Ok(Self {
@@ -954,6 +1064,9 @@ impl FromStr for DeploymentQid {
                 .parse()
                 .map_err(|_| ParseIdError::InvalidDeploymentQid(s.to_string()))?,
             deployment: deploy_part
+                .parse()
+                .map_err(|_| ParseIdError::InvalidDeploymentQid(s.to_string()))?,
+            nonce: nonce_part
                 .parse()
                 .map_err(|_| ParseIdError::InvalidDeploymentQid(s.to_string()))?,
         })
@@ -1075,8 +1188,36 @@ mod tests {
     }
 
     #[test]
+    fn deployment_nonce_roundtrip() {
+        let nonce = DeploymentNonce::from_u64(0xa1b2c3d4e5f60718);
+        assert_eq!(nonce.to_string(), "a1b2c3d4e5f60718");
+        let parsed: DeploymentNonce = "a1b2c3d4e5f60718".parse().unwrap();
+        assert_eq!(nonce, parsed);
+    }
+
+    #[test]
+    fn deployment_nonce_zero() {
+        let nonce = DeploymentNonce::zero();
+        assert_eq!(nonce.to_string(), "0000000000000000");
+        assert_eq!(nonce.as_u64(), 0);
+    }
+
+    #[test]
+    fn deployment_nonce_random_is_16_chars() {
+        let nonce = DeploymentNonce::random();
+        assert_eq!(nonce.to_string().len(), 16);
+    }
+
+    #[test]
+    fn deployment_nonce_invalid() {
+        assert!("too_short".parse::<DeploymentNonce>().is_err());
+        assert!("A1B2C3D4E5F60718".parse::<DeploymentNonce>().is_err()); // uppercase
+        assert!("zzzzzzzzzzzzzzzz".parse::<DeploymentNonce>().is_err()); // non-hex
+    }
+
+    #[test]
     fn deployment_qid_roundtrip() {
-        let s = "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268";
+        let s = "MyOrg/MyRepo::main@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268.a1b2c3d4e5f60718";
         let qid: DeploymentQid = s.parse().unwrap();
         assert_eq!(qid.to_string(), s);
         assert_eq!(qid.environment_qid().to_string(), "MyOrg/MyRepo::main");
@@ -1085,11 +1226,12 @@ mod tests {
             qid.deployment.as_str(),
             "2cbecbed4bfa1599ef4ce0dfc542c97a82d79268"
         );
+        assert_eq!(qid.nonce.as_u64(), 0xa1b2c3d4e5f60718);
     }
 
     #[test]
     fn deployment_qid_with_slashed_env() {
-        let s = "MyOrg/MyRepo::feature/my-branch@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268";
+        let s = "MyOrg/MyRepo::feature/my-branch@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268.a1b2c3d4e5f60718";
         let qid: DeploymentQid = s.parse().unwrap();
         assert_eq!(qid.to_string(), s);
         assert_eq!(
@@ -1100,7 +1242,7 @@ mod tests {
 
     #[test]
     fn deployment_qid_with_tag_env() {
-        let s = "MyOrg/MyRepo::tag:v1.0@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268";
+        let s = "MyOrg/MyRepo::tag:v1.0@2cbecbed4bfa1599ef4ce0dfc542c97a82d79268.a1b2c3d4e5f60718";
         let qid: DeploymentQid = s.parse().unwrap();
         assert_eq!(qid.to_string(), s);
         assert!(qid.environment_qid().environment.is_tag());

--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -283,16 +283,19 @@ impl ContainerPlugin {
         let env_qid: ids::EnvironmentQid = environment_qid.parse().map_err(|e| {
             PluginError::InvalidInput(format!("invalid environment QID '{environment_qid}': {e}"))
         })?;
-        let deployment: ids::DeploymentId = deployment_id.parse().map_err(|e| {
-            PluginError::InvalidInput(format!("invalid deployment ID '{deployment_id}': {e}"))
-        })?;
-        let deployment_qid = ids::DeploymentQid::new(env_qid.clone(), deployment);
+        let deployment_qid: ids::DeploymentQid =
+            format!("{env_qid}@{deployment_id}").parse().map_err(|e| {
+                PluginError::InvalidInput(format!(
+                    "invalid deployment QID '{env_qid}@{deployment_id}': {e}"
+                ))
+            })?;
 
         // Create a DeploymentClient for this deployment
         let repo_client = self.inner.cdb.repo(deployment_qid.repo_qid().clone());
         let deployment_client = repo_client.deployment(
             deployment_qid.environment_qid().environment.clone(),
             deployment_qid.deployment.clone(),
+            deployment_qid.nonce,
         );
 
         // Extract the Git context to a temporary directory

--- a/crates/rte/src/main.rs
+++ b/crates/rte/src/main.rs
@@ -222,9 +222,10 @@ async fn worker_loop_iteration(
 fn deployment_qid(
     environment_qid: &ids::EnvironmentQid,
     deployment_id: &ids::DeploymentId,
+    deployment_nonce: &ids::DeploymentNonce,
 ) -> String {
     environment_qid
-        .deployment(deployment_id.clone())
+        .deployment(deployment_id.clone(), *deployment_nonce)
         .to_string()
 }
 
@@ -379,7 +380,11 @@ async fn handle_create(
     };
 
     let id = resource_id_from_ref(&message.resource);
-    let dep_qid = deployment_qid(&message.resource.environment_qid, &message.deployment_id);
+    let dep_qid = deployment_qid(
+        &message.resource.environment_qid,
+        &message.deployment_id,
+        &message.deployment_nonce,
+    );
     let res_qid = resource_qid_string(&message.resource);
     let dep_short = deployment_short(&message.deployment_id);
 
@@ -513,7 +518,11 @@ async fn handle_destroy(
             message.resource.resource_type().to_owned(),
             message.resource.resource_name().to_owned(),
         );
-    let dep_qid = deployment_qid(&message.resource.environment_qid, &message.deployment_id);
+    let dep_qid = deployment_qid(
+        &message.resource.environment_qid,
+        &message.deployment_id,
+        &message.deployment_nonce,
+    );
 
     let current = match resource_client.get().await {
         Ok(Some(resource)) => {
@@ -698,6 +707,7 @@ struct UpdateParams<'a> {
     resource: &'a rtq::ResourceRef,
     owner_deployment_qid: &'a str,
     target_deployment_id: &'a ids::DeploymentId,
+    target_deployment_nonce: &'a ids::DeploymentNonce,
     desired_inputs: serde_json::Value,
     dependencies: &'a [rtq::ResourceRef],
     operation: &'a str,
@@ -843,8 +853,11 @@ async fn handle_update_inputs(
             return Ok(None);
         };
 
-        let target_dep_qid_for_log =
-            deployment_qid(&resource.environment_qid, target_deployment_id);
+        let target_dep_qid_for_log = deployment_qid(
+            &resource.environment_qid,
+            target_deployment_id,
+            params.target_deployment_nonce,
+        );
         let verb = match operation {
             "adopt" => "Adopting",
             "restore" => "Restoring",
@@ -935,7 +948,11 @@ async fn handle_update_inputs(
         );
     }
 
-    let target_dep_qid = deployment_qid(&resource.environment_qid, target_deployment_id);
+    let target_dep_qid = deployment_qid(
+        &resource.environment_qid,
+        target_deployment_id,
+        params.target_deployment_nonce,
+    );
 
     let outputs = outputs_to_persist.unwrap_or_default();
     if let Err(error) = persist_resource_state(
@@ -984,12 +1001,14 @@ async fn handle_adopt(
     let from_dep_qid = deployment_qid(
         &message.resource.environment_qid,
         &message.from_deployment_id,
+        &message.from_deployment_nonce,
     );
     let Some(to_dep_qid) = handle_update_inputs(
         UpdateParams {
             resource: &message.resource,
             owner_deployment_qid: &from_dep_qid,
             target_deployment_id: &message.to_deployment_id,
+            target_deployment_nonce: &message.to_deployment_nonce,
             desired_inputs: message.desired_inputs.clone(),
             dependencies: &message.dependencies,
             operation: "adopt",
@@ -1042,12 +1061,17 @@ async fn handle_restore(
     delivery: &rtq::Delivery,
     ctx: &WorkerContext,
 ) -> anyhow::Result<()> {
-    let dep_qid = deployment_qid(&message.resource.environment_qid, &message.deployment_id);
+    let dep_qid = deployment_qid(
+        &message.resource.environment_qid,
+        &message.deployment_id,
+        &message.deployment_nonce,
+    );
     let Some(dep_qid) = handle_update_inputs(
         UpdateParams {
             resource: &message.resource,
             owner_deployment_qid: &dep_qid,
             target_deployment_id: &message.deployment_id,
+            target_deployment_nonce: &message.deployment_nonce,
             desired_inputs: message.desired_inputs.clone(),
             dependencies: &message.dependencies,
             operation: "restore",
@@ -1099,7 +1123,11 @@ async fn handle_check(
             message.resource.resource_type().to_owned(),
             message.resource.resource_name().to_owned(),
         );
-    let dep_qid = deployment_qid(&message.resource.environment_qid, &message.deployment_id);
+    let dep_qid = deployment_qid(
+        &message.resource.environment_qid,
+        &message.deployment_id,
+        &message.deployment_nonce,
+    );
 
     let current = match resource_client.get().await {
         Ok(Some(resource)) => {

--- a/crates/rtq/src/lib.rs
+++ b/crates/rtq/src/lib.rs
@@ -173,6 +173,7 @@ impl ResourceRef {
 pub struct CreateMessage {
     pub resource: ResourceRef,
     pub deployment_id: ids::DeploymentId,
+    pub deployment_nonce: ids::DeploymentNonce,
     pub inputs: Value,
     pub dependencies: Vec<ResourceRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -184,6 +185,7 @@ pub struct CreateMessage {
 pub struct RestoreMessage {
     pub resource: ResourceRef,
     pub deployment_id: ids::DeploymentId,
+    pub deployment_nonce: ids::DeploymentNonce,
     pub desired_inputs: Value,
     pub dependencies: Vec<ResourceRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -196,7 +198,9 @@ pub struct RestoreMessage {
 pub struct AdoptMessage {
     pub resource: ResourceRef,
     pub from_deployment_id: ids::DeploymentId,
+    pub from_deployment_nonce: ids::DeploymentNonce,
     pub to_deployment_id: ids::DeploymentId,
+    pub to_deployment_nonce: ids::DeploymentNonce,
     pub desired_inputs: Value,
     pub dependencies: Vec<ResourceRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -208,6 +212,7 @@ pub struct AdoptMessage {
 pub struct DestroyMessage {
     pub resource: ResourceRef,
     pub deployment_id: ids::DeploymentId,
+    pub deployment_nonce: ids::DeploymentNonce,
 }
 
 /// Request to check (verify) the current state of a resource.
@@ -215,6 +220,7 @@ pub struct DestroyMessage {
 pub struct CheckMessage {
     pub resource: ResourceRef,
     pub deployment_id: ids::DeploymentId,
+    pub deployment_nonce: ids::DeploymentNonce,
 }
 
 #[derive(Debug, Error)]

--- a/crates/sclc/src/cross_repo.rs
+++ b/crates/sclc/src/cross_repo.rs
@@ -136,6 +136,7 @@ impl CrossRepoPackageFinder {
         let dc = self.cdb.repo(repo.clone()).deployment(
             deployment.environment.environment.clone(),
             deployment.deployment.clone(),
+            deployment.nonce,
         );
         let pkg: Arc<dyn Package> = Arc::new(CachedPackage::new(dc));
 
@@ -196,7 +197,7 @@ impl CrossRepoPackageFinder {
                         return Ok(repo
                             .clone()
                             .environment(deployment.environment)
-                            .deployment(deployment.deployment));
+                            .deployment(deployment.deployment, deployment.nonce));
                     }
                 }
                 Err(CrossRepoError::Unresolved {
@@ -224,7 +225,7 @@ impl CrossRepoPackageFinder {
                 return Ok(repo
                     .clone()
                     .environment(deployment.environment)
-                    .deployment(deployment.deployment));
+                    .deployment(deployment.deployment, deployment.nonce));
             }
         }
         Err(CrossRepoError::Unresolved {

--- a/crates/sclc/src/lib.rs
+++ b/crates/sclc/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// that need to construct an [`EvalCtx`] without a real deployment behind it
 /// (e.g. the REPL, the wasm playground, or in-memory unit tests).
 pub fn placeholder_deployment_qid() -> ids::DeploymentQid {
-    "placeholder/placeholder::main@0000000000000000000000000000000000000000"
+    "placeholder/placeholder::main@0000000000000000000000000000000000000000.0000000000000000"
         .parse()
         .expect("placeholder deployment QID is well-formed")
 }

--- a/crates/sclc/src/package.rs
+++ b/crates/sclc/src/package.rs
@@ -301,7 +301,11 @@ mod cdb_finder {
             };
 
             // Construct a cached DeploymentClient.
-            let dc = repo_client.deployment(deployment.environment, deployment.deployment);
+            let dc = repo_client.deployment(
+                deployment.environment,
+                deployment.deployment,
+                deployment.nonce,
+            );
             let pkg: Arc<dyn Package> = Arc::new(CachedPackage::new(dc));
             self.cache
                 .write()

--- a/crates/sclc/src/tests/cross_repo_eval.rs
+++ b/crates/sclc/src/tests/cross_repo_eval.rs
@@ -13,7 +13,9 @@ use crate::{Effect, EvalCtx, PackageId, Record, Resource, Value, placeholder_dep
 
 fn foreign_qid(suffix: char) -> DeploymentQid {
     let hash: String = std::iter::repeat(suffix).take(40).collect();
-    format!("foreign/repo::main@{hash}").parse().unwrap()
+    format!("foreign/repo::main@{hash}.0000000000000000")
+        .parse()
+        .unwrap()
 }
 
 fn record_with(name: &str, value: Value) -> Record {

--- a/crates/sclc/src/tests/effect_owner.rs
+++ b/crates/sclc/src/tests/effect_owner.rs
@@ -65,9 +65,10 @@ async fn current_owner_falls_back_to_local() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn with_owner_pushes_and_pops() {
     let local_owner = placeholder_deployment_qid();
-    let foreign: ids::DeploymentQid = "foreign/repo::main@1111111111111111111111111111111111111111"
-        .parse()
-        .unwrap();
+    let foreign: ids::DeploymentQid =
+        "foreign/repo::main@1111111111111111111111111111111111111111.0000000000000000"
+            .parse()
+            .unwrap();
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let ctx = EvalCtx::new(tx, "test", local_owner.clone());
 
@@ -80,9 +81,10 @@ async fn with_owner_pushes_and_pops() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn package_owner_falls_back_to_local() {
     let local_owner = placeholder_deployment_qid();
-    let foreign: ids::DeploymentQid = "foreign/repo::main@2222222222222222222222222222222222222222"
-        .parse()
-        .unwrap();
+    let foreign: ids::DeploymentQid =
+        "foreign/repo::main@2222222222222222222222222222222222222222.0000000000000000"
+            .parse()
+            .unwrap();
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut ctx = EvalCtx::new(tx, "test", local_owner.clone());
 

--- a/crates/scs/src/git/mod.rs
+++ b/crates/scs/src/git/mod.rs
@@ -67,19 +67,10 @@ impl<'a> CommandHandler<'a> {
             let deployment = deployment?;
 
             // Filter out deployments that are not the current head of
-            // their environment:
-            //   * Undesired/Lingering — an older deployment being torn
-            //     down or waiting to be.
-            //   * Failed — this deployment is terminal; either there is a
-            //     rollback `Desired` deployment in the same env (which
-            //     would otherwise produce a duplicate ref), or this env
-            //     genuinely has no working HEAD.
-            // `Failing` is kept: it's an actively-reconciled deployment
-            // that still represents the env's latest intent.
-            if matches!(
-                deployment.state,
-                DeploymentState::Undesired | DeploymentState::Lingering | DeploymentState::Failed
-            ) {
+            // their environment: Undesired/Lingering/Down are older
+            // deployments being torn down or already terminated.
+            // Only Desired deployments represent the environment's HEAD.
+            if deployment.state != DeploymentState::Desired {
                 continue;
             }
 

--- a/crates/scs/src/git/receive_pack.rs
+++ b/crates/scs/src/git/receive_pack.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail};
-use futures::AsyncWriteExt;
+use futures::{AsyncWriteExt, StreamExt};
 use tokio::io::AsyncReadExt;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -501,29 +501,33 @@ impl<'a> CommandHandler<'a> {
             if update.new != null_oid {
                 let deployment_id = ids::DeploymentId::from_bytes(update.new.as_bytes())
                     .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let deployment = self
-                    .client
-                    .deployment(environment_id.clone(), deployment_id);
-                deployment.set(DeploymentState::Desired).await?;
-            }
-
-            if update.old != null_oid && update.old != update.new {
-                let state = if update.new == null_oid {
-                    DeploymentState::Undesired
-                } else {
-                    DeploymentState::Lingering
-                };
+                let nonce = ids::DeploymentNonce::random();
+                let deployment =
+                    self.client
+                        .deployment(environment_id.clone(), deployment_id, nonce);
+                // make_desired atomically supersedes any active deployment
+                // in the same environment and promotes this one to Desired.
+                deployment.make_desired().await?;
+            } else if update.old != null_oid {
+                // Deleting a ref: find the active deployment for this
+                // environment and transition it to Undesired.
                 let old_deployment_id = ids::DeploymentId::from_bytes(update.old.as_bytes())
                     .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let deployment = self.client.deployment(environment_id, old_deployment_id);
-                let new_deployment_id = ids::DeploymentId::from_bytes(update.new.as_bytes())
-                    .map_err(|e| anyhow!("invalid deployment id: {}", e))?;
-                let (r1, r2) = futures::join!(
-                    deployment.set(state),
-                    deployment.mark_superseded_by(&new_deployment_id),
-                );
-                r1?;
-                r2?;
+                // Look up the deployment by scanning active deployments
+                // in this environment to find the one with this commit hash.
+                let mut stream = self.client.active_deployments().await?;
+                while let Some(dep) = stream.next().await {
+                    let dep = dep?;
+                    if dep.environment == environment_id && dep.deployment == old_deployment_id {
+                        let dc = self.client.deployment(
+                            dep.environment.clone(),
+                            dep.deployment.clone(),
+                            dep.nonce,
+                        );
+                        dc.set(DeploymentState::Undesired).await?;
+                        break;
+                    }
+                }
             }
 
             results.push(update.name.clone());

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             wasm-pack
             wasm-bindgen-cli
             typst
+            tlaplus18
           ];
           shellHook = ''
             export RUSTUP_TOOLCHAIN=nightly

--- a/web/src/lib/components/DeploymentState.svelte
+++ b/web/src/lib/components/DeploymentState.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
 import { DeploymentState } from "$lib/graphql/generated";
 
-let { state, size = "default" }: { state: DeploymentState; size?: "default" | "small" } = $props();
+let { state, bootstrapped = false, size = "default" }: { state: DeploymentState; bootstrapped?: boolean; size?: "default" | "small" } = $props();
 
 const styles: Record<DeploymentState, { bg: string; text: string }> = {
-    [DeploymentState.Up]: {
-        bg: "bg-green-50 border-green-300",
-        text: "text-green-700",
-    },
     [DeploymentState.Desired]: {
         bg: "bg-blue-50 border-blue-300",
         text: "text-blue-700",
@@ -24,18 +20,24 @@ const styles: Record<DeploymentState, { bg: string; text: string }> = {
         bg: "bg-orange-50 border-orange-300",
         text: "text-orange-700",
     },
-    [DeploymentState.Failing]: {
-        bg: "bg-amber-50 border-amber-300",
-        text: "text-amber-700",
-    },
-    [DeploymentState.Failed]: {
-        bg: "bg-red-50 border-red-300",
-        text: "text-red-700",
-    },
 };
 
-const style = $derived(styles[state]);
+const bootstrappedStyles = {
+    bg: "bg-green-50 border-green-300",
+    text: "text-green-700",
+};
+
+const style = $derived(
+    state === DeploymentState.Desired && bootstrapped
+        ? bootstrappedStyles
+        : styles[state],
+);
 const iconSize = $derived(size === "small" ? 10 : 12);
+const label = $derived(
+    state === DeploymentState.Desired && bootstrapped
+        ? "BOOTSTRAPPED"
+        : state,
+);
 </script>
 
 <span
@@ -44,7 +46,20 @@ const iconSize = $derived(size === "small" ? 10 : 12);
         ? 'px-1.5 py-px'
         : 'px-2 py-0.5'}"
 >
-    {#if state === DeploymentState.Up || state === DeploymentState.Down}
+    {#if state === DeploymentState.Desired && bootstrapped}
+        <svg
+            width={iconSize}
+            height={iconSize}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        >
+            <polyline points="3,8.5 6.5,12 13,4" />
+        </svg>
+    {:else if state === DeploymentState.Down}
         <svg
             width={iconSize}
             height={iconSize}
@@ -96,35 +111,8 @@ const iconSize = $derived(size === "small" ? 10 : 12);
         >
             <path d="M8 1.5a6.5 6.5 0 1 1-6.5 6.5" />
         </svg>
-    {:else if state === DeploymentState.Failing}
-        <svg
-            class="spinner-slow"
-            width={iconSize}
-            height={iconSize}
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-        >
-            <path d="M8 1.5a6.5 6.5 0 1 1-6.5 6.5" />
-        </svg>
-    {:else if state === DeploymentState.Failed}
-        <svg
-            width={iconSize}
-            height={iconSize}
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-        >
-            <line x1="4" y1="4" x2="12" y2="12" />
-            <line x1="12" y1="4" x2="4" y2="12" />
-        </svg>
     {/if}
-    {state}
+    {label}
 </span>
 
 <style>

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -60,10 +60,13 @@ export type CommitTreeEntryArgs = {
 
 export type Deployment = {
   __typename?: 'Deployment';
+  bootstrapped: Scalars['Boolean']['output'];
   commit: Commit;
   createdAt: Scalars['String']['output'];
+  failures: Scalars['Int']['output'];
   id: Scalars['String']['output'];
   lastLogs: Array<Log>;
+  nonce: Scalars['String']['output'];
   ref: Scalars['String']['output'];
   resources: Array<Resource>;
   state: DeploymentState;
@@ -77,11 +80,8 @@ export type DeploymentLastLogsArgs = {
 export enum DeploymentState {
   Desired = 'DESIRED',
   Down = 'DOWN',
-  Failed = 'FAILED',
-  Failing = 'FAILING',
   Lingering = 'LINGERING',
-  Undesired = 'UNDESIRED',
-  Up = 'UP'
+  Undesired = 'UNDESIRED'
 }
 
 export type Environment = {

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/+page.svelte
@@ -19,7 +19,7 @@ let env = $derived(envDetail.data?.organization.repository.environment ?? null);
 
 let desiredDeployment = $derived(
     env?.deployments.find(
-        (d) => d.state === DeploymentState.Desired || d.state === DeploymentState.Up,
+        (d) => d.state === DeploymentState.Desired,
     ) ?? null,
 );
 </script>

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
@@ -37,7 +37,6 @@ const liveStates: DeploymentState[] = [
     DeploymentState.Desired,
     DeploymentState.Lingering,
     DeploymentState.Undesired,
-    DeploymentState.Failing,
 ];
 let isLive = $derived(deployment != null && liveStates.includes(deployment.state));
 


### PR DESCRIPTION
## Summary

Redesigns the Deployment Engine around a simpler, formally verified lifecycle model with four states: **DESIRED → LINGERING → UNDESIRED → DOWN**.

### TLA+ specification

A formal TLA+ model of the lifecycle state machine lives in `crates/de/spec/`. TLC verifies three safety invariants across ~97k reachable states:

- **TypeOK** — all variables stay within declared domains
- **CurrentResourcesSafe** — once the current deployment is bootstrapped, its resources remain alive
- **NoResourceContention** — at most one deployment actively creates/adopts resources at a time

Under fair scheduling, the model also checks that every superseded deployment eventually reaches DOWN.

### Lifecycle changes

- **Simplified states**: Remove `UP`, `FAILING`, `FAILED`. A DESIRED deployment stays DESIRED until superseded — the `bootstrapped` flag tracks convergence separately.
- **LINGERING**: Superseded deployments idle until the current deployment is bootstrapped, then transition to UNDESIRED for teardown.
- **Failures are observational**: The `failures` counter drives exponential backoff but does not alter lifecycle transitions. No more rollback mechanism — operators use `makeDeploymentDesired` to retry.
- **Resource adoption is ID-based**: A desired deployment adopts any resource in the environment pool that matches by resource identity (type + name), regardless of which deployment currently owns it.

### Deployment identity

Introduces `DeploymentNonce` — a random component added to the deployment identity alongside the commit hash. This allows the same commit to be deployed multiple times as distinct deployments (`µ = << commit_hash, nonce >>`). The SCS generates a random nonce on each git push.

### Crate changes

- **ids**: Add `DeploymentNonce`, `DeploymentQid`, nonce-aware parsing and formatting
- **cdb**: Add `bootstrapped`/`failures` fields, `set_progress()`, `make_desired()` for atomic supersession, `mark_superseded_by()`/`get_superseding()`/`superseded()` for supersession chain traversal
- **de**: Rewrite lifecycle handlers for the four-state model with exponential backoff, dependency-respecting teardown, and ID-based resource adoption
- **rtq**: Add `DeploymentNonce` to all message types
- **rte**: Update message handling for nonce-aware identity
- **scs**: Generate random nonce on push, use `make_desired()` for atomic supersession
- **api**: Update GraphQL schema and resolvers for new state model
- **web**: Update frontend deployment state display
