### PR TITLE
feat(scop): optional mTLS for conduit <-> orchestrator gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,6 +5336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6434,8 +6435,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/crates/plugin_std_container/README.md
+++ b/crates/plugin_std_container/README.md
@@ -68,6 +68,25 @@ cargo run -p plugin_std_container -- \
   --cluster-cidr 10.42.0.0/16
 ```
 
+### Enabling mTLS
+
+Both directions of SCOP traffic (orchestrator RPCs from SCOC → plugin, conduit
+RPCs from plugin → SCOC) can optionally run over mutual TLS. All three flags
+are required together; omit all three to run plain gRPC.
+
+```sh
+cargo run -p plugin_std_container -- \
+  ... \
+  --tls-ca /etc/skyr/tls/ca.pem \
+  --tls-cert /etc/skyr/tls/plugin.pem \
+  --tls-key /etc/skyr/tls/plugin.key
+```
+
+The leaf certificate must carry both `serverAuth` and `clientAuth` Extended
+Key Usages so one cert works for the orchestrator listener and for outbound
+conduit connections. Use the same CA for the plugin and every SCOC node; see
+[SCOC's README](../scoc/README.md#enabling-mtls) for an `openssl` recipe.
+
 ## Related Crates
 
 - [IDs](../ids/) — parses deployment QIDs from resource namespaces

--- a/crates/plugin_std_container/src/main.rs
+++ b/crates/plugin_std_container/src/main.rs
@@ -77,6 +77,21 @@ struct Args {
     /// Default is false (HTTPS required).
     #[arg(long, default_value_t = false)]
     insecure_registry: bool,
+
+    /// Path to the PEM-encoded CA certificate used to verify SCOC conduits
+    /// and incoming orchestrator clients. When set together with `--tls-cert`
+    /// and `--tls-key`, the orchestrator listener and all conduit RPCs use
+    /// mTLS. All three flags must be provided together; omit all three to run
+    /// plain gRPC.
+    #[arg(long)]
+    tls_ca: Option<std::path::PathBuf>,
+    /// Path to the PEM-encoded leaf certificate for the plugin. The cert
+    /// must carry both `serverAuth` and `clientAuth` Extended Key Usages.
+    #[arg(long)]
+    tls_cert: Option<std::path::PathBuf>,
+    /// Path to the PEM-encoded private key matching `--tls-cert`.
+    #[arg(long)]
+    tls_key: Option<std::path::PathBuf>,
 }
 
 // Resource type constants
@@ -121,6 +136,9 @@ struct ContainerPluginInner {
     vip_allocator: RwLock<vip_allocator::VipAllocator>,
     /// Nodes that missed a broadcast and need reconciliation on next heartbeat.
     nodes_needing_reconciliation: RwLock<HashSet<String>>,
+    /// Optional mTLS material used for all conduit RPCs and the orchestrator
+    /// listener. `None` means plain gRPC.
+    tls: Option<scop::TlsMaterial>,
 }
 
 /// The container plugin manages connections to worker nodes.
@@ -144,6 +162,7 @@ impl ContainerPlugin {
         cluster_cidr: String,
         service_cidr: String,
         vip_allocator: vip_allocator::VipAllocator,
+        tls: Option<scop::TlsMaterial>,
     ) -> Self {
         Self {
             inner: Arc::new(ContainerPluginInner {
@@ -158,8 +177,14 @@ impl ContainerPlugin {
                 service_cidr,
                 vip_allocator: RwLock::new(vip_allocator),
                 nodes_needing_reconciliation: RwLock::new(HashSet::new()),
+                tls,
             }),
         }
+    }
+
+    /// Borrow the loaded mTLS material, if any, for use by client RPCs.
+    fn tls(&self) -> Option<&scop::TlsMaterial> {
+        self.inner.tls.as_ref()
     }
 
     /// Get a conduit client to a node by name.
@@ -181,7 +206,7 @@ impl ContainerPlugin {
 
         // Connect to the node's conduit service
         info!(node_name = %node_name, address = %node.address, "connecting to conduit");
-        let client = scop::ConduitClient::connect(node.address.clone())
+        let client = scop::connect_conduit(node.address.clone(), self.tls())
             .await
             .map_err(|e| PluginError::Connect(e.to_string()))?;
 
@@ -1436,7 +1461,7 @@ impl ContainerPlugin {
                 continue;
             }
 
-            let mut client = match scop::ConduitClient::connect(node.address.clone()).await {
+            let mut client = match scop::connect_conduit(node.address.clone(), self.tls()).await {
                 Ok(c) => c,
                 Err(e) => {
                     warn!(
@@ -1572,7 +1597,7 @@ impl ContainerPlugin {
             }
         };
 
-        let mut client = match scop::ConduitClient::connect(node.address.clone()).await {
+        let mut client = match scop::connect_conduit(node.address.clone(), self.tls()).await {
             Ok(c) => c,
             Err(e) => {
                 warn!(node = %node_name, error = %e, "failed to connect for overlay reconciliation");
@@ -1621,7 +1646,7 @@ impl ContainerPlugin {
             }
         };
 
-        let mut client = match scop::ConduitClient::connect(node.address.clone()).await {
+        let mut client = match scop::connect_conduit(node.address.clone(), self.tls()).await {
             Ok(c) => c,
             Err(e) => {
                 warn!(node = %node_name, error = %e, "failed to connect for DNS reconciliation");
@@ -1714,10 +1739,11 @@ impl ContainerPlugin {
             let address = node.address.clone();
             let node_name = node.name.clone();
             let operation = operation.to_string();
+            let tls = self.inner.tls.clone();
 
             handles.push(tokio::spawn(async move {
                 let _permit = semaphore.acquire().await;
-                match scop::ConduitClient::connect(address).await {
+                match scop::connect_conduit(address, tls.as_ref()).await {
                     Ok(client) => (node_name, Ok(client)),
                     Err(e) => {
                         warn!(
@@ -2246,14 +2272,42 @@ async fn extract_tree_recursive(
     Ok(())
 }
 
+/// Resolve the three optional `--tls-*` flags into `Option<TlsMaterial>`.
+///
+/// Either all three are provided (mTLS enabled) or none (plain gRPC). Any
+/// other combination is a startup error.
+async fn load_tls(
+    ca: Option<std::path::PathBuf>,
+    cert: Option<std::path::PathBuf>,
+    key: Option<std::path::PathBuf>,
+) -> Result<Option<scop::TlsMaterial>> {
+    match (ca, cert, key) {
+        (Some(ca), Some(cert), Some(key)) => {
+            let material = scop::TlsPaths { ca, cert, key }.load().await?;
+            Ok(Some(material))
+        }
+        (None, None, None) => Ok(None),
+        _ => {
+            anyhow::bail!(
+                "--tls-ca, --tls-cert, and --tls-key must all be provided together, or all omitted"
+            )
+        }
+    }
+}
+
 /// Attempt to add an overlay peer on a target node, with bounded exponential backoff.
-async fn notify_overlay_peer(target_address: String, target_name: String, peer_ip: String) {
+async fn notify_overlay_peer(
+    target_address: String,
+    target_name: String,
+    peer_ip: String,
+    tls: Option<scop::TlsMaterial>,
+) {
     const MAX_RETRIES: u32 = 4;
     const BASE_DELAY: Duration = Duration::from_secs(1);
 
     for attempt in 0..=MAX_RETRIES {
         match async {
-            let mut client = scop::ConduitClient::connect(target_address.clone())
+            let mut client = scop::connect_conduit(target_address.clone(), tls.as_ref())
                 .await
                 .map_err(|e| e.to_string())?;
             client
@@ -2416,6 +2470,7 @@ impl scop::Orchestrator for ContainerPlugin {
                             existing.address.clone(),
                             existing.name.clone(),
                             overlay_endpoint.clone(),
+                            self.inner.tls.clone(),
                         ));
 
                         // Tell new node about existing peer (background with retries)
@@ -2423,6 +2478,7 @@ impl scop::Orchestrator for ContainerPlugin {
                             request.conduit_address.clone(),
                             request.node_name.clone(),
                             existing.overlay_endpoint.clone(),
+                            self.inner.tls.clone(),
                         ));
                     }
                 }
@@ -2537,7 +2593,7 @@ impl scop::Orchestrator for ContainerPlugin {
                         if node.overlay_endpoint.is_empty() {
                             continue;
                         }
-                        match scop::ConduitClient::connect(node.address.clone()).await {
+                        match scop::connect_conduit(node.address.clone(), self.tls()).await {
                             Ok(mut client) => {
                                 if let Err(e) = client
                                     .remove_overlay_peer(scop::RemoveOverlayPeerRequest {
@@ -2922,6 +2978,10 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Load optional mTLS material for orchestrator ↔ conduit RPCs
+    let tls = load_tls(args.tls_ca, args.tls_cert, args.tls_key).await?;
+    info!("  mtls: {}", tls.is_some());
+
     // Create the plugin (shared between both servers)
     let plugin = ContainerPlugin::new(
         node_registry,
@@ -2934,6 +2994,7 @@ async fn main() -> Result<()> {
         cluster_cidr.to_string(),
         service_cidr.to_string(),
         vip_alloc,
+        tls,
     );
 
     // Reconcile network state: rebuild overlay mesh and re-broadcast DNS/routes
@@ -2958,8 +3019,9 @@ async fn main() -> Result<()> {
     info!("Starting RTP server on {}", args.rtp_bind);
 
     // Run both servers concurrently
+    let orchestrator_tls = plugin.inner.tls.clone();
     tokio::select! {
-        result = scop::serve_orchestrator(&orchestrator_target, plugin) => {
+        result = scop::serve_orchestrator(&orchestrator_target, plugin, orchestrator_tls.as_ref()) => {
             error!("Orchestrator server exited");
             result?;
         }

--- a/crates/scoc/README.md
+++ b/crates/scoc/README.md
@@ -160,6 +160,54 @@ cargo run -p scoc -- daemon \
   --pod-netmask 24
 ```
 
+### Enabling mTLS
+
+SCOC and the container plugin can optionally authenticate each other with
+mutual TLS. All three flags are required together; omit all three to run
+plain gRPC.
+
+```sh
+cargo run -p scoc -- daemon \
+  ... \
+  --tls-ca /etc/scoc/tls/ca.pem \
+  --tls-cert /etc/scoc/tls/node.pem \
+  --tls-key /etc/scoc/tls/node.key
+```
+
+The leaf certificate must carry both `serverAuth` and `clientAuth` Extended
+Key Usages because SCOC acts as a gRPC server (for conduit RPCs from the
+plugin) and as a gRPC client (for `register_node`/`heartbeat`/`unregister_node`
+calls to the orchestrator). Use the same CA on both sides and issue a leaf
+cert per node with the node hostname in a SAN that matches the conduit
+address passed via `--conduit-address`.
+
+Example issuance with `openssl` (simplified — production deployments should
+use an automated PKI):
+
+```sh
+# 1. Self-signed CA
+openssl req -x509 -newkey rsa:4096 -nodes -days 3650 \
+  -subj "/CN=Skyr SCOP CA" -keyout ca.key -out ca.pem
+
+# 2. Leaf key + CSR
+openssl req -newkey rsa:4096 -nodes \
+  -subj "/CN=scoc-1" \
+  -addext "subjectAltName=DNS:scoc-1" \
+  -addext "extendedKeyUsage=serverAuth,clientAuth" \
+  -keyout node.key -out node.csr
+
+# 3. Sign with CA, preserving EKUs
+openssl x509 -req -days 365 -in node.csr -CA ca.pem -CAkey ca.key \
+  -CAcreateserial -out node.pem \
+  -copy_extensions copyall
+```
+
+The container plugin takes the same three flags (`--tls-ca`, `--tls-cert`,
+`--tls-key`) — see `plugin_std_container`'s README.
+
+In container deployments the matching env vars `SCOC_TLS_CA`, `SCOC_TLS_CERT`,
+`SCOC_TLS_KEY` are forwarded by `dev/scoc-entrypoint.sh`.
+
 ## Related Crates
 
 - [SCOP](../scop/) — the protocol SCOC serves

--- a/crates/scoc/src/main.rs
+++ b/crates/scoc/src/main.rs
@@ -60,6 +60,20 @@ enum Command {
         /// a smaller subnet (fewer pods). Default /24 = 254 pods.
         #[arg(long, default_value = "24")]
         pod_netmask: String,
+        /// Path to the PEM-encoded CA certificate used to verify the
+        /// orchestrator and incoming conduit clients. When set together with
+        /// `--tls-cert` and `--tls-key`, the conduit listener and all
+        /// orchestrator RPCs use mTLS. All three flags must be provided
+        /// together; omit all three to run plain gRPC.
+        #[arg(long)]
+        tls_ca: Option<PathBuf>,
+        /// Path to the PEM-encoded leaf certificate for this node. The cert
+        /// must carry both `serverAuth` and `clientAuth` Extended Key Usages.
+        #[arg(long)]
+        tls_cert: Option<PathBuf>,
+        /// Path to the PEM-encoded private key matching `--tls-cert`.
+        #[arg(long)]
+        tls_key: Option<PathBuf>,
     },
     /// Check CRI connectivity and version.
     Version {
@@ -1029,6 +1043,9 @@ async fn main() -> Result<()> {
             max_pods,
             ldb_brokers,
             pod_netmask,
+            tls_ca,
+            tls_cert,
+            tls_key,
         } => {
             // Parse --pod-netmask, stripping optional leading slash
             let pod_netmask: u32 = pod_netmask
@@ -1041,6 +1058,8 @@ async fn main() -> Result<()> {
                 "--pod-netmask must be between 1 and 30"
             );
 
+            let tls = load_tls(tls_ca, tls_cert, tls_key).await?.map(Arc::new);
+
             tracing::info!("SCOC conduit starting");
             tracing::info!("  node_name: {}", node_name);
             tracing::info!("  bind: {}", bind);
@@ -1049,6 +1068,7 @@ async fn main() -> Result<()> {
             tracing::info!("  containerd_socket: {}", containerd_socket);
             tracing::info!("  ldb_brokers: {}", ldb_brokers);
             tracing::info!("  pod_netmask: /{}", pod_netmask);
+            tracing::info!("  mtls: {}", tls.is_some());
 
             // Verify CRI connectivity at startup
             let cri = {
@@ -1090,8 +1110,9 @@ async fn main() -> Result<()> {
             // registration.
             let listener = tokio::net::TcpListener::bind(&bind).await?;
             tracing::info!("Conduit TCP listener bound on {}", bind);
+            let server_tls = tls.clone();
             let server_handle = tokio::spawn(async move {
-                scop::serve_conduit_on_tcp_listener(listener, conduit).await
+                scop::serve_conduit_on_tcp_listener(listener, conduit, server_tls.as_deref()).await
             });
 
             // Connect to orchestrator and register (with retries)
@@ -1099,7 +1120,8 @@ async fn main() -> Result<()> {
             let mut retries = 0;
             let max_retries = 30;
             let register_response = loop {
-                match scop::OrchestratorClient::connect(orchestrator_address.clone()).await {
+                match scop::connect_orchestrator(orchestrator_address.clone(), tls.as_deref()).await
+                {
                     Ok(mut orchestrator) => {
                         match orchestrator
                             .register_node(scop::RegisterNodeRequest {
@@ -1238,7 +1260,8 @@ async fn main() -> Result<()> {
             // Pull overlay peers from orchestrator now that the Conduit server is running
             // and the network is initialized.
             {
-                match scop::OrchestratorClient::connect(orchestrator_address.clone()).await {
+                match scop::connect_orchestrator(orchestrator_address.clone(), tls.as_deref()).await
+                {
                     Ok(mut client) => {
                         match client
                             .get_overlay_peers(scop::GetOverlayPeersRequest {
@@ -1281,6 +1304,7 @@ async fn main() -> Result<()> {
             let orchestrator_address_heartbeat = orchestrator_address.clone();
             let conduit_address_heartbeat = conduit_address.clone();
             let pod_cidr_heartbeat = pod_cidr;
+            let tls_heartbeat = tls.clone();
             let heartbeat_handle = tokio::spawn(async move {
                 const BASE_INTERVAL_SECS: u64 = 30;
                 const MAX_BACKOFF_SECS: u64 = 300;
@@ -1318,8 +1342,9 @@ async fn main() -> Result<()> {
                             "heartbeat failures exceeded threshold, attempting re-registration"
                         );
 
-                        match scop::OrchestratorClient::connect(
+                        match scop::connect_orchestrator(
                             orchestrator_address_heartbeat.clone(),
+                            tls_heartbeat.as_deref(),
                         )
                         .await
                         {
@@ -1373,8 +1398,11 @@ async fn main() -> Result<()> {
                     }
 
                     // Normal heartbeat
-                    match scop::OrchestratorClient::connect(orchestrator_address_heartbeat.clone())
-                        .await
+                    match scop::connect_orchestrator(
+                        orchestrator_address_heartbeat.clone(),
+                        tls_heartbeat.as_deref(),
+                    )
+                    .await
                     {
                         Ok(mut client) => {
                             match client
@@ -1445,7 +1473,8 @@ async fn main() -> Result<()> {
 
             // Unregister from orchestrator
             tracing::info!("Unregistering from orchestrator");
-            if let Ok(mut client) = scop::OrchestratorClient::connect(orchestrator_address).await
+            if let Ok(mut client) =
+                scop::connect_orchestrator(orchestrator_address, tls.as_deref()).await
                 && let Err(e) = client
                     .unregister_node(scop::UnregisterNodeRequest {
                         node_name: node_name.clone(),
@@ -1488,6 +1517,29 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Resolve the three optional `--tls-*` flags into `Option<TlsMaterial>`.
+///
+/// Either all three are provided (mTLS enabled) or none (plain gRPC). Any
+/// other combination is a startup error.
+async fn load_tls(
+    ca: Option<PathBuf>,
+    cert: Option<PathBuf>,
+    key: Option<PathBuf>,
+) -> Result<Option<scop::TlsMaterial>> {
+    match (ca, cert, key) {
+        (Some(ca), Some(cert), Some(key)) => {
+            let material = scop::TlsPaths { ca, cert, key }.load().await?;
+            Ok(Some(material))
+        }
+        (None, None, None) => Ok(None),
+        _ => {
+            anyhow::bail!(
+                "--tls-ca, --tls-cert, and --tls-key must all be provided together, or all omitted"
+            )
+        }
+    }
 }
 
 /// Extract the host from a conduit address like "http://192.168.1.10:50054" or "http://scoc-1:50054".

--- a/crates/scop/Cargo.toml
+++ b/crates/scop/Cargo.toml
@@ -10,7 +10,7 @@ prost = "0.13"
 thiserror = "2.0"
 tokio = { version = "1.49", features = ["fs", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.12", features = ["transport"] }
+tonic = { version = "0.12", features = ["transport", "tls"] }
 tracing = "0.1"
 
 [build-dependencies]

--- a/crates/scop/src/lib.rs
+++ b/crates/scop/src/lib.rs
@@ -53,11 +53,15 @@
 //!
 //! ## Transport Security
 //!
-//! SCOP does not enforce TLS at the protocol level. In production deployments,
-//! transport encryption **must** be provided by the infrastructure layer (e.g.,
-//! a service mesh, encrypted overlay network, or Unix domain sockets). TCP
-//! listeners should never be exposed on untrusted networks without TLS
-//! termination in front.
+//! SCOP supports optional mutual TLS (mTLS) on both the Orchestrator and
+//! Conduit services. Callers that want mTLS load a [`TlsMaterial`] from
+//! [`TlsPaths`] (CA, leaf cert, private key) and pass it to the
+//! `serve_*`/`connect_*` helpers. Leaf certificates are expected to carry both
+//! the `serverAuth` and `clientAuth` Extended Key Usages, so a single identity
+//! cert per node works in both directions. When no material is supplied, the
+//! transport is plain gRPC over HTTP/2 — suitable for trusted networks
+//! (service mesh, Unix sockets, podman-compose) but never expose a plaintext
+//! TCP listener on an untrusted network.
 
 use std::{net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -300,7 +304,7 @@ impl FromStr for Target {
                 }
                 Ok(Target::Unix(PathBuf::from(path)))
             }
-            "tcp" | "http" => {
+            "tcp" | "http" | "https" => {
                 let Some(authority) = uri.authority() else {
                     return Err(TargetParseError::InvalidTcpAddress(s.to_owned()));
                 };
@@ -324,6 +328,115 @@ pub enum ServeError {
 
     #[error("invalid tcp bind address: {0}")]
     InvalidTcpBindAddress(String),
+
+    #[error("tls error: {0}")]
+    Tls(#[from] TlsError),
+}
+
+#[derive(Debug, Error)]
+pub enum ConnectError {
+    #[error("invalid target: {0}")]
+    Target(#[from] TargetParseError),
+
+    #[error("transport error: {0}")]
+    Transport(#[from] tonic::transport::Error),
+
+    #[error("tls error: {0}")]
+    Tls(#[from] TlsError),
+}
+
+// ============================================================================
+// Mutual TLS
+// ============================================================================
+
+/// Filesystem paths to the PEM-encoded TLS material for a single peer.
+///
+/// The same cert is used both as the server identity (Orchestrator or Conduit
+/// listener) and as the client identity (when connecting to the other side).
+/// This requires the leaf certificate to carry both the `serverAuth` and
+/// `clientAuth` Extended Key Usages. `ca` is the CA used to verify the peer.
+#[derive(Debug, Clone)]
+pub struct TlsPaths {
+    pub ca: PathBuf,
+    pub cert: PathBuf,
+    pub key: PathBuf,
+}
+
+/// Loaded TLS material, built once at startup and reused for all RPCs.
+#[derive(Debug, Clone)]
+pub struct TlsMaterial {
+    pub ca: tonic::transport::Certificate,
+    pub identity: tonic::transport::Identity,
+}
+
+#[derive(Debug, Error)]
+pub enum TlsError {
+    #[error("failed to read {path}: {source}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl TlsPaths {
+    /// Read the CA, certificate, and private key PEM files from disk.
+    pub async fn load(&self) -> Result<TlsMaterial, TlsError> {
+        let ca_pem = tokio::fs::read(&self.ca)
+            .await
+            .map_err(|e| TlsError::Read {
+                path: self.ca.clone(),
+                source: e,
+            })?;
+        let cert_pem = tokio::fs::read(&self.cert)
+            .await
+            .map_err(|e| TlsError::Read {
+                path: self.cert.clone(),
+                source: e,
+            })?;
+        let key_pem = tokio::fs::read(&self.key)
+            .await
+            .map_err(|e| TlsError::Read {
+                path: self.key.clone(),
+                source: e,
+            })?;
+
+        Ok(TlsMaterial {
+            ca: tonic::transport::Certificate::from_pem(ca_pem),
+            identity: tonic::transport::Identity::from_pem(cert_pem, key_pem),
+        })
+    }
+}
+
+impl TlsMaterial {
+    fn server_config(&self) -> tonic::transport::ServerTlsConfig {
+        tonic::transport::ServerTlsConfig::new()
+            .identity(self.identity.clone())
+            .client_ca_root(self.ca.clone())
+    }
+
+    fn client_config(&self, domain: &str) -> tonic::transport::ClientTlsConfig {
+        tonic::transport::ClientTlsConfig::new()
+            .ca_certificate(self.ca.clone())
+            .identity(self.identity.clone())
+            .domain_name(domain)
+    }
+}
+
+/// Extract the host portion of a `tcp://`, `http://`, `https://`, or bare
+/// `host:port` target for use as the TLS SNI/domain name.
+fn domain_for(target: &str) -> String {
+    if let Ok(uri) = target.parse::<http::Uri>()
+        && let Some(host) = uri.host()
+    {
+        return host.to_owned();
+    }
+    // Fall back to stripping a trailing `:port` from a bare authority.
+    target
+        .rsplit_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(target)
+        .to_owned()
 }
 
 // ============================================================================
@@ -455,13 +568,27 @@ async fn serve(target: Target, name: &str, router: Router) -> Result<(), ServeEr
     Ok(())
 }
 
+/// Build a [`Server`] with optional mTLS configured.
+fn tls_server(tls: Option<&TlsMaterial>) -> Result<Server, ServeError> {
+    let mut builder = Server::builder();
+    if let Some(material) = tls {
+        builder = builder.tls_config(material.server_config())?;
+    }
+    Ok(builder)
+}
+
 /// Serve the Orchestrator service (container plugin side).
+///
+/// When `tls` is `Some`, the listener terminates mTLS using the supplied
+/// material and requires each client to present a certificate signed by the
+/// CA in `material.ca`. When `None`, the listener speaks plain gRPC.
 pub async fn serve_orchestrator<O: Orchestrator>(
     target: impl AsRef<str>,
     orchestrator: O,
+    tls: Option<&TlsMaterial>,
 ) -> Result<(), ServeError> {
     let target: Target = target.as_ref().parse()?;
-    info!(target = ?target, "starting Orchestrator server");
+    info!(target = ?target, tls = tls.is_some(), "starting Orchestrator server");
 
     let service = proto::orchestrator_server::OrchestratorServer::new(OrchestratorService {
         orchestrator: Arc::new(orchestrator),
@@ -470,7 +597,7 @@ pub async fn serve_orchestrator<O: Orchestrator>(
     serve(
         target,
         "Orchestrator",
-        Server::builder().add_service(service),
+        tls_server(tls)?.add_service(service),
     )
     .await
 }
@@ -735,15 +862,16 @@ impl<C: Conduit> proto::conduit_server::Conduit for ConduitService<C> {
 pub async fn serve_conduit<C: Conduit>(
     target: impl AsRef<str>,
     conduit: C,
+    tls: Option<&TlsMaterial>,
 ) -> Result<(), ServeError> {
     let target: Target = target.as_ref().parse()?;
-    info!(target = ?target, "starting Conduit server");
+    info!(target = ?target, tls = tls.is_some(), "starting Conduit server");
 
     let service = proto::conduit_server::ConduitServer::new(ConduitService {
         conduit: Arc::new(conduit),
     });
 
-    serve(target, "Conduit", Server::builder().add_service(service)).await
+    serve(target, "Conduit", tls_server(tls)?.add_service(service)).await
 }
 
 /// Serve the Conduit service on an already-bound TCP listener.
@@ -752,17 +880,57 @@ pub async fn serve_conduit<C: Conduit>(
 pub async fn serve_conduit_on_tcp_listener<C: Conduit>(
     listener: tokio::net::TcpListener,
     conduit: C,
+    tls: Option<&TlsMaterial>,
 ) -> Result<(), ServeError> {
-    info!("starting Conduit server on existing TCP listener");
+    info!(
+        tls = tls.is_some(),
+        "starting Conduit server on existing TCP listener"
+    );
 
     let service = proto::conduit_server::ConduitServer::new(ConduitService {
         conduit: Arc::new(conduit),
     });
 
     let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
-    Server::builder()
+    tls_server(tls)?
         .add_service(service)
         .serve_with_incoming(incoming)
         .await
         .map_err(ServeError::Transport)
+}
+
+// ============================================================================
+// Client connect helpers
+// ============================================================================
+
+/// Build a tonic [`Endpoint`](tonic::transport::Endpoint) from a target URI,
+/// optionally applying mTLS configuration.
+async fn connect_channel(
+    target: &str,
+    tls: Option<&TlsMaterial>,
+) -> Result<tonic::transport::Channel, ConnectError> {
+    let mut endpoint = tonic::transport::Endpoint::from_shared(target.to_owned())?;
+    if let Some(material) = tls {
+        let domain = domain_for(target);
+        endpoint = endpoint.tls_config(material.client_config(&domain))?;
+    }
+    Ok(endpoint.connect().await?)
+}
+
+/// Connect to the Orchestrator service, optionally using mTLS.
+pub async fn connect_orchestrator(
+    target: impl AsRef<str>,
+    tls: Option<&TlsMaterial>,
+) -> Result<OrchestratorClient<tonic::transport::Channel>, ConnectError> {
+    let channel = connect_channel(target.as_ref(), tls).await?;
+    Ok(OrchestratorClient::new(channel))
+}
+
+/// Connect to a Conduit service, optionally using mTLS.
+pub async fn connect_conduit(
+    target: impl AsRef<str>,
+    tls: Option<&TlsMaterial>,
+) -> Result<ConduitClient<tonic::transport::Channel>, ConnectError> {
+    let channel = connect_channel(target.as_ref(), tls).await?;
+    Ok(ConduitClient::new(channel))
 }

--- a/dev/scoc-entrypoint.sh
+++ b/dev/scoc-entrypoint.sh
@@ -50,6 +50,8 @@ done
 echo "containerd is ready"
 
 # Start SCOC conduit server
+# TLS flags are forwarded only when all three env vars are set; otherwise SCOC
+# runs plain gRPC. Validated both at the shell layer and inside SCOC.
 exec /usr/local/bin/scoc daemon \
   --node-name "${SCOC_NODE_NAME}" \
   --bind "${SCOC_BIND:-0.0.0.0:50054}" \
@@ -59,4 +61,7 @@ exec /usr/local/bin/scoc daemon \
   --cpu-millis "${SCOC_CPU_MILLIS:-4000}" \
   --memory-bytes "${SCOC_MEMORY_BYTES:-8589934592}" \
   --max-pods "${SCOC_MAX_PODS:-100}" \
-  --ldb-brokers "${SCOC_LDB_BROKERS:-127.0.0.1:9092}"
+  --ldb-brokers "${SCOC_LDB_BROKERS:-127.0.0.1:9092}" \
+  ${SCOC_TLS_CA:+--tls-ca "$SCOC_TLS_CA"} \
+  ${SCOC_TLS_CERT:+--tls-cert "$SCOC_TLS_CERT"} \
+  ${SCOC_TLS_KEY:+--tls-key "$SCOC_TLS_KEY"}

--- a/infra/scoc-cloud-config.yaml
+++ b/infra/scoc-cloud-config.yaml
@@ -83,7 +83,10 @@ write_files:
         --cpu-millis ${SCOC_CPU_MILLIS:-4000} \
         --memory-bytes ${SCOC_MEMORY_BYTES:-8589934592} \
         --max-pods ${SCOC_MAX_PODS:-100} \
-        --ldb-brokers ${SCOC_LDB_BROKERS:-127.0.0.1:9092}"
+        --ldb-brokers ${SCOC_LDB_BROKERS:-127.0.0.1:9092} \
+        ${SCOC_TLS_CA:+--tls-ca ${SCOC_TLS_CA}} \
+        ${SCOC_TLS_CERT:+--tls-cert ${SCOC_TLS_CERT}} \
+        ${SCOC_TLS_KEY:+--tls-key ${SCOC_TLS_KEY}}"
       command_background=true
       pidfile="/run/${RC_SVCNAME}.pid"
 
@@ -122,6 +125,11 @@ write_files:
       }
 
   # SCOC environment variables
+  #
+  # SCOC_TLS_CA / SCOC_TLS_CERT / SCOC_TLS_KEY are optional paths to PEM files
+  # enabling mTLS against the container plugin orchestrator. All three must be
+  # set together; leave all three empty to run plain gRPC. The operator is
+  # responsible for provisioning the cert files on disk out-of-band.
   - path: /etc/conf.d/scoc
     content: |
       SCOC_NODE_NAME="${SCOC_NODE_NAME}"
@@ -132,6 +140,9 @@ write_files:
       SCOC_MEMORY_BYTES="${SCOC_MEMORY_BYTES}"
       SCOC_MAX_PODS="${SCOC_MAX_PODS}"
       SCOC_LDB_BROKERS="${SCOC_LDB_BROKERS}"
+      SCOC_TLS_CA="${SCOC_TLS_CA}"
+      SCOC_TLS_CERT="${SCOC_TLS_CERT}"
+      SCOC_TLS_KEY="${SCOC_TLS_KEY}"
 
 runcmd:
   # Download SCOC binary from latest GitHub release

--- a/infra/scoc-pve/cloud-config.yaml.tftpl
+++ b/infra/scoc-pve/cloud-config.yaml.tftpl
@@ -98,6 +98,22 @@ write_files:
       output_log="/dev/console"
       error_log="/dev/console"
 
+%{ if tls_enabled ~}
+  # mTLS material for SCOC <-> container plugin (600 perms, root-owned).
+  - path: /etc/scoc/tls/ca.pem
+    permissions: "0600"
+    content: |
+      ${indent(6, tls_ca_pem)}
+  - path: /etc/scoc/tls/cert.pem
+    permissions: "0600"
+    content: |
+      ${indent(6, tls_cert_pem)}
+  - path: /etc/scoc/tls/key.pem
+    permissions: "0600"
+    content: |
+      ${indent(6, tls_key_pem)}
+%{ endif ~}
+
   # OpenRC init script for SCOC
   - path: /etc/init.d/scoc
     permissions: "0755"
@@ -115,7 +131,10 @@ write_files:
         --cpu-millis ${cpu_millis} \
         --memory-bytes ${memory_bytes} \
         --max-pods ${max_pods} \
-        --ldb-brokers ${ldb_brokers}"
+        --ldb-brokers ${ldb_brokers}%{ if tls_enabled ~} \
+        --tls-ca /etc/scoc/tls/ca.pem \
+        --tls-cert /etc/scoc/tls/cert.pem \
+        --tls-key /etc/scoc/tls/key.pem%{ endif ~}"
       command_background=true
       pidfile="/run/$${RC_SVCNAME}.pid"
       output_log="/dev/console"

--- a/infra/scoc-pve/main.tf
+++ b/infra/scoc-pve/main.tf
@@ -5,6 +5,22 @@
 locals {
   # Strip CIDR suffix to get the bare IP for the conduit address
   vm_ip_bare = split("/", var.vm_ip)[0]
+
+  # mTLS is enabled when all three PEM variables are provided. The
+  # `tls_validation` check below rejects any partial combination.
+  tls_parts_present = length(compact([
+    var.tls_ca_pem != null ? "1" : "",
+    var.tls_cert_pem != null ? "1" : "",
+    var.tls_key_pem != null ? "1" : "",
+  ]))
+  tls_enabled = local.tls_parts_present == 3
+}
+
+check "tls_validation" {
+  assert {
+    condition     = local.tls_parts_present == 0 || local.tls_parts_present == 3
+    error_message = "tls_ca_pem, tls_cert_pem, and tls_key_pem must all be provided together, or all omitted."
+  }
 }
 
 # --- Download Alpine cloud image ---
@@ -41,6 +57,10 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
       nameserver           = var.nameserver
       root_password        = var.root_password
       ssh_authorized_keys  = var.ssh_authorized_keys
+      tls_enabled          = local.tls_enabled
+      tls_ca_pem           = var.tls_ca_pem
+      tls_cert_pem         = var.tls_cert_pem
+      tls_key_pem          = var.tls_key_pem
     })
     file_name = "${var.vm_name}-cloud-config.yaml"
   }

--- a/infra/scoc-pve/variables.tf
+++ b/infra/scoc-pve/variables.tf
@@ -170,3 +170,31 @@ variable "scoc_binary_url" {
   description = "URL to download the SCOC binary from."
   default     = "https://github.com/emilbroman/skyr/releases/latest/download/scoc-x86_64-unknown-linux-musl"
 }
+
+# --- mTLS ---
+#
+# Optional PEM-encoded material for mutual TLS against the container plugin
+# orchestrator. All three must be provided together; leave all three null to
+# run plain gRPC. The leaf certificate must carry both `serverAuth` and
+# `clientAuth` Extended Key Usages.
+
+variable "tls_ca_pem" {
+  type        = string
+  description = "PEM-encoded CA certificate used to verify the orchestrator and incoming clients."
+  default     = null
+  sensitive   = true
+}
+
+variable "tls_cert_pem" {
+  type        = string
+  description = "PEM-encoded leaf certificate for this SCOC node."
+  default     = null
+  sensitive   = true
+}
+
+variable "tls_key_pem" {
+  type        = string
+  description = "PEM-encoded private key matching tls_cert_pem."
+  default     = null
+  sensitive   = true
+}

--- a/infra/skyr-k8s/main.tf
+++ b/infra/skyr-k8s/main.tf
@@ -34,4 +34,21 @@ locals {
     "app.kubernetes.io/managed-by" = "opentofu"
     "app.kubernetes.io/part-of"    = "skyr"
   }
+
+  # mTLS between the container plugin orchestrator and SCOC conduits is
+  # enabled when all three PEM variables are provided. The tls_validation
+  # check rejects any partial combination.
+  scop_tls_parts_present = length(compact([
+    var.scop_tls_ca_pem != null ? "1" : "",
+    var.scop_tls_cert_pem != null ? "1" : "",
+    var.scop_tls_key_pem != null ? "1" : "",
+  ]))
+  scop_tls_enabled = local.scop_tls_parts_present == 3
+}
+
+check "scop_tls_validation" {
+  assert {
+    condition     = local.scop_tls_parts_present == 0 || local.scop_tls_parts_present == 3
+    error_message = "scop_tls_ca_pem, scop_tls_cert_pem, and scop_tls_key_pem must all be provided together, or all omitted."
+  }
 }

--- a/infra/skyr-k8s/plugins.tf
+++ b/infra/skyr-k8s/plugins.tf
@@ -7,6 +7,24 @@
 # their own infrastructure dependencies.
 # =============================================================================
 
+resource "kubernetes_secret" "plugin_std_container_tls" {
+  count = local.scop_tls_enabled ? 1 : 0
+
+  metadata {
+    name      = "plugin-std-container-tls"
+    namespace = local.namespace
+    labels    = merge(local.labels, { "app.kubernetes.io/name" = "plugin-std-container" })
+  }
+
+  type = "kubernetes.io/tls"
+
+  data = {
+    "ca.pem"  = var.scop_tls_ca_pem
+    "tls.crt" = var.scop_tls_cert_pem
+    "tls.key" = var.scop_tls_key_pem
+  }
+}
+
 resource "kubernetes_deployment" "plugin_std_container" {
   metadata {
     name      = "plugin-std-container"
@@ -42,6 +60,16 @@ resource "kubernetes_deployment" "plugin_std_container" {
           }
         }
 
+        dynamic "volume" {
+          for_each = local.scop_tls_enabled ? [1] : []
+          content {
+            name = "scop-tls"
+            secret {
+              secret_name = kubernetes_secret.plugin_std_container_tls[0].metadata[0].name
+            }
+          }
+        }
+
         container {
           name              = "plugin-std-container"
           image             = "ghcr.io/emilbroman/skyr-plugin_std_container:latest"
@@ -57,7 +85,14 @@ resource "kubernetes_deployment" "plugin_std_container" {
             "--registry-url", local.oci_registry_url,
             "--ldb-hostname", local.redpanda_hostname,
             "--cluster-cidr", var.cluster_cidr,
-          ], var.oci_registry_insecure ? ["--insecure-registry"] : [])
+            ],
+            var.oci_registry_insecure ? ["--insecure-registry"] : [],
+            local.scop_tls_enabled ? [
+              "--tls-ca", "/etc/skyr/tls/ca.pem",
+              "--tls-cert", "/etc/skyr/tls/tls.crt",
+              "--tls-key", "/etc/skyr/tls/tls.key",
+            ] : [],
+          )
 
           dynamic "env" {
             for_each = local.oci_registry_has_auth ? [1] : []
@@ -89,6 +124,15 @@ resource "kubernetes_deployment" "plugin_std_container" {
             content {
               name       = "registry-auth"
               mount_path = "/root/.docker"
+              read_only  = true
+            }
+          }
+
+          dynamic "volume_mount" {
+            for_each = local.scop_tls_enabled ? [1] : []
+            content {
+              name       = "scop-tls"
+              mount_path = "/etc/skyr/tls"
               read_only  = true
             }
           }

--- a/infra/skyr-k8s/variables.tf
+++ b/infra/skyr-k8s/variables.tf
@@ -207,3 +207,31 @@ variable "dns_service_type" {
   description = "Kubernetes Service type for the DNS plugin (ClusterIP, LoadBalancer, or NodePort)."
   default     = "ClusterIP"
 }
+
+# --- Container plugin <-> SCOC mTLS ---
+#
+# Optional PEM material for mutual TLS between the container plugin
+# orchestrator and SCOC conduits. All three must be provided together; leave
+# all three null to run plain gRPC. The leaf certificate must carry both
+# `serverAuth` and `clientAuth` Extended Key Usages.
+
+variable "scop_tls_ca_pem" {
+  type        = string
+  description = "PEM-encoded CA certificate used to verify SCOC conduits and incoming orchestrator clients."
+  default     = null
+  sensitive   = true
+}
+
+variable "scop_tls_cert_pem" {
+  type        = string
+  description = "PEM-encoded leaf certificate for the container plugin orchestrator."
+  default     = null
+  sensitive   = true
+}
+
+variable "scop_tls_key_pem" {
+  type        = string
+  description = "PEM-encoded private key matching scop_tls_cert_pem."
+  default     = null
+  sensitive   = true
+}


### PR DESCRIPTION
Adds TlsPaths/TlsMaterial to scop with TLS-aware serve_* and connect_*
helpers. SCOC and plugin_std_container gain --tls-ca/--tls-cert/--tls-key
flags (all-or-nothing); when set, every SCOP RPC in both directions runs
over mutual TLS using leaf certs with serverAuth+clientAuth EKUs. When
the flags are absent, the transport is unchanged plain gRPC.

https://claude.ai/code/session_01AKmhjcC3tTE2CT5E2nGxGs