### PR TITLE
feat(web): responsive small-screen layouts for environment pages

### DIFF
--- a/web/src/lib/components/LogStream.svelte
+++ b/web/src/lib/components/LogStream.svelte
@@ -105,7 +105,7 @@ onDestroy(() => {
     class="h-full overflow-y-auto font-mono text-xs p-3 space-y-0.5 bg-gray-900"
   >
     {#each logs as log}
-      <div class="flex gap-2 leading-5 hover:bg-gray-800 px-1 rounded">
+      <div class="flex flex-col sm:flex-row sm:gap-2 leading-5 hover:bg-gray-800 px-1 rounded">
         <span class="text-gray-500 shrink-0 select-none"
           >{formatLogTimestamp(log.timestamp)}</span
         >

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { page } from "$app/stores";
+import { MoreVertical } from "lucide-svelte";
 import DeploymentStateBadge from "$lib/components/DeploymentState.svelte";
 import {
     CreateDeploymentDocument,
@@ -90,7 +91,22 @@ function onDeploy(commitHash: string) {
         commitHash,
     });
 }
+
+let openMenuId = $state<string | null>(null);
+
+function toggleMenu(id: string) {
+    openMenuId = openMenuId === id ? null : id;
+}
+
+function onWindowClick(event: MouseEvent) {
+    if (openMenuId === null) return;
+    const target = event.target as Element | null;
+    if (target && target.closest(`[data-menu-root="${openMenuId}"]`)) return;
+    openMenuId = null;
+}
 </script>
+
+<svelte:window onclick={onWindowClick} />
 
 <svelte:head>
     <title>Deployments · {orgName}/{repoName} ({envName}) – Skyr</title>
@@ -106,7 +122,7 @@ function onDeploy(commitHash: string) {
   {#if env.deployments.length === 0}
     <p class="text-gray-500">No deployments.</p>
   {:else}
-    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+    <div class="hidden md:block bg-white border border-gray-200 rounded-lg overflow-hidden">
     <table class="w-full text-left">
       <thead>
         <tr class="border-b border-gray-200 text-gray-500">
@@ -194,6 +210,58 @@ function onDeploy(commitHash: string) {
         {/each}
       </tbody>
     </table>
+    </div>
+
+    <div class="md:hidden space-y-3">
+      {#each sortedDeployments as deployment}
+        <div class="relative bg-white border border-gray-200 rounded-lg p-4">
+          <div class="flex items-center justify-between text-xs text-gray-500">
+            <span class="font-mono">{deployment.commit.hash.substring(0, 8)}</span>
+            <span>{new Date(deployment.createdAt).toLocaleString()}</span>
+          </div>
+          <div class="mt-2 truncate">
+            <a
+              href={deploymentHref(orgName, repoName, envName, `${deployment.commit.hash}.${deployment.nonce}`)}
+              class="text-orange-600 hover:text-orange-500"
+            >
+              {deployment.commit.message.split("\n")[0]}
+            </a>
+          </div>
+          <div class="mt-3 flex items-center gap-3">
+            <DeploymentStateBadge state={deployment.state} bootstrapped={deployment.bootstrapped} failures={deployment.failures} volatile={deployment.resources.some((r) => r.markers.includes(ResourceMarker.Volatile))} size="small" />
+            <span class="text-sm text-gray-500">{deployment.resources.length} resources</span>
+            {#if deployment.state !== DeploymentState.Desired}
+              <div class="ml-auto" data-menu-root={deployment.id}>
+                <button
+                  type="button"
+                  onclick={() => toggleMenu(deployment.id)}
+                  class="p-1 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded cursor-pointer"
+                  aria-label="Open menu"
+                >
+                  <MoreVertical class="w-5 h-5" />
+                </button>
+                {#if openMenuId === deployment.id}
+                  <div class="absolute right-0 top-full mt-1 z-10 bg-white border border-gray-200 rounded shadow-md min-w-[10rem] py-1">
+                    <button
+                      type="button"
+                      onclick={() => {
+                        openMenuId = null;
+                        onDeploy(deployment.commit.hash);
+                      }}
+                      disabled={createDeployment.isPending && pendingCommit === deployment.commit.hash}
+                      class="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    >
+                      {createDeployment.isPending && pendingCommit === deployment.commit.hash
+                        ? "Deploying..."
+                        : "Deploy"}
+                    </button>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        </div>
+      {/each}
     </div>
   {/if}
 {/if}

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~d/[deployment]/+page.svelte
@@ -153,7 +153,7 @@ function onRedeploy() {
           class="bg-gray-900 border border-gray-800 rounded-lg p-3 font-mono text-xs space-y-0.5 max-h-60 overflow-y-auto"
         >
           {#each deployment.lastLogs as log}
-            <div class="flex gap-2 leading-5">
+            <div class="flex flex-col sm:flex-row sm:gap-2 leading-5">
               <span class="text-gray-500 shrink-0"
                 >{formatLogTimestamp(log.timestamp)}</span
               >

--- a/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~r/+page.svelte
+++ b/web/src/routes/(app)/[org]/[repo]/[env]/(tabs)/~r/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 import { page } from "$app/stores";
+import ResourceCardCompact from "$lib/components/ResourceCardCompact.svelte";
 import ResourceDag from "$lib/components/ResourceDag.svelte";
-import { EnvironmentDetailDocument } from "$lib/graphql/generated";
+import { EnvironmentDetailDocument, ResourceMarker } from "$lib/graphql/generated";
 import { graphqlQuery } from "$lib/graphql/query";
-import { decodeSegment } from "$lib/paths";
+import { decodeSegment, resourceHref } from "$lib/paths";
+import { List, Network } from "lucide-svelte";
+import { onMount } from "svelte";
 
 let orgName = $derived($page.params.org ?? "");
 let repoName = $derived($page.params.repo ?? "");
@@ -16,6 +19,28 @@ const envDetail = graphqlQuery(() => ({
 }));
 
 let env = $derived(envDetail.data?.organization.repository.environment ?? null);
+
+let view = $state<"graph" | "list">("graph");
+
+onMount(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    view = mq.matches ? "list" : "graph";
+});
+
+function resourceId(type: string, name: string): string {
+    return `${type}:${name}`;
+}
+
+function typeParts(type: string): { prefix: string; tail: string } {
+    const parts = type.split(".");
+    if (parts.length > 1) {
+        return {
+            prefix: `${parts.slice(0, -1).join(".")}.`,
+            tail: parts[parts.length - 1],
+        };
+    }
+    return { prefix: "", tail: type };
+}
 </script>
 
 <svelte:head>
@@ -23,10 +48,111 @@ let env = $derived(envDetail.data?.organization.repository.environment ?? null);
 </svelte:head>
 
 {#if env}
-  <ResourceDag
-    resources={env.resources}
-    org={orgName}
-    repo={repoName}
-    env={envName}
-  />
+  <div class="flex justify-end mb-3">
+    <div
+      role="radiogroup"
+      aria-label="Resource view mode"
+      class="inline-flex rounded-md border border-gray-200 overflow-hidden"
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={view === "graph"}
+        aria-label="Graph view"
+        onclick={() => {
+            view = "graph";
+        }}
+        class="px-3 py-1.5 transition-colors cursor-pointer {view === 'graph'
+            ? 'bg-orange-600 text-gray-900'
+            : 'bg-white text-gray-500 hover:bg-gray-50'}"
+      >
+        <Network size={16} />
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={view === "list"}
+        aria-label="List view"
+        onclick={() => {
+            view = "list";
+        }}
+        class="px-3 py-1.5 transition-colors cursor-pointer {view === 'list'
+            ? 'bg-orange-600 text-gray-900'
+            : 'bg-white text-gray-500 hover:bg-gray-50'}"
+      >
+        <List size={16} />
+      </button>
+    </div>
+  </div>
+
+  {#if view === "graph"}
+    <ResourceDag
+      resources={env.resources}
+      org={orgName}
+      repo={repoName}
+      env={envName}
+    />
+  {:else if env.resources.length === 0}
+    <p class="text-gray-500">No resources in this environment.</p>
+  {:else}
+    <div class="md:hidden space-y-3">
+      {#each env.resources as resource}
+        <ResourceCardCompact
+          {resource}
+          href={resourceHref(orgName, repoName, envName, resourceId(resource.type, resource.name))}
+        />
+      {/each}
+    </div>
+
+    <div class="hidden md:block bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <table class="w-full text-left">
+        <thead>
+          <tr class="border-b border-gray-200 text-gray-500">
+            <th class="pb-3 pt-3 pl-4 pr-4 font-medium">Type</th>
+            <th class="pb-3 pt-3 pr-4 font-medium">Name</th>
+            <th class="pb-3 pt-3 pr-4 font-medium">Markers</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each env.resources as resource}
+            {@const parts = typeParts(resource.type)}
+            <tr class="border-b border-gray-200 hover:bg-gray-50 last:border-b-0">
+              <td class="py-3 pl-4 pr-4">
+                <span class="text-orange-500/70">{parts.prefix}</span><span
+                  class="text-orange-500">{parts.tail}</span
+                >
+              </td>
+              <td class="py-3 pr-4">
+                <a
+                  href={resourceHref(
+                      orgName,
+                      repoName,
+                      envName,
+                      resourceId(resource.type, resource.name),
+                  )}
+                  class="text-orange-600 hover:text-orange-500"
+                >
+                  {resource.name}
+                </a>
+              </td>
+              <td class="py-3 pr-4">
+                <div class="flex items-center gap-1.5 flex-wrap">
+                  {#each resource.markers as marker}
+                    <span
+                      class="px-1 py-px rounded border {marker ===
+                      ResourceMarker.Volatile
+                          ? 'border-yellow-300 text-yellow-700'
+                          : 'border-blue-300 text-blue-700'}"
+                    >
+                      {marker}
+                    </span>
+                  {/each}
+                </div>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
 {/if}


### PR DESCRIPTION
## Summary

Three independent UI improvements to the environment subpages, merged together:

- **Logs** (`LogStream` + static `lastLogs` block on the deployment detail page): timestamps now stack above the message below the `sm` breakpoint. Horizontal layout preserved on `sm`+. Severity colors, padding, fonts, and hover states unchanged.

- **Deployments tab**: below `md`, the table is replaced by a vertical list of cards. Each card shows commit hash + timestamp, the commit message as a link to the deployment, the state badge, the resource count, and a kebab (⋮) menu containing the Deploy action when applicable. The kebab is hidden when there's nothing to do (state = Desired). Desktop table view is unchanged.

- **Resources tab**: new "list" view alternative to the existing graph (DAG). A small icon-only segmented toggle (radiogroup, `Network`/`List` lucide icons) sits above the view. List mode renders a desktop table (Type / Name / Markers, with the name as an orange link) and stacks `ResourceCardCompact` cards on mobile. Default view is `list` on small screens and `graph` on `md`+, computed once on mount.

## Test plan

- [ ] Verify log rows stack timestamp above message below 640px on both live (LogStream) and last-logs views.
- [ ] Verify deployments below 768px render as cards; kebab menu opens, closes on outside click, and only appears when not Desired.
- [ ] Verify the deployments desktop table at ≥768px is unchanged (sort buttons, Deploy button column).
- [ ] Verify resources page: toggle switches between graph and list, list renders cards on mobile and table on desktop, default is list under 768px and graph at/above 768px.
- [ ] Run `npx biome ci .` and `npm run check` from `web/` (existing two errors about `$lib/stdlib-types.json` and `$lib/sclc-wasm/sclc_wasm.js` are pre-existing generated-file imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)