### PR TITLE
feat(de): re-introduce terminal state for fully non-volatile bootstrapped deployments

### DIFF
--- a/crates/de/src/worker/eval.rs
+++ b/crates/de/src/worker/eval.rs
@@ -30,6 +30,20 @@ pub(crate) struct EvalOutcome {
     /// `LEVEL: <module>:<span>: <diag>` line per diagnostic, joined by `\n`,
     /// suitable for surfacing to end users via the RQ failure report.
     pub(crate) compile_error_message: Option<String>,
+    /// True when at least one resource owned by this deployment carries the
+    /// [`sclc::Marker::Volatile`] marker. Combined with
+    /// `has_volatile_cross_repo_pins`, this gates the terminal-state rule
+    /// for bootstrapped DESIRED deployments: when both are false and the
+    /// deployment has converged (`!had_effect`), the worker can stop its
+    /// reconciliation loop because nothing it depends on can change without
+    /// an external trigger (a new push or a supersession).
+    pub(crate) has_volatile_owned_resource: bool,
+    /// True when the local repo's `Package.scle` declares at least one
+    /// dependency pinned to a branch or tag (a volatile specifier per
+    /// [`sclc::Specifier::is_volatile`]). Hash-pinned and absent manifests
+    /// both yield `false`. See `has_volatile_owned_resource` for how this
+    /// participates in the terminal-state decision.
+    pub(crate) has_volatile_cross_repo_pins: bool,
 }
 
 impl Worker {
@@ -93,6 +107,11 @@ impl Worker {
                     fully_explored: false,
                     had_effect: false,
                     compile_error_message: Some(compile_error_message),
+                    // Compile failed; we never inspected resources or pins,
+                    // and the deployment must keep reconciling regardless
+                    // (the terminal rule is gated on `!had_effect` anyway).
+                    has_volatile_owned_resource: false,
+                    has_volatile_cross_repo_pins: false,
                 });
             }
 
@@ -172,16 +191,24 @@ impl Worker {
         }
         let mut unowned_resource_owner_by_id = HashMap::new();
         let mut volatile_resource_ids = HashSet::new();
+        // Tracked separately from `volatile_resource_ids` because the
+        // terminal-state rule cares only about resources THIS deployment
+        // owns, whereas `volatile_resource_ids` (used for Check messages
+        // on TouchResource) is scoped by effect filtering downstream and
+        // does not need to filter by owner here.
+        let mut has_volatile_owned_resource = false;
         let mut resources = self.namespace.list_resources().await?;
         while let Some(resource) = resources.try_next().await? {
             let resource_id = resource_id_from(&resource);
-            if resource.owner.as_deref() != Some(owner_deployment_qid.as_str())
-                && let Some(owner) = resource.owner.clone()
-            {
+            let is_owned = resource.owner.as_deref() == Some(owner_deployment_qid.as_str());
+            if !is_owned && let Some(owner) = resource.owner.clone() {
                 unowned_resource_owner_by_id.insert(resource_id.clone(), owner);
             }
             if resource.markers.contains(&sclc::Marker::Volatile) {
                 volatile_resource_ids.insert(resource_id.clone());
+                if is_owned {
+                    has_volatile_owned_resource = true;
+                }
             }
 
             eval_ctx.add_resource(
@@ -195,6 +222,16 @@ impl Worker {
             );
         }
         drop(resources);
+
+        // Captured before the effects task starts so we can stamp the
+        // resulting `EvalOutcome` with the terminal-rule inputs without
+        // having to thread the cross-repo finder into the spawned task.
+        // `None` (no manifest, or no dependencies) collapses to `false`,
+        // matching the pre-v2 behaviour: a deployment with no cross-repo
+        // deps cannot have volatile pins.
+        let has_volatile_cross_repo_pins = cross_repo_finder
+            .as_ref()
+            .is_some_and(|f| f.has_volatile_pins());
 
         let log_publisher = self.log_publisher.clone();
         let env_qid = self.environment_qid.clone();
@@ -447,6 +484,8 @@ impl Worker {
                         fully_explored: !had_mutation,
                         had_effect,
                         compile_error_message: None,
+                        has_volatile_owned_resource,
+                        has_volatile_cross_repo_pins,
                     }
                 }
             }

--- a/crates/de/src/worker/mod.rs
+++ b/crates/de/src/worker/mod.rs
@@ -493,6 +493,43 @@ impl Worker {
                         self.client.set_progress(true).await?;
                     }
                     self.transition_superseded_to_undesired().await?;
+
+                    // Terminal-state rule for bootstrapped DESIRED
+                    // deployments (re-introduced post-DE-v2; pre-v2 this
+                    // was the `Up` transition removed in 5f11804). When a
+                    // converged deployment owns no `Volatile` resources
+                    // and its `Package.scle` declares no branch- or
+                    // tag-pinned cross-repo dependencies, no internal
+                    // signal can change its state — only an external
+                    // trigger (a new push, or a supersession) can. Stop
+                    // the reconciliation loop so the daemon parks the
+                    // worker as idle. The daemon's idle/respawn machinery
+                    // (see `crates/de/src/main.rs` — `Some(sender)` flips
+                    // to `None` on the next tick, then is respawned only
+                    // when `get_superseding()` returns `Some`) is
+                    // load-bearing for this path: dropping the worker
+                    // outright, or skipping the supersession poll on idle
+                    // workers, would silently break LINGERING→UNDESIRED→
+                    // DOWN for terminal deployments.
+                    if !outcome.has_volatile_owned_resource && !outcome.has_volatile_cross_repo_pins
+                    {
+                        tracing::info!(
+                            "{sid} bootstrapped with no volatile inputs; \
+                             stopping reconciliation loop (terminal)",
+                        );
+                        self.log_publisher
+                            .info(format!(
+                                "{sid} converged on non-volatile inputs; \
+                                 worker going idle",
+                            ))
+                            .await;
+                        return Ok(WorkResult {
+                            keep_running: false,
+                            state,
+                            outcome: IterationOutcome::Success,
+                            is_backoff_replay: false,
+                        });
+                    }
                 } else {
                     tracing::info!(
                         "{sid} evaluation incomplete; deferring superseded deployment teardown"


### PR DESCRIPTION
Closes #290.

## Summary

Re-introduce the pre-v2 terminal-state rule for bootstrapped `DESIRED`
deployments: when a converged deployment owns no `Volatile` resources
and its `Package.scle` declares no branch- or tag-pinned cross-repo
dependencies, stop the 5s reconciliation loop and let the daemon park
the worker as idle.

This was originally the `UP` transition removed in `5f11804` ("feat(de):
implement DE v2 lifecycle model"). DE v2 collapsed `UP` into a permanent
`DESIRED`, which had the side effect that every bootstrapped `Main.scl`
deployment kept reconciling forever even when nothing it depended on
could change.

## Implementation

- `EvalOutcome` re-gains two flags:
  - `has_volatile_owned_resource` — at least one resource owned by
    _this_ deployment carries `sclc::Marker::Volatile`. Computed during
    the existing resource scan, filtered by owner so foreign volatile
    resources don't pin the local worker awake.
  - `has_volatile_cross_repo_pins` — `CrossRepoPackageFinder::has_volatile_pins()`,
    captured before the effects task starts. Absent manifests / no
    deps collapse to `false`.
- `run_desired` checks both flags after `!had_effect`, marking
  bootstrapped, and transitioning superseded deployments to `UNDESIRED`.
  When both are `false`, it returns `keep_running: false`. The existing
  reporting layer (`work_and_report` — `is_terminal = state == Down || !keep_running`)
  already publishes the terminal status report and stops the loop,
  matching the no-`Main.scl` terminal path.

## Load-bearing supersession path (called out in code comments)

The daemon's existing idle/respawn machinery in `crates/de/src/main.rs`
is what drives a terminal worker through `LINGERING → UNDESIRED → DOWN`
on supersession:

1. Workers whose loop has exited flip from `Some(sender)` to `None`
   (idle) on the next daemon tick.
2. Idle workers are respawned only when `get_superseding()` returns
   `Some` — that is the sole external trigger that can require more
   work from a terminal deployment.

Any change that bypasses this (dropping the worker from the map outright
instead of leaving an idle slot, or skipping the `get_superseding` poll
on idle workers) would silently break supersession for terminal
deployments. Both new and pre-existing terminal paths (no-`Main.scl`
and now non-volatile-bootstrapped) depend on it.

## Acceptance

- ✅ Bootstrapped deployment, only non-volatile resources, only
  hash-pinned (or no) cross-repo deps → terminal report, worker stops,
  daemon leaves an idle slot.
- ✅ At least one `Volatile` resource OR at least one branch/tag pin →
  keeps reconciling on the 5s loop (existing behaviour).
- ✅ Superseding either of the above respawns the worker via the
  daemon's existing idle/respawn machinery and drives the lifecycle to
  `DOWN`, identical to the no-`Main.scl` terminal path today.

## Out of scope

- The no-`Main.scl` terminal path (`crates/de/src/worker/mod.rs:438-454`)
  is unchanged.
- Volatility detection itself — `Marker::Volatile` and
  `Specifier::is_volatile` already exist; this PR only re-wires them
  back into the terminal decision.

## Verification

- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — all tests pass
- `cargo fmt` applied
