### PR TITLE
feat(scop,plugin_std_container,scoc): add GetOverlayPeers RPC

### DIFF
--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -2515,6 +2515,29 @@ impl scop::Orchestrator for ContainerPlugin {
             }
         }
     }
+
+    async fn get_overlay_peers(
+        &self,
+        request: scop::GetOverlayPeersRequest,
+    ) -> Result<scop::GetOverlayPeersResponse, scop::tonic::Status> {
+        let nodes = {
+            let mut registry = self.inner.node_registry.write().await;
+            registry
+                .list()
+                .await
+                .map_err(|e| scop::tonic::Status::internal(format!("failed to list nodes: {e}")))?
+        };
+
+        let peers = nodes
+            .into_iter()
+            .filter(|n| n.name != request.node_name && !n.overlay_endpoint.is_empty())
+            .map(|n| scop::OverlayPeer {
+                peer_host_ip: n.overlay_endpoint,
+            })
+            .collect();
+
+        Ok(scop::GetOverlayPeersResponse { peers })
+    }
 }
 
 // =============================================================================

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -1153,46 +1153,6 @@ async fn main() -> Result<()> {
                 dns_records,
             );
 
-            // Pull overlay peers from orchestrator now that Conduit is accepting connections
-            {
-                match scop::OrchestratorClient::connect(orchestrator_address.clone()).await {
-                    Ok(mut client) => {
-                        match client
-                            .get_overlay_peers(scop::GetOverlayPeersRequest {
-                                node_name: node_name.clone(),
-                            })
-                            .await
-                        {
-                            Ok(response) => {
-                                let peers = response.into_inner().peers;
-                                tracing::info!(
-                                    peer_count = peers.len(),
-                                    "fetched overlay peers from orchestrator"
-                                );
-                                for peer in &peers {
-                                    let peer_ip = match resolve_hostname_to_ip(&peer.peer_host_ip) {
-                                        Ok(ip) => ip,
-                                        Err(e) => {
-                                            tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to resolve overlay peer");
-                                            continue;
-                                        }
-                                    };
-                                    if let Err(e) = net::add_overlay_peer(&peer_ip) {
-                                        tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to add overlay peer");
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "failed to fetch overlay peers from orchestrator");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "failed to connect to orchestrator for peer fetch");
-                    }
-                }
-            }
-
             // Spawn heartbeat task with exponential backoff and re-registration
             let node_name_heartbeat = node_name.clone();
             let orchestrator_address_heartbeat = orchestrator_address.clone();
@@ -1338,6 +1298,46 @@ async fn main() -> Result<()> {
             let bind_target = format!("http://{}", bind);
             let server_handle =
                 tokio::spawn(async move { scop::serve_conduit(&bind_target, conduit).await });
+
+            // Pull overlay peers from orchestrator after Conduit server has been spawned
+            {
+                match scop::OrchestratorClient::connect(orchestrator_address.clone()).await {
+                    Ok(mut client) => {
+                        match client
+                            .get_overlay_peers(scop::GetOverlayPeersRequest {
+                                node_name: node_name.clone(),
+                            })
+                            .await
+                        {
+                            Ok(response) => {
+                                let peers = response.into_inner().peers;
+                                tracing::info!(
+                                    peer_count = peers.len(),
+                                    "fetched overlay peers from orchestrator"
+                                );
+                                for peer in &peers {
+                                    let peer_ip = match resolve_hostname_to_ip(&peer.peer_host_ip) {
+                                        Ok(ip) => ip,
+                                        Err(e) => {
+                                            tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to resolve overlay peer");
+                                            continue;
+                                        }
+                                    };
+                                    if let Err(e) = net::add_overlay_peer(&peer_ip) {
+                                        tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to add overlay peer");
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "failed to fetch overlay peers from orchestrator");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to connect to orchestrator for peer fetch");
+                    }
+                }
+            }
 
             // Wait for shutdown signal
             tokio::select! {

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -1153,6 +1153,46 @@ async fn main() -> Result<()> {
                 dns_records,
             );
 
+            // Pull overlay peers from orchestrator now that Conduit is accepting connections
+            {
+                match scop::OrchestratorClient::connect(orchestrator_address.clone()).await {
+                    Ok(mut client) => {
+                        match client
+                            .get_overlay_peers(scop::GetOverlayPeersRequest {
+                                node_name: node_name.clone(),
+                            })
+                            .await
+                        {
+                            Ok(response) => {
+                                let peers = response.into_inner().peers;
+                                tracing::info!(
+                                    peer_count = peers.len(),
+                                    "fetched overlay peers from orchestrator"
+                                );
+                                for peer in &peers {
+                                    let peer_ip = match resolve_hostname_to_ip(&peer.peer_host_ip) {
+                                        Ok(ip) => ip,
+                                        Err(e) => {
+                                            tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to resolve overlay peer");
+                                            continue;
+                                        }
+                                    };
+                                    if let Err(e) = net::add_overlay_peer(&peer_ip) {
+                                        tracing::warn!(peer = %peer.peer_host_ip, error = %e, "failed to add overlay peer");
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "failed to fetch overlay peers from orchestrator");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to connect to orchestrator for peer fetch");
+                    }
+                }
+            }
+
             // Spawn heartbeat task with exponential backoff and re-registration
             let node_name_heartbeat = node_name.clone();
             let orchestrator_address_heartbeat = orchestrator_address.clone();

--- a/crates/scop/proto/scop.proto
+++ b/crates/scop/proto/scop.proto
@@ -113,6 +113,24 @@ message UnregisterNodeResponse {
   bool success = 1;
 }
 
+// Request to retrieve overlay peers for a node.
+message GetOverlayPeersRequest {
+  // Name of the requesting node.
+  string node_name = 1;
+}
+
+// Response containing the list of overlay peers.
+message GetOverlayPeersResponse {
+  // The list of overlay peers (other nodes in the mesh).
+  repeated OverlayPeer peers = 1;
+}
+
+// Information about an overlay peer (another node in the VXLAN mesh).
+message OverlayPeer {
+  // The peer's host IP for VXLAN tunneling.
+  string peer_host_ip = 1;
+}
+
 // ============================================================================
 // Conduit Service (served by SCOC)
 // ============================================================================

--- a/crates/scop/proto/scop.proto
+++ b/crates/scop/proto/scop.proto
@@ -31,6 +31,9 @@ service Orchestrator {
 
   // UnregisterNode removes a node from the registry.
   rpc UnregisterNode(UnregisterNodeRequest) returns (UnregisterNodeResponse);
+
+  // GetOverlayPeers retrieves the list of overlay peers for a node.
+  rpc GetOverlayPeers(GetOverlayPeersRequest) returns (GetOverlayPeersResponse);
 }
 
 // Request to register a node with the orchestrator.

--- a/crates/scop/src/lib.rs
+++ b/crates/scop/src/lib.rs
@@ -79,8 +79,9 @@ pub mod proto {
 
 // --- Node registration (Orchestrator) ---
 pub use proto::{
-    HeartbeatRequest, HeartbeatResponse, NodeCapacity, NodeUsage, RegisterNodeRequest,
-    RegisterNodeResponse, UnregisterNodeRequest, UnregisterNodeResponse,
+    GetOverlayPeersRequest, GetOverlayPeersResponse, HeartbeatRequest, HeartbeatResponse,
+    NodeCapacity, NodeUsage, OverlayPeer, RegisterNodeRequest, RegisterNodeResponse,
+    UnregisterNodeRequest, UnregisterNodeResponse,
 };
 
 // --- Pod lifecycle (Conduit) ---
@@ -349,6 +350,12 @@ pub trait Orchestrator: Send + Sync + 'static {
         &self,
         request: UnregisterNodeRequest,
     ) -> Result<UnregisterNodeResponse, tonic::Status>;
+
+    /// Get the list of overlay peers for a node.
+    async fn get_overlay_peers(
+        &self,
+        request: GetOverlayPeersRequest,
+    ) -> Result<GetOverlayPeersResponse, tonic::Status>;
 }
 
 #[derive(Clone)]
@@ -384,6 +391,17 @@ impl<O: Orchestrator> proto::orchestrator_server::Orchestrator for OrchestratorS
         let response = self
             .orchestrator
             .unregister_node(request.into_inner())
+            .await?;
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn get_overlay_peers(
+        &self,
+        request: tonic::Request<GetOverlayPeersRequest>,
+    ) -> Result<tonic::Response<GetOverlayPeersResponse>, tonic::Status> {
+        let response = self
+            .orchestrator
+            .get_overlay_peers(request.into_inner())
             .await?;
         Ok(tonic::Response::new(response))
     }


### PR DESCRIPTION
## Summary

- Add `GetOverlayPeers` RPC to the Orchestrator service for pull-based overlay peer discovery
- scoc nodes call this after their Conduit server starts to fetch the full peer list
- Belt-and-suspenders fix: even if registration-time push notifications fail, the node can pull its peers

## Changes

- `scop/proto/scop.proto`: New `GetOverlayPeers` RPC + message types (`GetOverlayPeersRequest`, `GetOverlayPeersResponse`, `OverlayPeer`)
- `scop/src/lib.rs`: Trait method, tonic glue, re-exports
- `plugin_std_container/src/main.rs`: Handler implementation (~15 lines)
- `scoc/src/main.rs`: Caller after Conduit server spawn (~40 lines)

## Context

During simultaneous scoc restarts, the orchestrator pushes peer notifications that often fail because target nodes aren't ready yet. This adds a pull mechanism so nodes can fetch their peer list on demand after their Conduit server is accepting connections.

## Test plan

- [ ] Restart all scoc nodes simultaneously, verify each node fetches peers after startup
- [ ] Verify `add_overlay_peer` idempotency (no issues with already-known peers)
- [ ] Run `cargo clippy --workspace -- -D warnings` — no warnings
- [ ] Run `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)