### PR TITLE
fix(api): route deleteResource audit log to both topics

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -866,16 +866,29 @@ impl Mutation {
             internal_error()
         })?;
 
+        let resource_qid = ids::ResourceQid::new(env_qid.clone(), resource_id.clone());
         let resource_ref = rtq::ResourceRef {
             environment_qid: env_qid,
             resource_id,
         };
 
-        // Emit an audit log into the resource's log namespace (deployment
-        // QID) before enqueueing, so the action is visible in the resource
-        // detail page regardless of how the plugin-side delete resolves.
-        let log_namespace = owner_qid.to_string();
-        if let Ok(publisher) = context.ldb_publisher.namespace(log_namespace.clone()).await {
+        // Emit an audit log before enqueueing so the action is visible
+        // regardless of how the plugin-side delete resolves.  Published to
+        // both the resource-QID and deployment-QID log topics with the
+        // phrasing tailored to each: the resource topic already knows
+        // which resource it is, so naming it would be redundant; the
+        // deployment topic multiplexes many resources, so the line needs
+        // to name the resource explicitly.
+        if let Ok(publisher) = context
+            .ldb_publisher
+            .namespace(resource_qid.to_string())
+            .await
+        {
+            publisher
+                .info(format!("Manual deletion requested by {}", user.username))
+                .await;
+        }
+        if let Ok(publisher) = context.ldb_publisher.namespace(owner_qid.to_string()).await {
             publisher
                 .info(format!(
                     "Manual deletion of {}:{} requested by {}",


### PR DESCRIPTION
## Summary
Follow-up to #275. The manual-delete audit log line was only being published to the deployment-QID LDB topic, so it never showed up in the resource detail page's log stream (which tails the resource-QID topic).

Publish to both topics, with phrasing tailored per topic:
- **Resource topic** (reader already knows which resource): `Manual deletion requested by alice`
- **Deployment topic** (multiplexes many resources): `Manual deletion of Std/Random.Int:seed requested by alice`

## Test plan
- [x] Verified end-to-end against the dev harness (`make up`): delete request → audit line lands in both the resource detail log and the deployment log with the correct per-topic phrasing → RTE processes the DESTROY → resource is recreated by the next eval tick because SCL still declares it (result value changed from `31` → `35`).
- [x] `cargo clippy --workspace -- -D warnings` ✅
- [x] `cargo fmt` ✅
- [x] `cargo test --workspace` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)