### PR TITLE
feat(sclc,plugin_std_dns): add AAAA, CNAME, TXT, MX, SRV records to Std/DNS

### DIFF
--- a/crates/plugin_std_dns/README.md
+++ b/crates/plugin_std_dns/README.md
@@ -1,26 +1,71 @@
 # Std/DNS Plugin
 
-An [RTP](../rtp/) plugin implementing the `Std/DNS.ARecord` resource type.
+An [RTP](../rtp/) plugin implementing DNS resource types from `Std/DNS`. Records are stored in Redis and served by an embedded UDP DNS server.
 
 ## Role in the Architecture
 
-This is one of Skyr's standard library plugins, invoked by the [RTE](../rte/) when deployments use `DNS.ARecord` resources.
+This is one of Skyr's standard library plugins, invoked by the [RTE](../rte/) when deployments use `Std/DNS` resources.
 
-## Resource: `Std/DNS.ARecord`
+## Resources
 
-Manages a DNS A record.
+### `Std/DNS.ARecord`
+
+Manages a DNS A record (IPv4).
 
 | | Fields |
 |---|--------|
-| **Inputs** | `name` (string), `ttl` (Duration), `addresses` (list of strings) |
-| **Outputs** | (none beyond inputs) |
+| **Inputs** | `name` (Str), `ttl` (Duration), `addresses` ([Str]) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `addresses` ([Str]) |
 
-This is currently a stub plugin — it echoes inputs back without performing actual DNS provisioning.
+### `Std/DNS.AAAARecord`
+
+Manages a DNS AAAA record (IPv6).
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name` (Str), `ttl` (Duration), `addresses` ([Str]) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `addresses` ([Str]) |
+
+### `Std/DNS.CNAMERecord`
+
+Manages a DNS CNAME record.
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name` (Str), `ttl` (Duration), `target` (Str) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `target` (Str) |
+
+### `Std/DNS.TXTRecord`
+
+Manages a DNS TXT record.
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name` (Str), `ttl` (Duration), `values` ([Str]) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `values` ([Str]) |
+
+### `Std/DNS.MXRecord`
+
+Manages a DNS MX record.
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name` (Str), `ttl` (Duration), `exchanges` ([{priority: Int, host: Str}]) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `exchanges` ([{priority: Int, host: Str}]) |
+
+### `Std/DNS.SRVRecord`
+
+Manages a DNS SRV record.
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name` (Str), `ttl` (Duration), `records` ([{priority: Int, weight: Int, port: Int, target: Str}]) |
+| **Outputs** | `fqdn` (Str), `ttl` (Duration), `records` ([{priority: Int, weight: Int, port: Int, target: Str}]) |
 
 ## Running
 
 ```sh
-cargo run -p plugin_std_dns -- --bind 0.0.0.0:50057
+cargo run -p plugin_std_dns -- --bind 0.0.0.0:50057 --redis-hostname localhost --zone example.internal
 ```
 
 ## Related Crates

--- a/crates/plugin_std_dns/src/dns_server.rs
+++ b/crates/plugin_std_dns/src/dns_server.rs
@@ -1,14 +1,14 @@
 use std::net::SocketAddr;
 
 use hickory_proto::op::{Message, MessageType, OpCode, ResponseCode};
-use hickory_proto::rr::rdata::{A, SOA};
+use hickory_proto::rr::rdata::{A, AAAA, CNAME, MX, SOA, SRV, TXT};
 use hickory_proto::rr::{Name, RData, Record, RecordType};
 use tokio::net::UdpSocket;
 use tracing::{debug, error, warn};
 
 use crate::dns_store::DnsStore;
 
-/// Run a UDP DNS server that answers A and SOA queries for records in the zone.
+/// Run a UDP DNS server that answers queries for records in the zone.
 pub async fn run(addr: SocketAddr, zone: String, store: DnsStore) -> anyhow::Result<()> {
     let socket = UdpSocket::bind(addr).await?;
     tracing::info!("DNS server listening on {addr}");
@@ -69,6 +69,11 @@ async fn handle_query(query: &Message, zone_name: &Name, store: &DnsStore) -> Me
 
     match qtype {
         RecordType::A => handle_a_query(&mut response, qname, zone_name, store).await,
+        RecordType::AAAA => handle_aaaa_query(&mut response, qname, zone_name, store).await,
+        RecordType::CNAME => handle_cname_query(&mut response, qname, zone_name, store).await,
+        RecordType::TXT => handle_txt_query(&mut response, qname, zone_name, store).await,
+        RecordType::MX => handle_mx_query(&mut response, qname, zone_name, store).await,
+        RecordType::SRV => handle_srv_query(&mut response, qname, zone_name, store).await,
         RecordType::SOA if qname == zone_name => {
             add_soa(&mut response, zone_name, false);
             response.set_response_code(ResponseCode::NoError);
@@ -83,7 +88,6 @@ async fn handle_query(query: &Message, zone_name: &Name, store: &DnsStore) -> Me
 }
 
 async fn handle_a_query(response: &mut Message, qname: &Name, zone_name: &Name, store: &DnsStore) {
-    // Normalize: strip trailing dot for Redis lookup
     let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
 
     debug!(fqdn = %fqdn, "DNS A query");
@@ -103,6 +107,208 @@ async fn handle_a_query(response: &mut Message, qname: &Name, zone_name: &Name, 
         }
         Ok(None) => {
             debug!(fqdn = %fqdn, "DNS record not found");
+            response.set_response_code(ResponseCode::NXDomain);
+            add_soa(response, zone_name, true);
+        }
+        Err(e) => {
+            error!(fqdn = %fqdn, error = %e, "Redis lookup failed");
+            response.set_response_code(ResponseCode::ServFail);
+        }
+    }
+}
+
+async fn handle_aaaa_query(
+    response: &mut Message,
+    qname: &Name,
+    zone_name: &Name,
+    store: &DnsStore,
+) {
+    let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
+
+    debug!(fqdn = %fqdn, "DNS AAAA query");
+
+    match store.get_aaaa_record(&fqdn).await {
+        Ok(Some(data)) => {
+            for addr_str in &data.addresses {
+                if let Ok(addr) = addr_str.parse::<std::net::Ipv6Addr>() {
+                    let record = Record::from_rdata(
+                        qname.clone(),
+                        data.ttl_seconds,
+                        RData::AAAA(AAAA(addr)),
+                    );
+                    response.add_answer(record);
+                } else {
+                    warn!(address = %addr_str, "invalid IPv6 address in DNS record");
+                }
+            }
+            response.set_response_code(ResponseCode::NoError);
+        }
+        Ok(None) => {
+            debug!(fqdn = %fqdn, "DNS AAAA record not found");
+            response.set_response_code(ResponseCode::NXDomain);
+            add_soa(response, zone_name, true);
+        }
+        Err(e) => {
+            error!(fqdn = %fqdn, error = %e, "Redis lookup failed");
+            response.set_response_code(ResponseCode::ServFail);
+        }
+    }
+}
+
+async fn handle_cname_query(
+    response: &mut Message,
+    qname: &Name,
+    zone_name: &Name,
+    store: &DnsStore,
+) {
+    let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
+
+    debug!(fqdn = %fqdn, "DNS CNAME query");
+
+    match store.get_cname_record(&fqdn).await {
+        Ok(Some(data)) => {
+            let target_str = if data.target.ends_with('.') {
+                data.target.clone()
+            } else {
+                format!("{}.", data.target)
+            };
+            match Name::from_ascii(&target_str) {
+                Ok(name) => {
+                    let record = Record::from_rdata(
+                        qname.clone(),
+                        data.ttl_seconds,
+                        RData::CNAME(CNAME(name)),
+                    );
+                    response.add_answer(record);
+                    response.set_response_code(ResponseCode::NoError);
+                }
+                Err(e) => {
+                    warn!(target = %data.target, error = %e, "invalid CNAME target");
+                    response.set_response_code(ResponseCode::ServFail);
+                }
+            }
+        }
+        Ok(None) => {
+            debug!(fqdn = %fqdn, "DNS CNAME record not found");
+            response.set_response_code(ResponseCode::NXDomain);
+            add_soa(response, zone_name, true);
+        }
+        Err(e) => {
+            error!(fqdn = %fqdn, error = %e, "Redis lookup failed");
+            response.set_response_code(ResponseCode::ServFail);
+        }
+    }
+}
+
+async fn handle_txt_query(
+    response: &mut Message,
+    qname: &Name,
+    zone_name: &Name,
+    store: &DnsStore,
+) {
+    let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
+
+    debug!(fqdn = %fqdn, "DNS TXT query");
+
+    match store.get_txt_record(&fqdn).await {
+        Ok(Some(data)) => {
+            let record = Record::from_rdata(
+                qname.clone(),
+                data.ttl_seconds,
+                RData::TXT(TXT::new(data.values.clone())),
+            );
+            response.add_answer(record);
+            response.set_response_code(ResponseCode::NoError);
+        }
+        Ok(None) => {
+            debug!(fqdn = %fqdn, "DNS TXT record not found");
+            response.set_response_code(ResponseCode::NXDomain);
+            add_soa(response, zone_name, true);
+        }
+        Err(e) => {
+            error!(fqdn = %fqdn, error = %e, "Redis lookup failed");
+            response.set_response_code(ResponseCode::ServFail);
+        }
+    }
+}
+
+async fn handle_mx_query(response: &mut Message, qname: &Name, zone_name: &Name, store: &DnsStore) {
+    let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
+
+    debug!(fqdn = %fqdn, "DNS MX query");
+
+    match store.get_mx_record(&fqdn).await {
+        Ok(Some(data)) => {
+            for exchange in &data.exchanges {
+                let host_str = if exchange.host.ends_with('.') {
+                    exchange.host.clone()
+                } else {
+                    format!("{}.", exchange.host)
+                };
+                match Name::from_ascii(&host_str) {
+                    Ok(name) => {
+                        let record = Record::from_rdata(
+                            qname.clone(),
+                            data.ttl_seconds,
+                            RData::MX(MX::new(exchange.priority, name)),
+                        );
+                        response.add_answer(record);
+                    }
+                    Err(e) => {
+                        warn!(host = %exchange.host, error = %e, "invalid MX host");
+                    }
+                }
+            }
+            response.set_response_code(ResponseCode::NoError);
+        }
+        Ok(None) => {
+            debug!(fqdn = %fqdn, "DNS MX record not found");
+            response.set_response_code(ResponseCode::NXDomain);
+            add_soa(response, zone_name, true);
+        }
+        Err(e) => {
+            error!(fqdn = %fqdn, error = %e, "Redis lookup failed");
+            response.set_response_code(ResponseCode::ServFail);
+        }
+    }
+}
+
+async fn handle_srv_query(
+    response: &mut Message,
+    qname: &Name,
+    zone_name: &Name,
+    store: &DnsStore,
+) {
+    let fqdn = qname.to_ascii().trim_end_matches('.').to_lowercase();
+
+    debug!(fqdn = %fqdn, "DNS SRV query");
+
+    match store.get_srv_record(&fqdn).await {
+        Ok(Some(data)) => {
+            for entry in &data.records {
+                let target_str = if entry.target.ends_with('.') {
+                    entry.target.clone()
+                } else {
+                    format!("{}.", entry.target)
+                };
+                match Name::from_ascii(&target_str) {
+                    Ok(name) => {
+                        let record = Record::from_rdata(
+                            qname.clone(),
+                            data.ttl_seconds,
+                            RData::SRV(SRV::new(entry.priority, entry.weight, entry.port, name)),
+                        );
+                        response.add_answer(record);
+                    }
+                    Err(e) => {
+                        warn!(target = %entry.target, error = %e, "invalid SRV target");
+                    }
+                }
+            }
+            response.set_response_code(ResponseCode::NoError);
+        }
+        Ok(None) => {
+            debug!(fqdn = %fqdn, "DNS SRV record not found");
             response.set_response_code(ResponseCode::NXDomain);
             add_soa(response, zone_name, true);
         }

--- a/crates/plugin_std_dns/src/dns_store.rs
+++ b/crates/plugin_std_dns/src/dns_store.rs
@@ -7,6 +7,50 @@ pub struct ARecordData {
     pub ttl_seconds: u32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AAAARecordData {
+    pub addresses: Vec<String>,
+    pub ttl_seconds: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CNAMERecordData {
+    pub target: String,
+    pub ttl_seconds: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TXTRecordData {
+    pub values: Vec<String>,
+    pub ttl_seconds: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MXExchange {
+    pub priority: u16,
+    pub host: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MXRecordData {
+    pub exchanges: Vec<MXExchange>,
+    pub ttl_seconds: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SRVTarget {
+    pub priority: u16,
+    pub weight: u16,
+    pub port: u16,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SRVRecordData {
+    pub records: Vec<SRVTarget>,
+    pub ttl_seconds: u32,
+}
+
 #[derive(Clone)]
 pub struct DnsStore {
     conn: redis::aio::MultiplexedConnection,
@@ -20,8 +64,28 @@ impl DnsStore {
         Ok(Self { conn })
     }
 
-    fn key(fqdn: &str) -> String {
+    fn a_key(fqdn: &str) -> String {
         format!("dns:a:{}", fqdn.to_lowercase())
+    }
+
+    fn aaaa_key(fqdn: &str) -> String {
+        format!("dns:aaaa:{}", fqdn.to_lowercase())
+    }
+
+    fn cname_key(fqdn: &str) -> String {
+        format!("dns:cname:{}", fqdn.to_lowercase())
+    }
+
+    fn txt_key(fqdn: &str) -> String {
+        format!("dns:txt:{}", fqdn.to_lowercase())
+    }
+
+    fn mx_key(fqdn: &str) -> String {
+        format!("dns:mx:{}", fqdn.to_lowercase())
+    }
+
+    fn srv_key(fqdn: &str) -> String {
+        format!("dns:srv:{}", fqdn.to_lowercase())
     }
 
     pub async fn set_a_record(
@@ -35,17 +99,157 @@ impl DnsStore {
             ttl_seconds,
         };
         let json = serde_json::to_string(&data)?;
-        let _: () = self.conn.clone().set(Self::key(fqdn), json).await?;
+        let _: () = self.conn.clone().set(Self::a_key(fqdn), json).await?;
         Ok(())
     }
 
     pub async fn delete_a_record(&self, fqdn: &str) -> anyhow::Result<()> {
-        let _: () = self.conn.clone().del(Self::key(fqdn)).await?;
+        let _: () = self.conn.clone().del(Self::a_key(fqdn)).await?;
         Ok(())
     }
 
     pub async fn get_a_record(&self, fqdn: &str) -> anyhow::Result<Option<ARecordData>> {
-        let data: Option<String> = self.conn.clone().get(Self::key(fqdn)).await?;
+        let data: Option<String> = self.conn.clone().get(Self::a_key(fqdn)).await?;
+        match data {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set_aaaa_record(
+        &self,
+        fqdn: &str,
+        addresses: &[String],
+        ttl_seconds: u32,
+    ) -> anyhow::Result<()> {
+        let data = AAAARecordData {
+            addresses: addresses.to_vec(),
+            ttl_seconds,
+        };
+        let json = serde_json::to_string(&data)?;
+        let _: () = self.conn.clone().set(Self::aaaa_key(fqdn), json).await?;
+        Ok(())
+    }
+
+    pub async fn delete_aaaa_record(&self, fqdn: &str) -> anyhow::Result<()> {
+        let _: () = self.conn.clone().del(Self::aaaa_key(fqdn)).await?;
+        Ok(())
+    }
+
+    pub async fn get_aaaa_record(&self, fqdn: &str) -> anyhow::Result<Option<AAAARecordData>> {
+        let data: Option<String> = self.conn.clone().get(Self::aaaa_key(fqdn)).await?;
+        match data {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set_cname_record(
+        &self,
+        fqdn: &str,
+        target: &str,
+        ttl_seconds: u32,
+    ) -> anyhow::Result<()> {
+        let data = CNAMERecordData {
+            target: target.to_string(),
+            ttl_seconds,
+        };
+        let json = serde_json::to_string(&data)?;
+        let _: () = self.conn.clone().set(Self::cname_key(fqdn), json).await?;
+        Ok(())
+    }
+
+    pub async fn delete_cname_record(&self, fqdn: &str) -> anyhow::Result<()> {
+        let _: () = self.conn.clone().del(Self::cname_key(fqdn)).await?;
+        Ok(())
+    }
+
+    pub async fn get_cname_record(&self, fqdn: &str) -> anyhow::Result<Option<CNAMERecordData>> {
+        let data: Option<String> = self.conn.clone().get(Self::cname_key(fqdn)).await?;
+        match data {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set_txt_record(
+        &self,
+        fqdn: &str,
+        values: &[String],
+        ttl_seconds: u32,
+    ) -> anyhow::Result<()> {
+        let data = TXTRecordData {
+            values: values.to_vec(),
+            ttl_seconds,
+        };
+        let json = serde_json::to_string(&data)?;
+        let _: () = self.conn.clone().set(Self::txt_key(fqdn), json).await?;
+        Ok(())
+    }
+
+    pub async fn delete_txt_record(&self, fqdn: &str) -> anyhow::Result<()> {
+        let _: () = self.conn.clone().del(Self::txt_key(fqdn)).await?;
+        Ok(())
+    }
+
+    pub async fn get_txt_record(&self, fqdn: &str) -> anyhow::Result<Option<TXTRecordData>> {
+        let data: Option<String> = self.conn.clone().get(Self::txt_key(fqdn)).await?;
+        match data {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set_mx_record(
+        &self,
+        fqdn: &str,
+        exchanges: &[MXExchange],
+        ttl_seconds: u32,
+    ) -> anyhow::Result<()> {
+        let data = MXRecordData {
+            exchanges: exchanges.to_vec(),
+            ttl_seconds,
+        };
+        let json = serde_json::to_string(&data)?;
+        let _: () = self.conn.clone().set(Self::mx_key(fqdn), json).await?;
+        Ok(())
+    }
+
+    pub async fn delete_mx_record(&self, fqdn: &str) -> anyhow::Result<()> {
+        let _: () = self.conn.clone().del(Self::mx_key(fqdn)).await?;
+        Ok(())
+    }
+
+    pub async fn get_mx_record(&self, fqdn: &str) -> anyhow::Result<Option<MXRecordData>> {
+        let data: Option<String> = self.conn.clone().get(Self::mx_key(fqdn)).await?;
+        match data {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn set_srv_record(
+        &self,
+        fqdn: &str,
+        records: &[SRVTarget],
+        ttl_seconds: u32,
+    ) -> anyhow::Result<()> {
+        let data = SRVRecordData {
+            records: records.to_vec(),
+            ttl_seconds,
+        };
+        let json = serde_json::to_string(&data)?;
+        let _: () = self.conn.clone().set(Self::srv_key(fqdn), json).await?;
+        Ok(())
+    }
+
+    pub async fn delete_srv_record(&self, fqdn: &str) -> anyhow::Result<()> {
+        let _: () = self.conn.clone().del(Self::srv_key(fqdn)).await?;
+        Ok(())
+    }
+
+    pub async fn get_srv_record(&self, fqdn: &str) -> anyhow::Result<Option<SRVRecordData>> {
+        let data: Option<String> = self.conn.clone().get(Self::srv_key(fqdn)).await?;
         match data {
             Some(json) => Ok(Some(serde_json::from_str(&json)?)),
             None => Ok(None),

--- a/crates/plugin_std_dns/src/main.rs
+++ b/crates/plugin_std_dns/src/main.rs
@@ -8,6 +8,11 @@ mod dns_server;
 mod dns_store;
 
 const A_RECORD_RESOURCE_TYPE: &str = "Std/DNS.ARecord";
+const AAAA_RECORD_RESOURCE_TYPE: &str = "Std/DNS.AAAARecord";
+const CNAME_RECORD_RESOURCE_TYPE: &str = "Std/DNS.CNAMERecord";
+const TXT_RECORD_RESOURCE_TYPE: &str = "Std/DNS.TXTRecord";
+const MX_RECORD_RESOURCE_TYPE: &str = "Std/DNS.MXRecord";
+const SRV_RECORD_RESOURCE_TYPE: &str = "Std/DNS.SRVRecord";
 
 /// Normalize a string for use as a DNS label: lowercase and replace non-alphanumeric
 /// characters with hyphens.
@@ -83,6 +88,87 @@ impl DnsPlugin {
         (millis / 1000).clamp(1, u32::MAX as i64) as u32
     }
 
+    fn extract_target(inputs: &sclc::Record) -> Option<String> {
+        match inputs.get("target") {
+            sclc::Value::Str(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    fn extract_values(inputs: &sclc::Record) -> Vec<String> {
+        match inputs.get("values") {
+            sclc::Value::List(list) => list
+                .iter()
+                .filter_map(|v| match v {
+                    sclc::Value::Str(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    fn extract_exchanges(inputs: &sclc::Record) -> Vec<dns_store::MXExchange> {
+        match inputs.get("exchanges") {
+            sclc::Value::List(list) => list
+                .iter()
+                .filter_map(|v| {
+                    let r = match v {
+                        sclc::Value::Record(r) => r,
+                        _ => return None,
+                    };
+                    let priority = match r.get("priority") {
+                        sclc::Value::Int(i) => u16::try_from(*i).ok()?,
+                        _ => return None,
+                    };
+                    let host = match r.get("host") {
+                        sclc::Value::Str(s) => s.clone(),
+                        _ => return None,
+                    };
+                    Some(dns_store::MXExchange { priority, host })
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    fn extract_srv_records(inputs: &sclc::Record) -> Vec<dns_store::SRVTarget> {
+        match inputs.get("records") {
+            sclc::Value::List(list) => list
+                .iter()
+                .filter_map(|v| {
+                    let r = match v {
+                        sclc::Value::Record(r) => r,
+                        _ => return None,
+                    };
+                    let priority = match r.get("priority") {
+                        sclc::Value::Int(i) => u16::try_from(*i).ok()?,
+                        _ => return None,
+                    };
+                    let weight = match r.get("weight") {
+                        sclc::Value::Int(i) => u16::try_from(*i).ok()?,
+                        _ => return None,
+                    };
+                    let port = match r.get("port") {
+                        sclc::Value::Int(i) => u16::try_from(*i).ok()?,
+                        _ => return None,
+                    };
+                    let target = match r.get("target") {
+                        sclc::Value::Str(s) => s.clone(),
+                        _ => return None,
+                    };
+                    Some(dns_store::SRVTarget {
+                        priority,
+                        weight,
+                        port,
+                        target,
+                    })
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
     async fn dispatch(
         &self,
         environment_qid: &ids::EnvironmentQid,
@@ -108,6 +194,137 @@ impl DnsPlugin {
                 outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
                 outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
                 outputs.insert(String::from("addresses"), inputs.get("addresses").clone());
+
+                Ok(sclc::Resource {
+                    inputs,
+                    outputs,
+                    dependencies: vec![],
+                    markers: Default::default(),
+                })
+            }
+            AAAA_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let addresses = Self::extract_addresses(&inputs);
+                let ttl_seconds = Self::extract_ttl_seconds(&inputs);
+                let fqdn = self.fqdn(&name, environment_qid);
+
+                self.inner
+                    .store
+                    .set_aaaa_record(&fqdn, &addresses, ttl_seconds)
+                    .await?;
+
+                let mut outputs = sclc::Record::default();
+                outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
+                outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
+                outputs.insert(String::from("addresses"), inputs.get("addresses").clone());
+
+                Ok(sclc::Resource {
+                    inputs,
+                    outputs,
+                    dependencies: vec![],
+                    markers: Default::default(),
+                })
+            }
+            CNAME_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let target = Self::extract_target(&inputs)
+                    .ok_or_else(|| anyhow::anyhow!("missing or invalid 'target' input"))?;
+                let ttl_seconds = Self::extract_ttl_seconds(&inputs);
+                let fqdn = self.fqdn(&name, environment_qid);
+
+                self.inner
+                    .store
+                    .set_cname_record(&fqdn, &target, ttl_seconds)
+                    .await?;
+
+                let mut outputs = sclc::Record::default();
+                outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
+                outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
+                outputs.insert(String::from("target"), inputs.get("target").clone());
+
+                Ok(sclc::Resource {
+                    inputs,
+                    outputs,
+                    dependencies: vec![],
+                    markers: Default::default(),
+                })
+            }
+            TXT_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let values = Self::extract_values(&inputs);
+                let ttl_seconds = Self::extract_ttl_seconds(&inputs);
+                let fqdn = self.fqdn(&name, environment_qid);
+
+                self.inner
+                    .store
+                    .set_txt_record(&fqdn, &values, ttl_seconds)
+                    .await?;
+
+                let mut outputs = sclc::Record::default();
+                outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
+                outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
+                outputs.insert(String::from("values"), inputs.get("values").clone());
+
+                Ok(sclc::Resource {
+                    inputs,
+                    outputs,
+                    dependencies: vec![],
+                    markers: Default::default(),
+                })
+            }
+            MX_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let exchanges = Self::extract_exchanges(&inputs);
+                let ttl_seconds = Self::extract_ttl_seconds(&inputs);
+                let fqdn = self.fqdn(&name, environment_qid);
+
+                self.inner
+                    .store
+                    .set_mx_record(&fqdn, &exchanges, ttl_seconds)
+                    .await?;
+
+                let mut outputs = sclc::Record::default();
+                outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
+                outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
+                outputs.insert(String::from("exchanges"), inputs.get("exchanges").clone());
+
+                Ok(sclc::Resource {
+                    inputs,
+                    outputs,
+                    dependencies: vec![],
+                    markers: Default::default(),
+                })
+            }
+            SRV_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let records = Self::extract_srv_records(&inputs);
+                let ttl_seconds = Self::extract_ttl_seconds(&inputs);
+                let fqdn = self.fqdn(&name, environment_qid);
+
+                self.inner
+                    .store
+                    .set_srv_record(&fqdn, &records, ttl_seconds)
+                    .await?;
+
+                let mut outputs = sclc::Record::default();
+                outputs.insert(String::from("fqdn"), sclc::Value::Str(fqdn));
+                outputs.insert(String::from("ttl"), inputs.get("ttl").clone());
+                outputs.insert(String::from("records"), inputs.get("records").clone());
 
                 Ok(sclc::Resource {
                     inputs,
@@ -171,6 +388,51 @@ impl rtp::Plugin for DnsPlugin {
                 };
                 let fqdn = self.fqdn(&name, env_qid);
                 self.inner.store.delete_a_record(&fqdn).await?;
+                Ok(())
+            }
+            AAAA_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let fqdn = self.fqdn(&name, env_qid);
+                self.inner.store.delete_aaaa_record(&fqdn).await?;
+                Ok(())
+            }
+            CNAME_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let fqdn = self.fqdn(&name, env_qid);
+                self.inner.store.delete_cname_record(&fqdn).await?;
+                Ok(())
+            }
+            TXT_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let fqdn = self.fqdn(&name, env_qid);
+                self.inner.store.delete_txt_record(&fqdn).await?;
+                Ok(())
+            }
+            MX_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let fqdn = self.fqdn(&name, env_qid);
+                self.inner.store.delete_mx_record(&fqdn).await?;
+                Ok(())
+            }
+            SRV_RECORD_RESOURCE_TYPE => {
+                let name = match inputs.get("name") {
+                    sclc::Value::Str(s) => s.clone(),
+                    _ => anyhow::bail!("missing or invalid 'name' input"),
+                };
+                let fqdn = self.fqdn(&name, env_qid);
+                self.inner.store.delete_srv_record(&fqdn).await?;
                 Ok(())
             }
             _ => anyhow::bail!("unsupported resource type: {}", id.typ),

--- a/crates/sclc/src/std/DNS.scl
+++ b/crates/sclc/src/std/DNS.scl
@@ -29,3 +29,153 @@ export type ARecordOutput {
 	/// IPv4 addresses
 	addresses: [Str],
 }
+
+/// Create a DNS AAAA record.
+///
+/// ```scl
+/// import Std/DNS
+/// import Std/Time
+///
+/// DNS.AAAARecord({
+///     name: "a.b.c",
+///     ttl: Time.minute,
+///     addresses: ["2001:db8::1"],
+/// })
+/// ```
+export let AAAARecord = extern "Std/DNS.AAAARecord": fn({
+	/// Fully-qualified domain name
+	name: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// IPv6 addresses
+	addresses: [Str],
+}) AAAARecordOutput
+
+export type AAAARecordOutput {
+	/// Fully-qualified domain name (name + zone)
+	fqdn: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// IPv6 addresses
+	addresses: [Str],
+}
+
+/// Create a DNS CNAME record.
+///
+/// ```scl
+/// import Std/DNS
+/// import Std/Time
+///
+/// DNS.CNAMERecord({
+///     name: "alias.example.com",
+///     ttl: Time.minute,
+///     target: "canonical.example.com",
+/// })
+/// ```
+export let CNAMERecord = extern "Std/DNS.CNAMERecord": fn({
+	/// Fully-qualified domain name
+	name: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// CNAME target
+	target: Str,
+}) CNAMERecordOutput
+
+export type CNAMERecordOutput {
+	/// Fully-qualified domain name (name + zone)
+	fqdn: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// CNAME target
+	target: Str,
+}
+
+/// Create a DNS TXT record.
+///
+/// ```scl
+/// import Std/DNS
+/// import Std/Time
+///
+/// DNS.TXTRecord({
+///     name: "example.com",
+///     ttl: Time.minute,
+///     values: ["v=spf1 -all"],
+/// })
+/// ```
+export let TXTRecord = extern "Std/DNS.TXTRecord": fn({
+	/// Fully-qualified domain name
+	name: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Text values
+	values: [Str],
+}) TXTRecordOutput
+
+export type TXTRecordOutput {
+	/// Fully-qualified domain name (name + zone)
+	fqdn: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Text values
+	values: [Str],
+}
+
+/// Create a DNS MX record.
+///
+/// ```scl
+/// import Std/DNS
+/// import Std/Time
+///
+/// DNS.MXRecord({
+///     name: "example.com",
+///     ttl: Time.minute,
+///     exchanges: [{ priority: 10, host: "mail.example.com" }],
+/// })
+/// ```
+export let MXRecord = extern "Std/DNS.MXRecord": fn({
+	/// Fully-qualified domain name
+	name: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Mail exchangers
+	exchanges: [{ priority: Int, host: Str }],
+}) MXRecordOutput
+
+export type MXRecordOutput {
+	/// Fully-qualified domain name (name + zone)
+	fqdn: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Mail exchangers
+	exchanges: [{ priority: Int, host: Str }],
+}
+
+/// Create a DNS SRV record.
+///
+/// ```scl
+/// import Std/DNS
+/// import Std/Time
+///
+/// DNS.SRVRecord({
+///     name: "_svc._tcp.example.com",
+///     ttl: Time.minute,
+///     records: [{ priority: 10, weight: 5, port: 443, target: "svc.example.com" }],
+/// })
+/// ```
+export let SRVRecord = extern "Std/DNS.SRVRecord": fn({
+	/// Fully-qualified domain name
+	name: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Service records
+	records: [{ priority: Int, weight: Int, port: Int, target: Str }],
+}) SRVRecordOutput
+
+export type SRVRecordOutput {
+	/// Fully-qualified domain name (name + zone)
+	fqdn: Str,
+	/// Time to live
+	ttl: Time.Duration,
+	/// Service records
+	records: [{ priority: Int, weight: Int, port: Int, target: Str }],
+}

--- a/crates/sclc/src/std/dns.rs
+++ b/crates/sclc/src/std/dns.rs
@@ -1,48 +1,32 @@
 const A_RECORD_RESOURCE_TYPE: &str = "Std/DNS.ARecord";
+const AAAA_RECORD_RESOURCE_TYPE: &str = "Std/DNS.AAAARecord";
+const CNAME_RECORD_RESOURCE_TYPE: &str = "Std/DNS.CNAMERecord";
+const TXT_RECORD_RESOURCE_TYPE: &str = "Std/DNS.TXTRecord";
+const MX_RECORD_RESOURCE_TYPE: &str = "Std/DNS.MXRecord";
+const SRV_RECORD_RESOURCE_TYPE: &str = "Std/DNS.SRVRecord";
 
-pub fn register_extern(eval: &mut impl super::ExternRegistry) {
-    eval.add_extern_fn(A_RECORD_RESOURCE_TYPE, |args, eval_ctx| {
+fn register_record_extern(registry: &mut impl super::ExternRegistry, resource_type: &'static str) {
+    registry.add_extern_fn(resource_type, move |args, eval_ctx| {
         use crate::ValueAssertions;
 
-        let mut args = args.into_iter();
-        let config_arg = args
-            .next()
-            .unwrap_or_else(|| crate::TrackedValue::new(crate::Value::Nil));
-        let argument_dependencies = config_arg.dependencies.clone();
-
-        if config_arg.value.has_pending() {
-            return Ok(crate::TrackedValue::pending().with_dependencies(argument_dependencies));
-        }
-
-        let config = config_arg.value.assert_record()?;
-
-        let name = config.get("name").assert_str_ref()?;
-        let ttl = config.get("ttl").assert_record_ref()?;
-        let addresses = match config.get("addresses") {
-            crate::Value::List(list) => list.clone(),
-            _ => vec![],
+        let (config, deps) = match super::extract_config_arg(args)? {
+            Ok(pair) => pair,
+            Err(pending) => return Ok(pending),
         };
 
+        let name = config.get("name").assert_str_ref()?;
+
         let resource_id = ids::ResourceId {
-            typ: A_RECORD_RESOURCE_TYPE.to_string(),
+            typ: resource_type.to_string(),
             name: name.to_owned(),
         };
 
         let mut inputs = crate::Record::default();
-        inputs.insert(String::from("name"), crate::Value::Str(name.to_owned()));
-        inputs.insert(
-            String::from("ttl"),
-            crate::Value::Record(ttl.clone()),
-        );
-        inputs.insert(String::from("addresses"), crate::Value::List(addresses));
+        for (k, v) in config.iter() {
+            inputs.insert(k.to_string(), v.clone());
+        }
 
-        let Some(outputs) = eval_ctx.resource(
-            A_RECORD_RESOURCE_TYPE,
-            name,
-            &inputs,
-            argument_dependencies.clone(),
-        )?
-        else {
+        let Some(outputs) = eval_ctx.resource(resource_type, name, &inputs, deps.clone())? else {
             return Ok(crate::TrackedValue::pending().with_dependency(resource_id));
         };
 
@@ -52,4 +36,13 @@ pub fn register_extern(eval: &mut impl super::ExternRegistry) {
         }
         Ok(crate::TrackedValue::new(crate::Value::Record(merged)).with_dependency(resource_id))
     })
+}
+
+pub fn register_extern(eval: &mut impl super::ExternRegistry) {
+    register_record_extern(eval, A_RECORD_RESOURCE_TYPE);
+    register_record_extern(eval, AAAA_RECORD_RESOURCE_TYPE);
+    register_record_extern(eval, CNAME_RECORD_RESOURCE_TYPE);
+    register_record_extern(eval, TXT_RECORD_RESOURCE_TYPE);
+    register_record_extern(eval, MX_RECORD_RESOURCE_TYPE);
+    register_record_extern(eval, SRV_RECORD_RESOURCE_TYPE);
 }

--- a/crates/sclc/src/tests/DNSAAAARecord/Main.scl
+++ b/crates/sclc/src/tests/DNSAAAARecord/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.AAAARecord({
+    name: "a.b.c",
+    ttl: { milliseconds: 60000 },
+    addresses: ["2001:db8::1"],
+})

--- a/crates/sclc/src/tests/DNSAAAARecord/effects.log
+++ b/crates/sclc/src/tests/DNSAAAARecord/effects.log
@@ -1,0 +1,1 @@
+CreateResource ty=Std/DNS.AAAARecord name=a.b.c inputs={addresses: ["2001:db8::1"], name: "a.b.c", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSAAAARecord/exports.txt
+++ b/crates/sclc/src/tests/DNSAAAARecord/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSAAAARecordTouch/Main.scl
+++ b/crates/sclc/src/tests/DNSAAAARecordTouch/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.AAAARecord({
+    name: "a.b.c",
+    ttl: { milliseconds: 60000 },
+    addresses: ["2001:db8::1"],
+})

--- a/crates/sclc/src/tests/DNSAAAARecordTouch/effects.log
+++ b/crates/sclc/src/tests/DNSAAAARecordTouch/effects.log
@@ -1,0 +1,1 @@
+TouchResource ty=Std/DNS.AAAARecord name=a.b.c inputs={addresses: ["2001:db8::1"], name: "a.b.c", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSAAAARecordTouch/exports.txt
+++ b/crates/sclc/src/tests/DNSAAAARecordTouch/exports.txt
@@ -1,0 +1,1 @@
+{record: {addresses: ["2001:db8::1"], fqdn: "a.b.c", name: "a.b.c", ttl: {milliseconds: 60000}}}

--- a/crates/sclc/src/tests/DNSAAAARecordTouch/rdb.json
+++ b/crates/sclc/src/tests/DNSAAAARecordTouch/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.AAAARecord": {
+      "a.b.c": {
+        "inputs": {
+          "name": "a.b.c",
+          "ttl": { "milliseconds": 60000 },
+          "addresses": ["2001:db8::1"]
+        },
+        "outputs": {
+          "fqdn": "a.b.c",
+          "ttl": { "milliseconds": 60000 },
+          "addresses": ["2001:db8::1"]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSAAAARecordUpdate/Main.scl
+++ b/crates/sclc/src/tests/DNSAAAARecordUpdate/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.AAAARecord({
+    name: "a.b.c",
+    ttl: { milliseconds: 60000 },
+    addresses: ["2001:db8::1", "2001:db8::2"],
+})

--- a/crates/sclc/src/tests/DNSAAAARecordUpdate/effects.log
+++ b/crates/sclc/src/tests/DNSAAAARecordUpdate/effects.log
@@ -1,0 +1,1 @@
+UpdateResource ty=Std/DNS.AAAARecord name=a.b.c inputs={addresses: ["2001:db8::1", "2001:db8::2"], name: "a.b.c", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSAAAARecordUpdate/exports.txt
+++ b/crates/sclc/src/tests/DNSAAAARecordUpdate/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSAAAARecordUpdate/rdb.json
+++ b/crates/sclc/src/tests/DNSAAAARecordUpdate/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.AAAARecord": {
+      "a.b.c": {
+        "inputs": {
+          "name": "a.b.c",
+          "ttl": { "milliseconds": 30000 },
+          "addresses": ["2001:db8::1"]
+        },
+        "outputs": {
+          "fqdn": "a.b.c",
+          "ttl": { "milliseconds": 30000 },
+          "addresses": ["2001:db8::1"]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSCNAMERecord/Main.scl
+++ b/crates/sclc/src/tests/DNSCNAMERecord/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.CNAMERecord({
+    name: "alias.example.com",
+    ttl: { milliseconds: 60000 },
+    target: "canonical.example.com",
+})

--- a/crates/sclc/src/tests/DNSCNAMERecord/effects.log
+++ b/crates/sclc/src/tests/DNSCNAMERecord/effects.log
@@ -1,0 +1,1 @@
+CreateResource ty=Std/DNS.CNAMERecord name=alias.example.com inputs={name: "alias.example.com", target: "canonical.example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSCNAMERecord/exports.txt
+++ b/crates/sclc/src/tests/DNSCNAMERecord/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSCNAMERecordTouch/Main.scl
+++ b/crates/sclc/src/tests/DNSCNAMERecordTouch/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.CNAMERecord({
+    name: "alias.example.com",
+    ttl: { milliseconds: 60000 },
+    target: "canonical.example.com",
+})

--- a/crates/sclc/src/tests/DNSCNAMERecordTouch/effects.log
+++ b/crates/sclc/src/tests/DNSCNAMERecordTouch/effects.log
@@ -1,0 +1,1 @@
+TouchResource ty=Std/DNS.CNAMERecord name=alias.example.com inputs={name: "alias.example.com", target: "canonical.example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSCNAMERecordTouch/exports.txt
+++ b/crates/sclc/src/tests/DNSCNAMERecordTouch/exports.txt
@@ -1,0 +1,1 @@
+{record: {fqdn: "alias.example.com", name: "alias.example.com", target: "canonical.example.com", ttl: {milliseconds: 60000}}}

--- a/crates/sclc/src/tests/DNSCNAMERecordTouch/rdb.json
+++ b/crates/sclc/src/tests/DNSCNAMERecordTouch/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.CNAMERecord": {
+      "alias.example.com": {
+        "inputs": {
+          "name": "alias.example.com",
+          "ttl": { "milliseconds": 60000 },
+          "target": "canonical.example.com"
+        },
+        "outputs": {
+          "fqdn": "alias.example.com",
+          "ttl": { "milliseconds": 60000 },
+          "target": "canonical.example.com"
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSCNAMERecordUpdate/Main.scl
+++ b/crates/sclc/src/tests/DNSCNAMERecordUpdate/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.CNAMERecord({
+    name: "alias.example.com",
+    ttl: { milliseconds: 60000 },
+    target: "new.example.com",
+})

--- a/crates/sclc/src/tests/DNSCNAMERecordUpdate/effects.log
+++ b/crates/sclc/src/tests/DNSCNAMERecordUpdate/effects.log
@@ -1,0 +1,1 @@
+UpdateResource ty=Std/DNS.CNAMERecord name=alias.example.com inputs={name: "alias.example.com", target: "new.example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSCNAMERecordUpdate/exports.txt
+++ b/crates/sclc/src/tests/DNSCNAMERecordUpdate/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSCNAMERecordUpdate/rdb.json
+++ b/crates/sclc/src/tests/DNSCNAMERecordUpdate/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.CNAMERecord": {
+      "alias.example.com": {
+        "inputs": {
+          "name": "alias.example.com",
+          "ttl": { "milliseconds": 30000 },
+          "target": "canonical.example.com"
+        },
+        "outputs": {
+          "fqdn": "alias.example.com",
+          "ttl": { "milliseconds": 30000 },
+          "target": "canonical.example.com"
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSMXRecord/Main.scl
+++ b/crates/sclc/src/tests/DNSMXRecord/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.MXRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    exchanges: [{ priority: 10, host: "mail.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSMXRecord/effects.log
+++ b/crates/sclc/src/tests/DNSMXRecord/effects.log
@@ -1,0 +1,1 @@
+CreateResource ty=Std/DNS.MXRecord name=example.com inputs={exchanges: [{host: "mail.example.com", priority: 10}], name: "example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSMXRecord/exports.txt
+++ b/crates/sclc/src/tests/DNSMXRecord/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSMXRecordTouch/Main.scl
+++ b/crates/sclc/src/tests/DNSMXRecordTouch/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.MXRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    exchanges: [{ priority: 10, host: "mail.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSMXRecordTouch/effects.log
+++ b/crates/sclc/src/tests/DNSMXRecordTouch/effects.log
@@ -1,0 +1,1 @@
+TouchResource ty=Std/DNS.MXRecord name=example.com inputs={exchanges: [{host: "mail.example.com", priority: 10}], name: "example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSMXRecordTouch/exports.txt
+++ b/crates/sclc/src/tests/DNSMXRecordTouch/exports.txt
@@ -1,0 +1,1 @@
+{record: {exchanges: [{host: "mail.example.com", priority: 10}], fqdn: "example.com", name: "example.com", ttl: {milliseconds: 60000}}}

--- a/crates/sclc/src/tests/DNSMXRecordTouch/rdb.json
+++ b/crates/sclc/src/tests/DNSMXRecordTouch/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.MXRecord": {
+      "example.com": {
+        "inputs": {
+          "name": "example.com",
+          "ttl": { "milliseconds": 60000 },
+          "exchanges": [{ "priority": 10, "host": "mail.example.com" }]
+        },
+        "outputs": {
+          "fqdn": "example.com",
+          "ttl": { "milliseconds": 60000 },
+          "exchanges": [{ "priority": 10, "host": "mail.example.com" }]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSMXRecordUpdate/Main.scl
+++ b/crates/sclc/src/tests/DNSMXRecordUpdate/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.MXRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    exchanges: [{ priority: 10, host: "mail.example.com" }, { priority: 20, host: "mail2.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSMXRecordUpdate/effects.log
+++ b/crates/sclc/src/tests/DNSMXRecordUpdate/effects.log
@@ -1,0 +1,1 @@
+UpdateResource ty=Std/DNS.MXRecord name=example.com inputs={exchanges: [{host: "mail.example.com", priority: 10}, {host: "mail2.example.com", priority: 20}], name: "example.com", ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSMXRecordUpdate/exports.txt
+++ b/crates/sclc/src/tests/DNSMXRecordUpdate/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSMXRecordUpdate/rdb.json
+++ b/crates/sclc/src/tests/DNSMXRecordUpdate/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.MXRecord": {
+      "example.com": {
+        "inputs": {
+          "name": "example.com",
+          "ttl": { "milliseconds": 30000 },
+          "exchanges": [{ "priority": 10, "host": "mail.example.com" }]
+        },
+        "outputs": {
+          "fqdn": "example.com",
+          "ttl": { "milliseconds": 30000 },
+          "exchanges": [{ "priority": 10, "host": "mail.example.com" }]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSSRVRecord/Main.scl
+++ b/crates/sclc/src/tests/DNSSRVRecord/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.SRVRecord({
+    name: "_svc._tcp.example.com",
+    ttl: { milliseconds: 60000 },
+    records: [{ priority: 10, weight: 5, port: 443, target: "svc.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSSRVRecord/effects.log
+++ b/crates/sclc/src/tests/DNSSRVRecord/effects.log
@@ -1,0 +1,1 @@
+CreateResource ty=Std/DNS.SRVRecord name=_svc._tcp.example.com inputs={name: "_svc._tcp.example.com", records: [{port: 443, priority: 10, target: "svc.example.com", weight: 5}], ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSSRVRecord/exports.txt
+++ b/crates/sclc/src/tests/DNSSRVRecord/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSSRVRecordTouch/Main.scl
+++ b/crates/sclc/src/tests/DNSSRVRecordTouch/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.SRVRecord({
+    name: "_svc._tcp.example.com",
+    ttl: { milliseconds: 60000 },
+    records: [{ priority: 10, weight: 5, port: 443, target: "svc.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSSRVRecordTouch/effects.log
+++ b/crates/sclc/src/tests/DNSSRVRecordTouch/effects.log
@@ -1,0 +1,1 @@
+TouchResource ty=Std/DNS.SRVRecord name=_svc._tcp.example.com inputs={name: "_svc._tcp.example.com", records: [{port: 443, priority: 10, target: "svc.example.com", weight: 5}], ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSSRVRecordTouch/exports.txt
+++ b/crates/sclc/src/tests/DNSSRVRecordTouch/exports.txt
@@ -1,0 +1,1 @@
+{record: {fqdn: "_svc._tcp.example.com", name: "_svc._tcp.example.com", records: [{port: 443, priority: 10, target: "svc.example.com", weight: 5}], ttl: {milliseconds: 60000}}}

--- a/crates/sclc/src/tests/DNSSRVRecordTouch/rdb.json
+++ b/crates/sclc/src/tests/DNSSRVRecordTouch/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.SRVRecord": {
+      "_svc._tcp.example.com": {
+        "inputs": {
+          "name": "_svc._tcp.example.com",
+          "ttl": { "milliseconds": 60000 },
+          "records": [{ "priority": 10, "weight": 5, "port": 443, "target": "svc.example.com" }]
+        },
+        "outputs": {
+          "fqdn": "_svc._tcp.example.com",
+          "ttl": { "milliseconds": 60000 },
+          "records": [{ "priority": 10, "weight": 5, "port": 443, "target": "svc.example.com" }]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSSRVRecordUpdate/Main.scl
+++ b/crates/sclc/src/tests/DNSSRVRecordUpdate/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.SRVRecord({
+    name: "_svc._tcp.example.com",
+    ttl: { milliseconds: 60000 },
+    records: [{ priority: 10, weight: 10, port: 443, target: "svc2.example.com" }],
+})

--- a/crates/sclc/src/tests/DNSSRVRecordUpdate/effects.log
+++ b/crates/sclc/src/tests/DNSSRVRecordUpdate/effects.log
@@ -1,0 +1,1 @@
+UpdateResource ty=Std/DNS.SRVRecord name=_svc._tcp.example.com inputs={name: "_svc._tcp.example.com", records: [{port: 443, priority: 10, target: "svc2.example.com", weight: 10}], ttl: {milliseconds: 60000}}

--- a/crates/sclc/src/tests/DNSSRVRecordUpdate/exports.txt
+++ b/crates/sclc/src/tests/DNSSRVRecordUpdate/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSSRVRecordUpdate/rdb.json
+++ b/crates/sclc/src/tests/DNSSRVRecordUpdate/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.SRVRecord": {
+      "_svc._tcp.example.com": {
+        "inputs": {
+          "name": "_svc._tcp.example.com",
+          "ttl": { "milliseconds": 30000 },
+          "records": [{ "priority": 10, "weight": 5, "port": 443, "target": "svc.example.com" }]
+        },
+        "outputs": {
+          "fqdn": "_svc._tcp.example.com",
+          "ttl": { "milliseconds": 30000 },
+          "records": [{ "priority": 10, "weight": 5, "port": 443, "target": "svc.example.com" }]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSTXTRecord/Main.scl
+++ b/crates/sclc/src/tests/DNSTXTRecord/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.TXTRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    values: ["v=spf1 -all"],
+})

--- a/crates/sclc/src/tests/DNSTXTRecord/effects.log
+++ b/crates/sclc/src/tests/DNSTXTRecord/effects.log
@@ -1,0 +1,1 @@
+CreateResource ty=Std/DNS.TXTRecord name=example.com inputs={name: "example.com", ttl: {milliseconds: 60000}, values: ["v=spf1 -all"]}

--- a/crates/sclc/src/tests/DNSTXTRecord/exports.txt
+++ b/crates/sclc/src/tests/DNSTXTRecord/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSTXTRecordTouch/Main.scl
+++ b/crates/sclc/src/tests/DNSTXTRecordTouch/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.TXTRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    values: ["v=spf1 -all"],
+})

--- a/crates/sclc/src/tests/DNSTXTRecordTouch/effects.log
+++ b/crates/sclc/src/tests/DNSTXTRecordTouch/effects.log
@@ -1,0 +1,1 @@
+TouchResource ty=Std/DNS.TXTRecord name=example.com inputs={name: "example.com", ttl: {milliseconds: 60000}, values: ["v=spf1 -all"]}

--- a/crates/sclc/src/tests/DNSTXTRecordTouch/exports.txt
+++ b/crates/sclc/src/tests/DNSTXTRecordTouch/exports.txt
@@ -1,0 +1,1 @@
+{record: {fqdn: "example.com", name: "example.com", ttl: {milliseconds: 60000}, values: ["v=spf1 -all"]}}

--- a/crates/sclc/src/tests/DNSTXTRecordTouch/rdb.json
+++ b/crates/sclc/src/tests/DNSTXTRecordTouch/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.TXTRecord": {
+      "example.com": {
+        "inputs": {
+          "name": "example.com",
+          "ttl": { "milliseconds": 60000 },
+          "values": ["v=spf1 -all"]
+        },
+        "outputs": {
+          "fqdn": "example.com",
+          "ttl": { "milliseconds": 60000 },
+          "values": ["v=spf1 -all"]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/DNSTXTRecordUpdate/Main.scl
+++ b/crates/sclc/src/tests/DNSTXTRecordUpdate/Main.scl
@@ -1,0 +1,7 @@
+import Std/DNS
+
+export let record = DNS.TXTRecord({
+    name: "example.com",
+    ttl: { milliseconds: 60000 },
+    values: ["v=spf1 include:example.net -all"],
+})

--- a/crates/sclc/src/tests/DNSTXTRecordUpdate/effects.log
+++ b/crates/sclc/src/tests/DNSTXTRecordUpdate/effects.log
@@ -1,0 +1,1 @@
+UpdateResource ty=Std/DNS.TXTRecord name=example.com inputs={name: "example.com", ttl: {milliseconds: 60000}, values: ["v=spf1 include:example.net -all"]}

--- a/crates/sclc/src/tests/DNSTXTRecordUpdate/exports.txt
+++ b/crates/sclc/src/tests/DNSTXTRecordUpdate/exports.txt
@@ -1,0 +1,1 @@
+{record: <pending>}

--- a/crates/sclc/src/tests/DNSTXTRecordUpdate/rdb.json
+++ b/crates/sclc/src/tests/DNSTXTRecordUpdate/rdb.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "Std/DNS.TXTRecord": {
+      "example.com": {
+        "inputs": {
+          "name": "example.com",
+          "ttl": { "milliseconds": 30000 },
+          "values": ["v=spf1 -all"]
+        },
+        "outputs": {
+          "fqdn": "example.com",
+          "ttl": { "milliseconds": 30000 },
+          "values": ["v=spf1 -all"]
+        }
+      }
+    }
+  }
+}

--- a/crates/sclc/src/tests/mod.rs
+++ b/crates/sclc/src/tests/mod.rs
@@ -486,6 +486,21 @@ test_case!(ContainerHost);
 test_case!(DNSARecord);
 test_case!(DNSARecordTouch);
 test_case!(DNSARecordUpdate);
+test_case!(DNSAAAARecord);
+test_case!(DNSAAAARecordTouch);
+test_case!(DNSAAAARecordUpdate);
+test_case!(DNSCNAMERecord);
+test_case!(DNSCNAMERecordTouch);
+test_case!(DNSCNAMERecordUpdate);
+test_case!(DNSTXTRecord);
+test_case!(DNSTXTRecordTouch);
+test_case!(DNSTXTRecordUpdate);
+test_case!(DNSMXRecord);
+test_case!(DNSMXRecordTouch);
+test_case!(DNSMXRecordUpdate);
+test_case!(DNSSRVRecord);
+test_case!(DNSSRVRecordTouch);
+test_case!(DNSSRVRecordUpdate);
 
 // Std/Crypto
 test_case!(CryptoED25519);

--- a/docs/scl/stdlib.md
+++ b/docs/scl/stdlib.md
@@ -24,7 +24,129 @@ DNS.ARecord({
 | **Inputs** | `name: Str` — fully-qualified domain name |
 | | `ttl: Time.Duration` — time to live |
 | | `addresses: [Str]` — list of IPv4 addresses |
-| **Outputs** | Same as inputs |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `addresses: [Str]` |
+
+### DNS.AAAARecord
+
+Create a DNS AAAA record (IPv6).
+
+```scl
+import Std/DNS
+import Std/Time
+
+DNS.AAAARecord({
+    name: "example.com",
+    ttl: Time.minute,
+    addresses: ["2001:db8::1"],
+})
+```
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name: Str` — fully-qualified domain name |
+| | `ttl: Time.Duration` — time to live |
+| | `addresses: [Str]` — list of IPv6 addresses |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `addresses: [Str]` |
+
+### DNS.CNAMERecord
+
+Create a DNS CNAME record.
+
+```scl
+import Std/DNS
+import Std/Time
+
+DNS.CNAMERecord({
+    name: "alias.example.com",
+    ttl: Time.minute,
+    target: "canonical.example.com",
+})
+```
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name: Str` — fully-qualified domain name |
+| | `ttl: Time.Duration` — time to live |
+| | `target: Str` — canonical name target |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `target: Str` |
+
+### DNS.TXTRecord
+
+Create a DNS TXT record.
+
+```scl
+import Std/DNS
+import Std/Time
+
+DNS.TXTRecord({
+    name: "example.com",
+    ttl: Time.minute,
+    values: ["v=spf1 -all"],
+})
+```
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name: Str` — fully-qualified domain name |
+| | `ttl: Time.Duration` — time to live |
+| | `values: [Str]` — one or more text strings |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `values: [Str]` |
+
+### DNS.MXRecord
+
+Create a DNS MX record.
+
+```scl
+import Std/DNS
+import Std/Time
+
+DNS.MXRecord({
+    name: "example.com",
+    ttl: Time.minute,
+    exchanges: [{ priority: 10, host: "mail.example.com" }],
+})
+```
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name: Str` — fully-qualified domain name |
+| | `ttl: Time.Duration` — time to live |
+| | `exchanges: [{priority: Int, host: Str}]` — mail exchangers |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `exchanges: [{priority: Int, host: Str}]` |
+
+### DNS.SRVRecord
+
+Create a DNS SRV record.
+
+```scl
+import Std/DNS
+import Std/Time
+
+DNS.SRVRecord({
+    name: "_svc._tcp.example.com",
+    ttl: Time.minute,
+    records: [{ priority: 10, weight: 5, port: 443, target: "svc.example.com" }],
+})
+```
+
+| | Fields |
+|---|--------|
+| **Inputs** | `name: Str` — fully-qualified domain name |
+| | `ttl: Time.Duration` — time to live |
+| | `records: [{priority: Int, weight: Int, port: Int, target: Str}]` — service locations |
+| **Outputs** | `fqdn: Str` — fully-qualified domain name (name + zone) |
+| | `ttl: Time.Duration` |
+| | `records: [{priority: Int, weight: Int, port: Int, target: Str}]` |
 
 ## Std/Crypto
 


### PR DESCRIPTION
## Summary

Closes #274.

Expands `Std/DNS` from just `ARecord` to a full set of common record types needed by real deployments:

- **`AAAARecord`** — IPv6 addresses
- **`CNAMERecord`** — single-target alias
- **`TXTRecord`** — text records (SPF/DKIM/ACME challenges, verification tokens)
- **`MXRecord`** — mail exchangers, `[{priority, host}]`
- **`SRVRecord`** — service location, `[{priority, weight, port, target}]`

Each is wired through the full stack: SCL signature in `Std/DNS.scl`, extern registration in `crates/sclc/src/std/dns.rs`, RTP plugin dispatch in `crates/plugin_std_dns/`, and answers from the embedded UDP DNS server. Records are stored in Redis under per-type key prefixes (`dns:aaaa:`, `dns:cname:`, `dns:txt:`, `dns:mx:`, `dns:srv:`).

`NSRecord` is intentionally deferred — the issue marks it lower priority and we kept the PR scoped.

## Notes

- The extern handler in `crates/sclc/src/std/dns.rs` is refactored into a single `register_record_extern` helper since every record type follows the same input-passthrough + `eval_ctx.resource` pattern. Existing `ARecord` behavior is preserved exactly (all three pre-existing `DNSARecord*` fixtures still pass unchanged).
- DNS server: `CNAME`/`MX`/`SRV` targets/hosts get a trailing `.` appended before `Name::from_ascii` if not already absolute, so they resolve as FQDNs.
- TXT values are passed straight to `hickory_proto`'s `TXT::new(Vec<String>)`; the whole list lives in a single TXT record.
- Bad payloads (unparseable IPv6, malformed names) are `warn!`-skipped, mirroring the existing `handle_a_query` posture.
- 15 new fixture tests (Create / Touch / Update for each record type), bringing `cargo test -p sclc` to 545 passing.
- Docs: added a section per record type to `docs/scl/stdlib.md`; rewrote `crates/plugin_std_dns/README.md` to a `## Resources` section listing all six.

## Test plan

- [x] `cargo test -p sclc` — 545 passed (15 new DNS fixtures + the 3 existing `DNSARecord*`)
- [x] `cargo test -p plugin_std_dns` — clean build (no unit tests)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p plugin_std_dns -p sclc` — no new warnings on our changes (two pre-existing warnings on `crates/sclc/src/{checker.rs,cross_repo.rs}` only fire on stable; CI uses nightly)
- [ ] Full `cargo clippy --workspace -- -D warnings` and `cargo test --workspace` in CI (nightly toolchain)
- [ ] Reviewer verifies the input-passthrough refactor of `dns.rs` doesn't regress edge cases for `ARecord`

🤖 Generated with [Claude Code](https://claude.com/claude-code)