### PR TITLE
chore: tofu fmt + move dns host port to 15353

### DIFF
--- a/dev/podman-compose.yml
+++ b/dev/podman-compose.yml
@@ -238,7 +238,7 @@ services:
         "--dns-port", "5353",
       ]
     ports:
-      - 5353:5353/udp
+      - 15353:5353/udp
     restart: always
 
   plugin-std-time:

--- a/infra/skyr-k8s/secrets.tf
+++ b/infra/skyr-k8s/secrets.tf
@@ -22,7 +22,7 @@ locals {
     join("\n", concat(
       ["-----BEGIN OPENSSH PRIVATE KEY-----"],
       [for i in range(ceil(length(local._scs_key_b64) / 70)) :
-        substr(local._scs_key_b64, i * 70, min(70, length(local._scs_key_b64) - i * 70))],
+      substr(local._scs_key_b64, i * 70, min(70, length(local._scs_key_b64) - i * 70))],
       ["-----END OPENSSH PRIVATE KEY-----", ""]
     ))
   )


### PR DESCRIPTION
## Summary
Two small chore commits, split per package:

- **`chore(infra): tofu fmt`** — applies `tofu fmt` to `infra/skyr-k8s/secrets.tf` (pre-existing indentation drift in a `for` expression, surfaced while running `tofu fmt -check` in the earlier PR). No behaviour change.
- **`chore(dev): move plugin-std-dns host port from 5353 to 15353`** — host port 5353/udp is typically held by mDNSResponder on macOS, which made `plugin-std-dns` fail to start and cascaded into the rte-* workers exiting (they can't resolve `plugin-std-dns` during plugin dial on startup). Moving the host-side mapping to 15353 avoids the conflict; the container-internal port is unchanged, so RTEs and the plugin continue to talk to each other on 5353 over the podman network.

## Test plan
- [x] `tofu fmt -check -diff infra/skyr-k8s/` is clean after this change.
- [x] `make up` brings the full stack up without the previous 5353 port bind error; `skyr_rte-0_1`, `skyr_rte-1_1`, and `skyr_rte-2_1` all start cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)