### PR TITLE
fix(cdb): reset deployment failure count on state change

### DIFF
--- a/crates/cdb/src/client.rs
+++ b/crates/cdb/src/client.rs
@@ -1002,6 +1002,17 @@ impl DeploymentClient {
             return Ok(());
         }
 
+        // Reset the failure counter on every state change so that the
+        // exponential backoff window doesn't carry over across transitions.
+        // If the new state matches the previous state (no-op transition),
+        // preserve the existing count.
+        let state_changed = prev_state.as_ref().is_none_or(|s| s.state != state);
+        let failures = if state_changed {
+            0
+        } else {
+            prev_state.as_ref().map(|s| s.failures).unwrap_or(0)
+        };
+
         let deployment = Deployment {
             repo: self.repo.name.clone(),
             environment: self.environment.clone(),
@@ -1013,7 +1024,7 @@ impl DeploymentClient {
                 .unwrap_or_else(Utc::now),
             state,
             bootstrapped: prev_state.as_ref().map(|s| s.bootstrapped).unwrap_or(false),
-            failures: prev_state.as_ref().map(|s| s.failures).unwrap_or(0),
+            failures,
         };
 
         self.repo.client.set_deployment(deployment).await?;


### PR DESCRIPTION
## Summary
- The failure counter on deployments accumulated across state transitions, so exponential-backoff windows from a prior state lingered after a transition.
- `DeploymentClient::set()` (the existing common state-transition method) now zeros `failures` whenever the new state differs from the previous state. Because `set_deployment()` already UPSERTs every column in a single statement, the reset happens in the same db query as the state change.
- No-op transitions (calling `set()` with the current state) preserve the existing count. `set_progress()` is unchanged and remains the path for updating `failures`/`bootstrapped` without touching state.

## Test plan
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo test`
- [ ] Manually verify a deployment with non-zero `failures` has its counter zeroed after transitioning state (e.g., Desired → Lingering) in CDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)