### PR TITLE
fix(de): mark no-Main.scl idle report as terminal

### DIFF
--- a/crates/de/src/reporter.rs
+++ b/crates/de/src/reporter.rs
@@ -21,8 +21,13 @@
 //! ## Terminal flag
 //!
 //! The deployment-scoped extension carries a terminal flag that is set on the
-//! single last report emitted for a deployment — when the deployment reaches
-//! the DOWN terminal state. After that, no further reports are emitted.
+//! last report a worker invocation will emit. That happens when the deployment
+//! reaches the DOWN terminal state, and also when the worker stops its loop
+//! while the deployment is still in another state but has nothing left to do
+//! (e.g. a bootstrapped no-`Main.scl` deployment idling until an external
+//! trigger such as a supersession respawns the worker). The RE uses this flag
+//! to drop the entity from heartbeat tracking so the watchdog does not fire
+//! while no reports are expected.
 
 use std::time::Duration;
 

--- a/crates/de/src/worker/mod.rs
+++ b/crates/de/src/worker/mod.rs
@@ -46,8 +46,10 @@ pub(crate) struct Worker {
     /// is unchanged; cleared on compile error or when the key differs.
     pub(crate) cached_compile: Option<CachedCompile>,
     /// Latched once the deployment's terminal status report has been emitted
-    /// onto the RQ. The terminal report is, by design, the last report ever
-    /// emitted for this deployment.
+    /// onto the RQ. The terminal report is the last report this worker
+    /// invocation will emit — either because the deployment reached DOWN, or
+    /// because the worker has nothing left to do (no `Main.scl`) and is going
+    /// idle until an external trigger (e.g. supersession) respawns it.
     pub(crate) terminal_reported: bool,
 }
 
@@ -156,7 +158,14 @@ impl Worker {
             }
         }
 
-        let is_terminal = matches!(work_result.state, DeploymentState::Down);
+        // A report is terminal when this worker invocation will emit no
+        // further reports — either because the deployment reached DOWN, or
+        // because the per-state handler decided to stop the loop (e.g. a
+        // bootstrapped no-Main.scl deployment with nothing left to do). The
+        // RE uses this flag to drop the entity from heartbeat tracking, so
+        // the watchdog does not fire while we sit idle.
+        let is_terminal =
+            matches!(work_result.state, DeploymentState::Down) || !work_result.keep_running;
 
         // Build & publish the report. Reporting failures are logged but never
         // propagate — the DE keeps reconciling regardless of broker health.
@@ -175,13 +184,10 @@ impl Worker {
                 deployment = %deployment_qid,
                 "emitted terminal status report; stopping worker",
             );
-            // The terminal report is the last report ever emitted; stop the
-            // loop unconditionally.
             return true;
         }
 
-        // Otherwise the inner work() decision dictates whether we keep going.
-        !work_result.keep_running
+        false
     }
 
     /// Read SDB signals for backoff and eligibility decisions. Errors are
@@ -289,7 +295,9 @@ impl Worker {
     ///
     /// Returns a [`WorkResult`] whose `keep_running` is `false` to signal that
     /// the processing loop should stop (e.g., when there is no `Main.scl` and
-    /// thus no volatile resources).
+    /// thus no volatile resources). The reporting layer reads `keep_running`
+    /// to decide whether to mark the iteration's report as terminal — see
+    /// `work_and_report` and the reporter module's terminal-flag docs.
     async fn run_desired(
         &mut self,
         deployment: &Deployment,


### PR DESCRIPTION
## Summary

- DE workers that find no `Main.scl` mark the deployment bootstrapped and stop the loop, but the final RQ report was emitted with `terminal: false`. RE kept the entity in its heartbeat cache and the watchdog eventually opened a synthetic `SystemError` incident even though no further reports were ever expected.
- Treat `keep_running: false` the same as `DOWN` for the terminal flag in `work_and_report`, so RE drops the entity from heartbeat tracking and the watchdog stays quiet while the worker is idle.
- If the deployment is later superseded, `main.rs` respawns the worker; that next invocation walks the normal lifecycle and re-establishes RE-side tracking via fresh non-terminal reports, ending in the `DOWN` terminal report. So the SDB summary cleanup that happens on the idle terminal report is reversible.

## Test plan

- [x] `cargo clippy -p de -- -D warnings`
- [x] `cargo test -p de`
- [x] `cargo fmt -p de`
- [ ] End-to-end: push a commit with no `Main.scl` to the dev cluster and confirm no watchdog `SystemError` notification is emitted by NE within the DESIRED cadence (60s) window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)